### PR TITLE
Changed Model dir reference to model

### DIFF
--- a/xLights/effects/MorphEffect.cpp
+++ b/xLights/effects/MorphEffect.cpp
@@ -6,7 +6,7 @@
 #include "../UtilClasses.h"
 #include "assist/AssistPanel.h"
 #include "assist/xlGridCanvasMorph.h"
-#include "../Models/Model.h"
+#include "../models/Model.h"
 
 #include "../../include/morph-16.xpm"
 #include "../../include/morph-64.xpm"


### PR DESCRIPTION
The directory is 'model' but it was being included as Model, likely due to using a case-insensitive, but case-aware filesystem. Most filesystems on Linux are case-sensitive and, as a result, this was causing a compilation error on Linux.