### PR TITLE
Set video exporter to export stereo audio

### DIFF
--- a/xLights/VideoExporter.h
+++ b/xLights/VideoExporter.h
@@ -26,7 +26,7 @@ public:
 	bool Export(const char *path);
 
 protected:
-	typedef float AudioSample; // hard-coding to mono for now...
+	struct AudioSample { float left; float right; };
 	typedef std::queue<AudioSample> AudioSampleQueue;
 
 	static bool dummyGetVideoFrame(unsigned char *buf, int bufSize, int width, int height, float scaleFactor, unsigned frameIndex);

--- a/xLights/VideoExporter.h
+++ b/xLights/VideoExporter.h
@@ -2,7 +2,6 @@
 #define VIDEOEXPORTER_H
 
 #include <functional>
-#include <queue>
 
 struct AVCodecContext;
 struct AVFormatContext;
@@ -26,15 +25,12 @@ public:
 	bool Export(const char *path);
 
 protected:
-	struct AudioSample { float left; float right; };
-	typedef std::queue<AudioSample> AudioSampleQueue;
-
 	static bool dummyGetVideoFrame(unsigned char *buf, int bufSize, int width, int height, float scaleFactor, unsigned frameIndex);
 	static bool dummyGetAudioFrame(float *samples, int framSize, int numChannels);
 
 	bool write_video_frame(AVFormatContext *oc, int streamIndex, AVCodecContext *cc, AVFrame *srcFrame, AVFrame *dstFrame,
 		SwsContext *sws_ctx, unsigned char *buf, int width, int height, int frameIndex, log4cpp::Category &logger_base);
-	bool write_audio_frame(AVFormatContext *oc, AVStream *st, AudioSampleQueue &queue, log4cpp::Category &logger_base, bool clearQueue = false);
+	bool write_audio_frame(AVFormatContext *oc, AVStream *st, float *sampleBuff, int sampleCount, log4cpp::Category &logger_base, bool clearQueue = false);
 
 	const int m_width;
 	const int m_height;

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2835,13 +2835,13 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
 			{
 				if (audioFrameIndex + i >= trackSize)
 				{
-					samples[i] = 0.f;
+					*samples++ = 0.f;
+					*samples++ = 0.f;
 				}
 				else
 				{
-					double left = leftptr[i];
-					double right = rightptr[i];
-					samples[i] = float(0.5 * (left + right));
+					*samples++ = leftptr[i];
+					*samples++ = rightptr[i];
 				}
 			}
 

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2827,23 +2827,14 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
 	videoExporter.SetGetAudioFrameCallback(
 		[audioMgr, &audioFrameIndex](float *samples, int frameSize, int numChannels) {
 		   int trackSize = audioMgr->GetTrackSize();
+			int clampedSize = std::min(frameSize, trackSize - audioFrameIndex );
+
 			const float *leftptr = audioMgr->GetLeftDataPtr(audioFrameIndex);
 			const float *rightptr = audioMgr->GetRightDataPtr(audioFrameIndex);
 
-			// We're currently exporting mono audio, so mix left & right
-			for (int i = 0; i < frameSize; ++i)
-			{
-				if (audioFrameIndex + i >= trackSize)
-				{
-					*samples++ = 0.f;
-					*samples++ = 0.f;
-				}
-				else
-				{
-					*samples++ = leftptr[i];
-					*samples++ = rightptr[i];
-				}
-			}
+			memcpy(samples, leftptr, clampedSize * sizeof(float));
+			samples += clampedSize;
+			memcpy(samples, rightptr, clampedSize * sizeof(float));
 
 			audioFrameIndex += frameSize;
 			return true;


### PR DESCRIPTION
Many of the encoding/decoding code samples out there have interleaved audio, but these days, for AAC at least, the left and right channels are specified as separate 'planar' buffers. Once I figured that out, it was pretty straightforward to get stereo output working. But we were doing an awful lot of pushing audio samples around in order to convert from interleaved to planar and to square up video-frame-size frames of audio with the 1024-sample frames that AAC encoding uses, so I simplified it by encoding all the video first and then going back and encoding the audio in 1024-sample frames. I tested with a couple of long-ish (for Christmas music so still under 4 minutes) sequences and it didn't seem to make a difference what order the video / audio was encoded in.