### PR TITLE
Add a button to reverse the numbering on custom models

### DIFF
--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -32,6 +32,7 @@ const long CustomModelDialog::ID_CHECKBOX1 = wxNewId();
 const long CustomModelDialog::ID_BUTTON3 = wxNewId();
 const long CustomModelDialog::ID_BUTTON_Flip_Horizontal = wxNewId();
 const long CustomModelDialog::ID_BUTTON_Flip_Vertical = wxNewId();
+const long CustomModelDialog::ID_BUTTON_Reverse = wxNewId();
 const long CustomModelDialog::ID_BITMAPBUTTON_CUSTOM_CUT = wxNewId();
 const long CustomModelDialog::ID_BITMAPBUTTON_CUSTOM_COPY = wxNewId();
 const long CustomModelDialog::ID_BITMAPBUTTON_CUSTOM_PASTE = wxNewId();
@@ -113,6 +114,8 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent)
 	FlexGridSizer9->Add(Button_Flip_Horizonal, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Button_Flip_Vertical = new wxButton(this, ID_BUTTON_Flip_Vertical, _("Flip Vert"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_Flip_Vertical"));
 	FlexGridSizer9->Add(Button_Flip_Vertical, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Button_Reverse = new wxButton(this, ID_BUTTON_Reverse, _("Reverse"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_Reverse"));
+	FlexGridSizer9->Add(Button_Reverse, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Sizer2->Add(FlexGridSizer9, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer5 = new wxFlexGridSizer(0, 7, 0, 0);
 	BitmapButtonCustomCut = new wxBitmapButton(this, ID_BITMAPBUTTON_CUSTOM_CUT, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("wxART_CUT")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_BITMAPBUTTON_CUSTOM_CUT"));
@@ -190,6 +193,7 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent)
 	Connect(ID_BUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnButtonWiringClick);
 	Connect(ID_BUTTON_Flip_Horizontal,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnButton_Flip_HorizonalClick);
 	Connect(ID_BUTTON_Flip_Vertical,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnButton_Flip_VerticalClick);
+	Connect(ID_BUTTON_Reverse,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnButton_ReverseClick);
 	Connect(ID_BITMAPBUTTON_CUSTOM_CUT,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnBitmapButtonCustomCutClick);
 	Connect(ID_BITMAPBUTTON_CUSTOM_COPY,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnBitmapButtonCustomCopyClick);
 	Connect(ID_BITMAPBUTTON_CUSTOM_PASTE,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CustomModelDialog::OnBitmapButtonCustomPasteClick);
@@ -831,4 +835,59 @@ void CustomModelDialog::OnButton_Flip_VerticalClick(wxCommandEvent& event)
     UpdateBackground();
 
     ValidateWindow();
+}
+
+void CustomModelDialog::OnButton_ReverseClick(wxCommandEvent& event)
+{
+    int min = 1;
+    int max = 1;
+
+    //Find the max value returned
+    for(size_t c = 0; c < GridCustom->GetNumberCols(); c++)
+    {
+        for (size_t r = 0; r < GridCustom->GetNumberRows(); ++r)
+        {
+            wxString s = GridCustom->GetCellValue(r, c);
+
+            if(s.IsEmpty()==false)
+            {
+                long val;
+
+                if(s.ToCLong(&val)==true)
+                {
+                    if(val>max)max=val;
+                    if(val<min)min=val;
+                }
+            }
+        }
+    }
+
+    max++;
+    //Rewrite the grid values
+    for(size_t c = 0; c < GridCustom->GetNumberCols(); c++)
+    {
+        std::list<wxString> vals;
+        for (size_t r = 0; r < GridCustom->GetNumberRows(); ++r)
+        {
+            wxString s  = GridCustom->GetCellValue(r, c);
+
+            if(s.IsEmpty()==false)
+            {
+                long val;
+
+                if(s.ToCLong(&val)==true)
+                {
+                    long newVal = max-val;
+                    s.Printf("%d",newVal);
+
+                    GridCustom->SetCellValue(r, c, s);
+                }
+            }
+        }
+    }
+
+
+    UpdateBackground();
+    ValidateWindow();
+
 }

--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -248,6 +248,7 @@ void CustomModelDialog::ValidateWindow()
         ButtonOk->Disable();
         Button_Flip_Horizonal->Disable();
         Button_Flip_Vertical->Disable();
+        Button_Reverse->Disable();
     }
     else
     {
@@ -269,6 +270,8 @@ void CustomModelDialog::ValidateWindow()
         ButtonOk->Enable();
         Button_Flip_Horizonal->Enable();
         Button_Flip_Vertical->Enable();
+        Button_Reverse->Enable();
+
         if (background_image == "")
         {
             SliderCustomLightness->Disable();
@@ -839,13 +842,13 @@ void CustomModelDialog::OnButton_Flip_VerticalClick(wxCommandEvent& event)
 
 void CustomModelDialog::OnButton_ReverseClick(wxCommandEvent& event)
 {
-    int min = 1;
-    int max = 1;
+    auto min = 1;
+    auto max = 1;
 
     //Find the max value returned
-    for(size_t c = 0; c < GridCustom->GetNumberCols(); c++)
+    for(auto c = 0; c < GridCustom->GetNumberCols(); c++)
     {
-        for (size_t r = 0; r < GridCustom->GetNumberRows(); ++r)
+        for (auto r = 0; r < GridCustom->GetNumberRows(); ++r)
         {
             wxString s = GridCustom->GetCellValue(r, c);
 
@@ -864,10 +867,10 @@ void CustomModelDialog::OnButton_ReverseClick(wxCommandEvent& event)
 
     max++;
     //Rewrite the grid values
-    for(size_t c = 0; c < GridCustom->GetNumberCols(); c++)
+    for(auto c = 0; c < GridCustom->GetNumberCols(); c++)
     {
         std::list<wxString> vals;
-        for (size_t r = 0; r < GridCustom->GetNumberRows(); ++r)
+        for (auto r = 0; r < GridCustom->GetNumberRows(); ++r)
         {
             wxString s  = GridCustom->GetCellValue(r, c);
 

--- a/xLights/CustomModelDialog.h
+++ b/xLights/CustomModelDialog.h
@@ -54,6 +54,7 @@ class CustomModelDialog: public wxDialog
 		//(*Declarations(CustomModelDialog)
 		wxCheckBox* CheckBoxAutoNumber;
 		wxButton* Button_Flip_Vertical;
+		wxButton* Button_Reverse;
 		wxButton* ButtonWiring;
 		wxCheckBox* CheckBoxAutoIncrement;
 		wxBitmapButton* BitmapButtonCustomBkgrd;
@@ -90,6 +91,7 @@ class CustomModelDialog: public wxDialog
 		static const long ID_BUTTON3;
 		static const long ID_BUTTON_Flip_Horizontal;
 		static const long ID_BUTTON_Flip_Vertical;
+		static const long ID_BUTTON_Reverse;
 		static const long ID_BITMAPBUTTON_CUSTOM_CUT;
 		static const long ID_BITMAPBUTTON_CUSTOM_COPY;
 		static const long ID_BITMAPBUTTON_CUSTOM_PASTE;
@@ -140,6 +142,7 @@ class CustomModelDialog: public wxDialog
 		void OnButtonWiringClick(wxCommandEvent& event);
 		void OnButton_Flip_HorizonalClick(wxCommandEvent& event);
 		void OnButton_Flip_VerticalClick(wxCommandEvent& event);
+		void OnButton_ReverseClick(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/CustomModelDialog.wxs
+++ b/xLights/wxsmith/CustomModelDialog.wxs
@@ -111,6 +111,15 @@
 								<border>5</border>
 								<option>1</option>
 							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_Reverse" variable="Button_Reverse" member="yes">
+									<label>Reverse</label>
+									<handler function="OnButton_ReverseClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
 						</object>
 						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>


### PR DESCRIPTION
Reverses the numbering on custom models.  I used this to fix several models that were wired from the opposite end then the model I designed because I wired it backward.