### PR TITLE
Add missing glutInit call (needed on Linux for glut functions to work)

### DIFF
--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -15,6 +15,9 @@
 #include <wx/image.h>
 //*)
 
+#ifdef LINUX
+#include <GL/glut.h>
+#endif
 
 #ifndef __WXMSW__
 #include <execinfo.h>
@@ -227,6 +230,10 @@ bool xLightsApp::OnInit()
     topFrame = (xLightsFrame* )GetTopWindow();
 
     wxImage::AddHandler(new wxPNGHandler);
+    #ifdef LINUX
+        glutInit(&(wxApp::argc), wxApp::argv);
+    #endif
+
 
     return wxsOK;
 }


### PR DESCRIPTION
Without this call to glutInit() xLights would crash when working with imported timing tracks with messages such as:
freeglut  ERROR:  Function <glutBitmapWidth> called without first calling 'glutInit'.
I have put the changes within "#ifdef LINUX" checks since I don't know if it is needed for other platforms