### PR TITLE
Fixes for Sequence Video panel

### DIFF
--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -692,6 +692,14 @@ void SeqSettingsDialog::OnChoice_Xml_Seq_TypeSelect(wxCommandEvent& event)
         xml_file->SetSequenceType(type);
         ProcessSequenceType();
     }
+
+    wxString path;
+    if ( type != "Animation" )
+       path = TextCtrl_Xml_Media_File->GetValue();
+    xLightsFrame *pFrame = dynamic_cast<xLightsFrame *>( GetParent() );
+    wxASSERT( pFrame != nullptr );
+    if ( pFrame != nullptr )
+      pFrame->UpdateSequenceVideoPanel( path );
 }
 
 void SeqSettingsDialog::OnBitmapButton_Xml_Media_FileClick(wxCommandEvent& event)

--- a/xLights/SequenceVideoPanel.cpp
+++ b/xLights/SequenceVideoPanel.cpp
@@ -39,6 +39,7 @@ void SequenceVideoPanel::SetMediaPath( const std::string& path )
 {
     if (path == "")
     {
+        _VideoReader.reset();
         _VideoWidth = 0;
         _VideoHeight = 0;
         _VideoLength = 0;

--- a/xLights/SequenceVideoPanel.cpp
+++ b/xLights/SequenceVideoPanel.cpp
@@ -20,13 +20,13 @@ BEGIN_EVENT_TABLE(SequenceVideoPanel,wxPanel)
 END_EVENT_TABLE()
 
 SequenceVideoPanel::SequenceVideoPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const wxSize& size)
-   : _Path(), _VideoReader(), _IsValidVideo(false), _VideoWidth(0), _VideoHeight(0), _VideoLength(0), _VideoPreview(nullptr)
+   : _path(), _videoReader(), _isValidVideo(false), _videoWidth(0), _videoHeight(0), _videoLength(0), _videoPreview(nullptr)
 {
 	//(*Initialize(SequenceVideoPanel)
 	Create(parent, id, wxDefaultPosition, wxSize(268,203), wxTAB_TRAVERSAL, _T("id"));
 	//*)
 
-   _VideoPreview = new SequenceVideoPreview( this );
+   _videoPreview = new SequenceVideoPreview( this );
 }
 
 SequenceVideoPanel::~SequenceVideoPanel()
@@ -39,44 +39,44 @@ void SequenceVideoPanel::SetMediaPath( const std::string& path )
 {
     if (path == "")
     {
-        _VideoReader.reset();
-        _VideoWidth = 0;
-        _VideoHeight = 0;
-        _VideoLength = 0;
-        _IsValidVideo = false;
-        _VideoPreview->Clear();
+        _videoReader.reset();
+        _videoWidth = 0;
+        _videoHeight = 0;
+        _videoLength = 0;
+        _isValidVideo = false;
+        _videoPreview->Clear();
     }
     else
     {
-        _VideoReader.reset(new VideoReader(std::string(path), 0, 0, false, true));
-        if (_VideoReader->IsValid())
+        _videoReader.reset(new VideoReader(std::string(path), 0, 0, false, true));
+        if (_videoReader->IsValid())
         {
-            _IsValidVideo = true;
-            _VideoWidth = _VideoReader->GetWidth();
-            _VideoHeight = _VideoReader->GetHeight();
-            _VideoLength = _VideoReader->GetLengthMS();
+            _isValidVideo = true;
+            _videoWidth = _videoReader->GetWidth();
+            _videoHeight = _videoReader->GetHeight();
+            _videoLength = _videoReader->GetLengthMS();
         }
     }
 }
 
 void SequenceVideoPanel::UpdateVideo( int ms )
 {
-   if ( !_IsValidVideo || !IsShown() )
+   if ( !_isValidVideo || !IsShown() )
       return;
 
-   int clampedTime = std::min( ms, _VideoLength );
+   int clampedTime = std::min( ms, _videoLength );
 
-   AVFrame *frame = _VideoReader->GetNextFrame( clampedTime );
+   AVFrame *frame = _videoReader->GetNextFrame( clampedTime );
    if ( frame != nullptr )
-   _VideoPreview->Render( frame );
+   _videoPreview->Render( frame );
 }
 
 void SequenceVideoPanel::Resized( wxSizeEvent& evt )
 {
-   if ( _VideoPreview )
+   if ( _videoPreview )
    {
-      _VideoPreview->Move( 0, 0 );
-      _VideoPreview->SetSize( evt.GetSize() );
+      _videoPreview->Move( 0, 0 );
+      _videoPreview->SetSize( evt.GetSize() );
    }
 }
 

--- a/xLights/SequenceVideoPanel.h
+++ b/xLights/SequenceVideoPanel.h
@@ -38,13 +38,13 @@ class SequenceVideoPanel: public wxPanel
 
       void Resized( wxSizeEvent& evt );
 
-      std::string                   _Path;
-      std::unique_ptr<VideoReader>  _VideoReader;
-      bool                          _IsValidVideo;
-      int                           _VideoWidth;
-      int                           _VideoHeight;
-      int                           _VideoLength;
-      SequenceVideoPreview *        _VideoPreview;
+      std::string                   _path;
+      std::unique_ptr<VideoReader>  _videoReader;
+      bool                          _isValidVideo;
+      int                           _videoWidth;
+      int                           _videoHeight;
+      int                           _videoLength;
+      SequenceVideoPreview *        _videoPreview;
 };
 
 #endif

