### PR TITLE
Added 3D fade to Single Strand Effect for Rainbow Pallet.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,6 +27,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
    -- enh (keith)  Rework the window frame model to allow it to go CW and CCW. This may break some existing models
    -- enh (keith)  Check sequence to detect effects dropped on strands, submodels and models with no nodes
    -- bug (scott)  Fixed FPP Connect USB Drive Upload
+   -- bug (scott)  Added 3D fade to Single Strand Effect for Rainbow Pallet
 2018.5 Feb 05, 2018
    -- enh (gil)    Added a new LOR output that allows xLights to control CCRs, Pixies, and other
                    existing controllers to run on a LOR network (LOR USB dongle).

--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -472,7 +472,7 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
                     if (colorcnt==1) {
                         colorIdx=0;
                     } else {
-                        colorIdx=((double)((max_chase_width - i + 1)*colorcnt))/(double)max_chase_width;
+                        colorIdx = std::ceil (((double)((max_chase_width - i)*colorcnt)) / (double)max_chase_width) - 1;
                     }
                     if (colorIdx >= colorcnt) colorIdx=colorcnt-1;
 
@@ -483,15 +483,18 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
                         buffer.palette.GetSpatialColor(colorIdx, ((float)(i % (int)((float)max_chase_width / (float)colorcnt))) / ((float)max_chase_width / (float)colorcnt), 0.0, color);
                     }
 
-                    if (Chase_Fade3d1) {
-                        if (buffer.allowAlpha) {
-                            color.alpha = 255.0 * (i + 1.0)/max_chase_width;
-                        } else {
-                            HSVValue hsv1 = color.asHSV();
-                            hsv1.value=orig_v - ((max_chase_width - (i + 1.0))/max_chase_width); // fades data down over chase width
-                            if (hsv1.value<0.0) hsv1.value=0.0;
-                            color = hsv1;
-                        }
+                    
+                }
+
+                if (Chase_Fade3d1) {
+                    if (buffer.allowAlpha) {
+                        color.alpha = 255.0 * (i + 1.0) / max_chase_width;
+                    }
+                    else {
+                        HSVValue hsv1 = color.asHSV();
+                        hsv1.value = orig_v - ((max_chase_width - (i + 1.0)) / max_chase_width); // fades data down over chase width
+                        if (hsv1.value<0.0) hsv1.value = 0.0;
+                        color = hsv1;
                     }
                 }
 


### PR DESCRIPTION
#964 I also fixed a rounding error for color pallet selection. The current code does not evenly color the chase based on it's size and the number of colors selected. Two colors would look like this before:

![image](https://user-images.githubusercontent.com/2293065/36348144-0864f3a6-1437-11e8-8d56-94a7c62d8e31.png)

Now it will color the chase evenly:

![image](https://user-images.githubusercontent.com/2293065/36348151-37cac274-1437-11e8-9909-638697b4784e.png)

