### PR TITLE
Add capability to save the model layout canvas as an image

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -88,6 +88,7 @@ const long LayoutPanel::ID_PREVIEW_MODEL_ADDPOINT = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_DELETEPOINT = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_ADDCURVE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_DELCURVE = wxNewId();
+const long LayoutPanel::ID_PREVIEW_SAVE_LAYOUT_IMAGE = wxNewId();
 
 #define CHNUMWIDTH "10000000000000"
 
@@ -262,6 +263,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     modelPreview->Connect(wxEVT_RIGHT_DOWN,(wxObjectEventFunction)&LayoutPanel::OnPreviewRightDown, nullptr,this);
     modelPreview->Connect(wxEVT_MOTION,(wxObjectEventFunction)&LayoutPanel::OnPreviewMouseMove, nullptr,this);
     modelPreview->Connect(wxEVT_LEAVE_WINDOW,(wxObjectEventFunction)&LayoutPanel::OnPreviewMouseLeave, nullptr, this);
+	 modelPreview->Connect(wxEVT_CONTEXT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewContextMenu, nullptr, this);
 
     propertyEditor = new wxPropertyGrid(ModelSplitter,
                                         wxID_ANY, // id
@@ -2852,6 +2854,20 @@ void LayoutPanel::OnChoiceLayoutGroupsSelect(wxCommandEvent& event)
     UpdatePreview();
 
     xlights->SetStoredLayoutGroup(currentLayoutGroup);
+}
+
+void LayoutPanel::OnPreviewContextMenu(wxContextMenuEvent& event)
+{
+	wxMenu menu;
+	menu.Append(ID_PREVIEW_SAVE_LAYOUT_IMAGE, _("Save Layout Image"));
+	menu.Connect(wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&LayoutPanel::OnPreviewSaveImage, nullptr, this);
+
+	PopupMenu(&menu);
+}
+
+void LayoutPanel::OnPreviewSaveImage(wxCommandEvent& event)
+{
+	// todo: grab image from modelPreview and allow to save!
 }
 
 void LayoutPanel::AddPreviewChoice(const std::string &name)

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -10,6 +10,7 @@
 #include <wx/intl.h>
 #include <wx/button.h>
 #include <wx/string.h>
+#include <wx/filedlg.h>
 //*)
 
 #include <wx/clipbrd.h>
@@ -2867,7 +2868,25 @@ void LayoutPanel::OnPreviewContextMenu(wxContextMenuEvent& event)
 
 void LayoutPanel::OnPreviewSaveImage(wxCommandEvent& event)
 {
-	// todo: grab image from modelPreview and allow to save!
+	wxImage *image = modelPreview->GrabImage();
+	if (image == nullptr)
+	{
+		wxMessageDialog msgDlg(this, _("Error capturing preview image"), _("Image Capture Error"), wxOK | wxCENTRE);
+		msgDlg.ShowModal();
+		return;
+	}
+
+	const char wildcard[] = "JPG files (*.jpg;*.jpeg)|*.jpg;*.jpeg|PNG files (*.png)|*.png";
+	wxFileDialog saveDlg(this, _("Save Image"), wxEmptyString, wxEmptyString,
+		wildcard, wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+	if (saveDlg.ShowModal() == wxID_OK)
+	{
+		wxString path = saveDlg.GetPath();
+		wxBitmapType bitmapType = path.EndsWith(".png") ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_JPEG;
+		image->SaveFile(path, bitmapType);
+	}
+
+	delete image;
 }
 
 void LayoutPanel::AddPreviewChoice(const std::string &name)

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -125,6 +125,7 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_MODEL_DELETEPOINT;
         static const long ID_PREVIEW_MODEL_ADDCURVE;
         static const long ID_PREVIEW_MODEL_DELCURVE;
+		  static const long ID_PREVIEW_SAVE_LAYOUT_IMAGE;
 
 	public:
 
@@ -145,6 +146,8 @@ class LayoutPanel: public wxPanel
 		void OnCharHook(wxKeyEvent& event);
 		void OnChar(wxKeyEvent& event);
 		void OnChoiceLayoutGroupsSelect(wxCommandEvent& event);
+		void OnPreviewContextMenu(wxContextMenuEvent& event);
+		void OnPreviewSaveImage(wxCommandEvent& event);
 		//*)
 
         void OnPropertyGridSelection(wxPropertyGridEvent& event);

--- a/xLights/xlGLCanvas.h
+++ b/xLights/xlGLCanvas.h
@@ -4,6 +4,8 @@
 #include "wx/glcanvas.h"
 #include "DrawGLUtils.h"
 
+class wxImage;
+
 
 class xlGLCanvas
     : public wxGLCanvas
@@ -24,6 +26,10 @@ class xlGLCanvas
         double translateToBacking(double x);
 
         void DisplayWarning(const wxString &msg);
+
+		  // Grab a copy of the front buffer at window dimensions; it's the caller's
+		  // responsibility to delete the image when done with it
+		  wxImage *GrabImage();
     protected:
       	DECLARE_EVENT_TABLE()
 


### PR DESCRIPTION
This simple change was suggested to me by Keith as a starting point for my first contribution to xLights... or at least I think this is what he meant; if not, I'll make some changes!

Demo video available here: https://vimeo.com/249181779