### PR TITLE
Model layout print image

### DIFF
--- a/xLights/DrawGLUtils31.cpp
+++ b/xLights/DrawGLUtils31.cpp
@@ -67,6 +67,19 @@ PFNGLDISABLEVERTEXATTRIBARRAYPROC glDisableVertexAttribArray;
 PFNGLGETATTRIBLOCATIONPROC glGetAttribLocation;
 PFNGLPOINTPARAMETERFPROC glPointParameterf;
 
+PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;
+PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer;
+PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers;
+PFNGLISFRAMEBUFFERPROC glIsFramebuffer;
+PFNGLFRAMEBUFFERPARAMETERIPROC glFramebufferParameteri;
+PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers;
+PFNGLDELETERENDERBUFFERSPROC glDeleteRenderbuffers;
+PFNGLISRENDERBUFFERPROC glIsRenderbuffer;
+PFNGLBINDRENDERBUFFERPROC glBindRenderbuffer;
+PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage;
+PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC glRenderbufferStorageMultisample;
+PFNGLFRAMEBUFFERRENDERBUFFERPROC glFramebufferRenderbuffer;
+
 #ifdef LINUX // conversion function from glx to wgl calls
 __GLXextFuncPtr wglGetProcAddress(const char* a) {
     return glXGetProcAddress((const GLubyte*)a);
@@ -113,6 +126,21 @@ bool DrawGLUtils::LoadGLFunctions() {
     glDisableVertexAttribArray = (PFNGLDISABLEVERTEXATTRIBARRAYPROC)wglGetProcAddress("glDisableVertexAttribArray");
     glGetAttribLocation = (PFNGLGETATTRIBLOCATIONPROC)wglGetProcAddress("glGetAttribLocation");
     glPointParameterf = (PFNGLPOINTPARAMETERFPROC)wglGetProcAddress("glPointParameterf");
+
+	 glGenFramebuffers = (PFNGLGENFRAMEBUFFERSPROC)wglGetProcAddress("glGenFramebuffersEXT");
+	 glBindFramebuffer = (PFNGLBINDFRAMEBUFFERPROC)wglGetProcAddress("glBindFramebuffer");
+	 glDeleteFramebuffers = (PFNGLDELETEFRAMEBUFFERSPROC)wglGetProcAddress("glDeleteFramebuffers");
+	 glIsFramebuffer = (PFNGLISFRAMEBUFFERPROC)wglGetProcAddress("glIsFramebuffer");
+	 glFramebufferParameteri = (PFNGLFRAMEBUFFERPARAMETERIPROC)wglGetProcAddress("glFramebufferParameteri");
+	 glGenRenderbuffers = (PFNGLGENRENDERBUFFERSPROC)wglGetProcAddress("glGenRenderbuffers");
+	 glDeleteRenderbuffers = (PFNGLDELETERENDERBUFFERSPROC)wglGetProcAddress("glDeleteRenderbuffers");
+	 glIsRenderbuffer = (PFNGLISRENDERBUFFERPROC)wglGetProcAddress("glIsRenderbuffer");
+	 glBindRenderbuffer = (PFNGLBINDRENDERBUFFERPROC)wglGetProcAddress("glBindRenderbuffer");
+	 glRenderbufferStorage = (PFNGLRENDERBUFFERSTORAGEPROC)wglGetProcAddress("glRenderbufferStorage");
+	 glRenderbufferStorageMultisample = (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC)wglGetProcAddress("glRenderbufferStorageMultisample");
+	 glFramebufferRenderbuffer = (PFNGLFRAMEBUFFERRENDERBUFFERPROC)wglGetProcAddress("glFramebufferRenderbuffer");
+
+
     return (glUseProgram != nullptr);
 }
 #else

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -131,6 +131,7 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_MODEL_ADDCURVE;
         static const long ID_PREVIEW_MODEL_DELCURVE;
 		  static const long ID_PREVIEW_SAVE_LAYOUT_IMAGE;
+		  static const long ID_PREVIEW_PRINT_LAYOUT_IMAGE;
 
 	public:
 
@@ -152,7 +153,7 @@ class LayoutPanel: public wxPanel
 		void OnChar(wxKeyEvent& event);
 		void OnChoiceLayoutGroupsSelect(wxCommandEvent& event);
 		void OnPreviewContextMenu(wxContextMenuEvent& event);
-		void OnPreviewSaveImage(wxCommandEvent& event);
+		void OnPreviewContextMenuCommand(wxCommandEvent& event);
 		//*)
 
         void OnPropertyGridSelection(wxPropertyGridEvent& event);
@@ -214,6 +215,8 @@ class LayoutPanel: public wxPanel
         void PreviewModelVDistribute();
         void PreviewModelResize(bool sameWidth, bool sameHeight);
         Model *CreateNewModel(const std::string &type);
+		  void SavePreviewImage();
+		  void PrintPreviewImage();
 
         bool _firstTreeLoad;
         bool m_dragging;

--- a/xLights/ModelPreview.cpp
+++ b/xLights/ModelPreview.cpp
@@ -299,6 +299,13 @@ bool ModelPreview::GetActive()
     return mPreviewPane->GetActive();
 }
 
