### PR TITLE
Check for 32 bit version of xLights on a 64 bit Computer.

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -1764,7 +1764,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent,wxWindowID id) : mSequenceElements(t
 
     splash.Hide();
 
+#ifdef __WXMSW__
     check32AppOn64Machine();
+#endif
 
     logger_base.debug("xLightsFrame construction complete.");
 }

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -1764,6 +1764,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent,wxWindowID id) : mSequenceElements(t
 
     splash.Hide();
 
+    check32AppOn64Machine();
+
     logger_base.debug("xLightsFrame construction complete.");
 }
 
@@ -7007,6 +7009,18 @@ bool xLightsFrame::CheckForUpdate(bool force)
     wxDELETE(httpStream);
     get.Close();
     return found_update;
+}
+
+void xLightsFrame::check32AppOn64Machine()
+{
+    wxConfigBase* config = wxConfigBase::Get();
+    bool alreadyRun = config->ReadBool("xLights32bitCheck", false);
+
+    if (!alreadyRun && wxIsPlatform64Bit() && sizeof(size_t) == 4)
+    {
+        config->Write("xLights32bitCheck", true);
+        wxMessageBox("You are running the 32 bit version of xLights on a 64 bit Computer\nPlease Update to the 64 bit version of xLights", "Update to 64bit");
+    }
 }
 
 void xLightsFrame::OnMenuItem_SmallWaveformSelected(wxCommandEvent& event)

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1308,6 +1308,7 @@ private:
     void DoDonate();
     void AutoShowHouse();
     bool CheckForUpdate(bool force);
+    void check32AppOn64Machine();
 
     std::map<int, std::list<float>> LoadPolyphonicTranscription(AudioManager* audio, int intervalMS);
     std::map<int, std::list<float>> LoadAudacityFile(std::string file, int intervalMS);


### PR DESCRIPTION
Check for 32 bit version of xLights on a 64 bit Computer. It uses wxConfigBase to persist a bool property to prevent the dialog from displaying at every launch, just on first launch of the app.