### PR TITLE
Custom Model Renumber

### DIFF
--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -908,32 +908,32 @@ void CustomModelDialog::OnButton_RenumberClick(wxCommandEvent& event)
     auto min = 1;
     auto max = 1;
 
-    wxNumberEntryDialog dlg(this, "Enter Increase/Decrease Value", "", "Increment/Decrement Value", 0, -100000, 100000);
+    //Find the max value returned
+    for (auto c = 0; c < GridCustom->GetNumberCols(); c++)
+    {
+        for (auto r = 0; r < GridCustom->GetNumberRows(); ++r)
+        {
+            wxString s = GridCustom->GetCellValue(r, c);
+
+            if (s.IsEmpty() == false)
+            {
+                long val;
+
+                if (s.ToCLong(&val) == true)
+                {
+                    if (val > max)max = val;
+                    if (val < min)min = val;
+                }
+            }
+        }
+    }
+
+    wxNumberEntryDialog dlg(this, "Enter Increase/Decrease Value", "", "Increment/Decrement Value", 0, -(max - 1), max - 1);
     if (dlg.ShowModal() == wxID_OK)
     {
         auto scaleFactor = dlg.GetValue();
         if (scaleFactor != 0)
         {
-            //Find the max value returned
-            for (auto c = 0; c < GridCustom->GetNumberCols(); c++)
-            {
-                for (auto r = 0; r < GridCustom->GetNumberRows(); ++r)
-                {
-                    wxString s = GridCustom->GetCellValue(r, c);
-
-                    if (s.IsEmpty() == false)
-                    {
-                        long val;
-
-                        if (s.ToCLong(&val) == true)
-                        {
-                            if (val > max)max = val;
-                            if (val < min)min = val;
-                        }
-                    }
-                }
-            }
-
             //Rewrite the grid values
             for (auto c = 0; c < GridCustom->GetNumberCols(); c++)
             {

--- a/xLights/CustomModelDialog.h
+++ b/xLights/CustomModelDialog.h
@@ -72,6 +72,7 @@ class CustomModelDialog: public wxDialog
 		wxCheckBox* CheckBox_RearView;
 		wxButton* Button_CustomModelZoomOut;
 		wxFlexGridSizer* Sizer1;
+		wxButton* Button_Renumber;
 		wxSpinCtrl* WidthSpin;
 		//*)
 
@@ -92,6 +93,7 @@ class CustomModelDialog: public wxDialog
 		static const long ID_BUTTON_Flip_Horizontal;
 		static const long ID_BUTTON_Flip_Vertical;
 		static const long ID_BUTTON_Reverse;
+		static const long ID_BUTTON_RENUMBER;
 		static const long ID_BITMAPBUTTON_CUSTOM_CUT;
 		static const long ID_BITMAPBUTTON_CUSTOM_COPY;
 		static const long ID_BITMAPBUTTON_CUSTOM_PASTE;
@@ -143,6 +145,7 @@ class CustomModelDialog: public wxDialog
 		void OnButton_Flip_HorizonalClick(wxCommandEvent& event);
 		void OnButton_Flip_VerticalClick(wxCommandEvent& event);
 		void OnButton_ReverseClick(wxCommandEvent& event);
+		void OnButton_RenumberClick(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/CustomModelDialog.wxs
+++ b/xLights/wxsmith/CustomModelDialog.wxs
@@ -6,7 +6,7 @@
 		<size>450,350d</size>
 		<minsize>300,200d</minsize>
 		<id_arg>0</id_arg>
-		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
 		<object class="wxFlexGridSizer" variable="Sizer1" member="yes">
 			<cols>2</cols>
 			<growablecols>1</growablecols>
@@ -115,6 +115,16 @@
 								<object class="wxButton" name="ID_BUTTON_Reverse" variable="Button_Reverse" member="yes">
 									<label>Reverse</label>
 									<handler function="OnButton_ReverseClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_RENUMBER" variable="Button_Renumber" member="yes">
+									<label>Renumber</label>
+									<tooltip>Increase or Decrease The Node Number Values</tooltip>
+									<handler function="OnButton_RenumberClick" entry="EVT_BUTTON" />
 								</object>
 								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 								<border>5</border>


### PR DESCRIPTION
I added a feature to increment or decrement the node numbers of a custom model. It basically just "shifts" the node numbers by the inputted value. If you have a model with 50 nodes, you can renumber by 10 it will shift 1 to 11 and 41 to 1. I also added the Maximize Box to the windows. 