+void ModelPreview::render()
+{
+	wxPaintEvent dummyEvent;
+
+	render(dummyEvent);
+}
+
 void ModelPreview::SetActive(bool show) {
     if( show ) {
         mPreviewPane->Show();

--- a/xLights/ModelPreview.cpp
+++ b/xLights/ModelPreview.cpp
@@ -299,11 +299,30 @@ bool ModelPreview::GetActive()
     return mPreviewPane->GetActive();
 }
 
-void ModelPreview::render()
+void ModelPreview::render(const wxSize& size/*wxSize(0,0)*/)
 {
 	wxPaintEvent dummyEvent;
+	wxSize origSize(0, 0);
+	wxSize origVirtSize(virtualWidth, virtualHeight);
+	if (size != wxSize(0, 0))
+	{
+		origSize = wxSize(mWindowWidth, mWindowHeight);
+		mWindowWidth = size.GetWidth();
+		mWindowHeight = size.GetHeight();
+		float mult = float(size.GetWidth()) / origSize.GetWidth();
+		virtualWidth = int(mult * origVirtSize.GetWidth());
+		virtualHeight = int(mult * origVirtSize.GetHeight());
+	}
 
 	render(dummyEvent);
+
+	if (origSize != wxSize(0, 0))
+	{
+		mWindowWidth = origSize.GetWidth();
+		mWindowHeight = origSize.GetHeight();
+		virtualWidth = origVirtSize.GetWidth();
+		virtualHeight = origVirtSize.GetHeight();
+	}
 }
 
 void ModelPreview::SetActive(bool show) {

--- a/xLights/ModelPreview.h
+++ b/xLights/ModelPreview.h
@@ -76,6 +76,8 @@ public:
     void SetActive(bool show);
     bool GetActive();
 
+	 void render() override;
+
     DrawGLUtils::xlAccumulator &GetAccumulator() {return accumulator;}
 protected:
     virtual void InitializeGLCanvas();

--- a/xLights/ModelPreview.h
+++ b/xLights/ModelPreview.h
@@ -76,7 +76,7 @@ public:
     void SetActive(bool show);
     bool GetActive();
 
-	 void render() override;
+	 virtual void render(const wxSize& size=wxSize(0,0)) override;
 
     DrawGLUtils::xlAccumulator &GetAccumulator() {return accumulator;}
 protected:

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2527,11 +2527,12 @@ void Model::DisplayModelOnWindow(ModelPreview* preview, DrawGLUtils::xlAccumulat
         color = *c;
     }
     int w, h;
-    //int vw, vh;
-    //preview->GetSize(&w, &h);
     preview->GetVirtualCanvasSize(w, h);
 
-    GetModelScreenLocation().PrepareToDraw();
+	 ModelScreenLocation& screenLocation = GetModelScreenLocation();
+	 screenLocation.SetPreviewSize(w, h, std::vector<NodeBaseClassPtr>());
+
+    screenLocation.PrepareToDraw();
 
     int vcount = 0;
     for (auto it = Nodes.begin(); it != Nodes.end(); ++it) {

--- a/xLights/xlGLCanvas.h
+++ b/xLights/xlGLCanvas.h
@@ -31,7 +31,7 @@ class xlGLCanvas
 		  // caller's responsibility to delete the image when done with it
 		  wxImage *GrabImage( wxSize size = wxSize(0,0) );
 
-		  virtual void render() {};
+		  virtual void render( const wxSize& = wxSize(0,0) ) {};
     protected:
       	DECLARE_EVENT_TABLE()
 

--- a/xLights/xlGLCanvas.h
+++ b/xLights/xlGLCanvas.h
@@ -27,9 +27,11 @@ class xlGLCanvas
 
         void DisplayWarning(const wxString &msg);
 
-		  // Grab a copy of the front buffer at window dimensions; it's the caller's
-		  // responsibility to delete the image when done with it
-		  wxImage *GrabImage();
+		  // Grab a copy of the front buffer (at window dimensions by default); it's the
+		  // caller's responsibility to delete the image when done with it
+		  wxImage *GrabImage( wxSize size = wxSize(0,0) );
+
+		  virtual void render() {};
     protected:
       	DECLARE_EVENT_TABLE()
 


### PR DESCRIPTION
This adds capability to print out the canvas in the Model Layout tab
Initially, I set it up to simply print a canvas-dimensions copy; later I made some updates so that the ModelLayout canvas can be rendered at arbitrary dimensions, so I render the image at something closer to printer-friendly dimensions, which arguably looks a little nicer.

Demo video available here: https://vimeo.com/249436627

Now that I look at the results some more, it might be better to just send the canvas-dimensions version to the printer; it seems like it might be useful elsewhere to be able to render the ModelPreview at arbitrary dimensions though?