### PR TITLE
Fix URL parameter decoding in xSchedule Web

### DIFF
--- a/bin/xScheduleWeb/js/pageNavagation.js
+++ b/bin/xScheduleWeb/js/pageNavagation.js
@@ -71,7 +71,7 @@ function getQueryVariable(variable) {
   for (var i = 0; i < vars.length; i++) {
     var pair = vars[i].split("=");
     if (pair[0] == variable) {
-      return pair[1];
+      return decodeURIComponent(pair[1]);
     }
   }
   return (false);


### PR DESCRIPTION
Issue: In the xSchedule web view playlists with spaces in them caused errors.

Example: If a playlist is called 'TEST TEST' you can play it but if you click view the playlist name shows as TEST%20TEST and trying to play a step results in Failed: "Parameter 1: 'TEST%20TEST' is not a known playlist."

Cause: playlist name is getting encoded in the URL and then the encoded value is being use

Fix: decode any URL parameters when getting their values