### PR TITLE
Fix truncated video stream for music sequences

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-xLights is a show sequencer and player/scheduler designed to control
+﻿xLights is a show sequencer and player/scheduler designed to control
 USB/sACN(e1.31)/ArtNET(e.1.17) controllers.
 xLights also integrates with the Falcon Player.
 xLights imports and exports sequence data from sequencers such as LOR (SE & SS),
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- enh (k.mojek) Add "Export House Preview Video" to File menu
    -- enh (gil)    Add Snap to Timing Marks feature.  Turn this on in Settings.  Only works for single effect resizing.  Fixes #132.
    -- enh (gil)    Make snap to timing mark feature temporary toggle using control key.
    -- bug (gil)    Prevent error message when importing ISEQ data layer not in show directory.  Fixes #1047.

--- a/xLights/VideoExporter.cpp
+++ b/xLights/VideoExporter.cpp
@@ -204,7 +204,7 @@ bool VideoExporter::Export(const char *path)
 	if (!wasErrored && !wasCanceled)
 	{
 		// delayed video frames
-		for (int got_video_output = 1; !got_video_output;)
+		for (int got_video_output = 1; got_video_output;)
 		{
 			AVPacket pkt;
 			av_init_packet(&pkt);
@@ -264,8 +264,6 @@ bool VideoExporter::Export(const char *path)
 
 				av_packet_unref(&pkt);
 			}
-
-			av_frame_free(&frame);
 		}
 	}
 


### PR DESCRIPTION
I made some small changes in a previous commit for no-music sequences. In doing so, I introduced a bug that causes cached video frames at the end of the sequence to be discarded instead of written out. Here
is the fix for that.