### PR TITLE
Resolve crash due to out of order events in AC mode

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -5674,7 +5674,15 @@ void EffectsGrid::RaiseSelectedEffectChanged(Effect* effect, bool isNew, bool up
     }
     // Place effect pointer in client data
     SelectedEffectChangedEvent eventEffectChanged(effect, isNew, updateUI);
-    wxPostEvent(GetParent(), eventEffectChanged);
+
+    //Mouse events and custom events do not always occur in the correct order, which causes crashes in AC mode.
+    if(IsACActive()){
+        //Therefore perform the actions synchronously
+        GetParent()->GetEventHandler()->ProcessEvent(eventEffectChanged);
+    }
+    else{
+        wxPostEvent(GetParent(), eventEffectChanged);
+    }
 }
 
 void EffectsGrid::RaisePlayModelEffect(Element* element, Effect* effect,bool renderEffect)
@@ -5685,7 +5693,15 @@ void EffectsGrid::RaisePlayModelEffect(Element* element, Effect* effect,bool ren
     playArgs->effect = effect;
     playArgs->renderEffect = renderEffect;
     eventPlayModelEffect.SetClientData(playArgs);
-    wxPostEvent(GetParent(), eventPlayModelEffect);
+
+    //Mouse events and custom events do not always occur in the correct order, which causes crashes in AC mode.
+    if(IsACActive()){
+        //Therefore perform the actions synchronously
+        GetParent()->GetEventHandler()->ProcessEvent(eventPlayModelEffect);
+    }
+    else{
+        wxPostEvent(GetParent(), eventPlayModelEffect);
+    }
 }
 
 void EffectsGrid::RaiseEffectDropped(int x, int y)


### PR DESCRIPTION
This PR is a potential solution for the crashes I am experiencing in issue #1021. Since the issue appears to be a result of the wxWidgets handling the SelectedEffectChanged and mouse button up events in a nondeterministic order, which risks a crash in AC mode due to a use-after-free scenario, my proposed fix is to force both custom events fired as a result of the mouse down handler to occur synchronously if AC mode is enabled.