--- a/xLights/SequenceVideoPreview.cpp
+++ b/xLights/SequenceVideoPreview.cpp
@@ -12,7 +12,7 @@ EVT_PAINT( SequenceVideoPreview::paint )
 END_EVENT_TABLE()
 
 
-SequenceVideoPreview::SequenceVideoPreview(wxPanel *parent) : xlGLCanvas(parent, wxID_ANY), _TexId(0), _TexWidth(0), _TexHeight(0)
+SequenceVideoPreview::SequenceVideoPreview(wxPanel *parent) : xlGLCanvas(parent, wxID_ANY), _texId(0), _texWidth(0), _texHeight(0)
 {
 
 }
@@ -51,18 +51,18 @@ void SequenceVideoPreview::Render( AVFrame *frame )
    if ( !IsShownOnScreen() ) return;
    SetCurrentGLContext();
 
-   if ( _TexId == 0 || frame->width != _TexWidth || frame->height != _TexHeight )
+   if ( _texId == 0 || frame->width != _texWidth || frame->height != _texHeight )
       reinitTexture( frame->width, frame->height );
 
    // Upload video frame to texture
-   LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, _TexId ) );
-   LOG_GL_ERRORV( glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, _TexWidth, _TexHeight, GL_RGB, GL_UNSIGNED_BYTE, frame->data[0] ) );
+   LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, _texId ) );
+   LOG_GL_ERRORV( glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, _texWidth, _texHeight, GL_RGB, GL_UNSIGNED_BYTE, frame->data[0] ) );
    LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, 0 ) );
 
    // Draw video frame and swap-buffers
    prepare2DViewport( 0, 0, mWindowWidth, mWindowHeight );
    cache->Ortho( 0, 0, mWindowWidth, mWindowHeight );
-   cache->DrawTexture( _TexId, 0, 0, mWindowWidth, mWindowHeight );
+   cache->DrawTexture( _texId, 0, 0, mWindowWidth, mWindowHeight );
 
    SwapBuffers();
 }
@@ -86,8 +86,8 @@ void SequenceVideoPreview::reinitTexture( int width, int height )
 {
    deleteTexture();
 
-   LOG_GL_ERRORV( glGenTextures( 1, &_TexId ) );
-   LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, _TexId ) );
+   LOG_GL_ERRORV( glGenTextures( 1, &_texId ) );
+   LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, _texId ) );
 
    LOG_GL_ERRORV( glTexImage2D( GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr ) );
    LOG_GL_ERRORV( glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR ) );
@@ -97,15 +97,15 @@ void SequenceVideoPreview::reinitTexture( int width, int height )
 
    LOG_GL_ERRORV( ::glBindTexture( GL_TEXTURE_2D, 0 ) );
 
-   _TexWidth = width;
-   _TexHeight = height;
+   _texWidth = width;
+   _texHeight = height;
 }
 
 void SequenceVideoPreview::deleteTexture()
 {
-   if ( _TexId )
+   if ( _texId )
    {
-      LOG_GL_ERRORV( glDeleteTextures( 1, &_TexId ) );
-      _TexId = 0;
+      LOG_GL_ERRORV( glDeleteTextures( 1, &_texId ) );
+      _texId = 0;
    }
 }

--- a/xLights/SequenceVideoPreview.cpp
+++ b/xLights/SequenceVideoPreview.cpp
@@ -20,11 +20,7 @@ SequenceVideoPreview::SequenceVideoPreview(wxPanel *parent) : xlGLCanvas(parent,
 
 SequenceVideoPreview::~SequenceVideoPreview()
 {
-   if ( _TexId )
-   {
-      LOG_GL_ERRORV( glDeleteTextures( 1, &_TexId ) );
-      _TexId = 0;
-   }
+   deleteTexture();
 }
 
 void SequenceVideoPreview::InitializeGLCanvas()
@@ -73,16 +69,22 @@ void SequenceVideoPreview::Render( AVFrame *frame )
 
 void SequenceVideoPreview::Clear()
 {
-    // TODO Kevin ... we need to clear the image texture
-    Refresh();
+   deleteTexture();
+
+   SetCurrentGLContext();
+
+   LOG_GL_ERRORV( glClear( GL_COLOR_BUFFER_BIT ) );
+
+   SwapBuffers();
+   
+   Refresh();
 }
 
 #define GL_CLAMP_TO_EDGE 0x812F
 
 void SequenceVideoPreview::reinitTexture( int width, int height )
 {
-   if ( _TexId )
-      ::glDeleteTextures( 1, &_TexId );
+   deleteTexture();
 
    LOG_GL_ERRORV( glGenTextures( 1, &_TexId ) );
    LOG_GL_ERRORV( glBindTexture( GL_TEXTURE_2D, _TexId ) );
@@ -97,4 +99,13 @@ void SequenceVideoPreview::reinitTexture( int width, int height )
 
    _TexWidth = width;
    _TexHeight = height;
+}
+
+void SequenceVideoPreview::deleteTexture()
+{
+   if ( _TexId )
+   {
+      LOG_GL_ERRORV( glDeleteTextures( 1, &_TexId ) );
+      _TexId = 0;
+   }
 }

--- a/xLights/SequenceVideoPreview.h
+++ b/xLights/SequenceVideoPreview.h
@@ -26,9 +26,9 @@ protected:
 private:
    void paint( wxPaintEvent& evt );
 
-   unsigned _TexId;
-   int      _TexWidth;
-   int      _TexHeight;
+   unsigned _texId;
+   int      _texWidth;
+   int      _texHeight;
 
    DECLARE_EVENT_TABLE()
 };

--- a/xLights/SequenceVideoPreview.h
+++ b/xLights/SequenceVideoPreview.h
@@ -21,6 +21,8 @@ protected:
 
    void reinitTexture( int width, int height );
 
+   void deleteTexture();
+
 private:
    void paint( wxPaintEvent& evt );
 

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -3247,3 +3247,12 @@ void xLightsFrame::OnAuiToolBarItemShowHideEffects(wxCommandEvent& event)
     m_mgr->Update();
 }
 
+void xLightsFrame::UpdateSequenceVideoPanel(const wxString& path)
+{
+   if ( sequenceVideoPanel != nullptr )
+   {
+      std::string spath( path.ToStdString() );
+      ObtainAccessToURL( spath );
+      sequenceVideoPanel->SetMediaPath( spath );
+   }
+}

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1157,6 +1157,8 @@ public:
 
     bool GetSnapToTimingMarks() const { return _snapToTimingMarks; }
 
+    void UpdateSequenceVideoPanel( const wxString& path );
+
 protected:
     bool SeqLoadXlightsFile(const wxString& filename, bool ChooseModels);
     bool SeqLoadXlightsFile(xLightsXmlFile& xml_file, bool ChooseModels);


### PR DESCRIPTION
Cases tested:
* [x] Closing sequence should not leave video-frame image showing
* [x] Changing sequence type from media to animation should not leave video-frame image showing
* [x] After changing sequence type from media to animation, previous sequence-media video should not play

Unrelated, but after changing sequence type from media to animation, the audio is gone but the waveform display isn't cleared out.

I also renamed class member variables for code style consistency. 