### PR TITLE
Fix bug with 'Export House Preview' on high DPI

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- bug (kevin)  Fix house preview video export on Windows with high DPI settings
    -- enh (keith)  Change the colour panel update button to purely apply the colour palette. All other colour settings are ignored.
    -- enh (keith)  Add the ability to change custom model background image from within the model data dialog
    -- enh (keith)  Strip out some buttons and replace them with a right click menu with enhancements to create 

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -3133,6 +3133,9 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
     int width = housePreview->getWidth();
     int height = housePreview->getHeight();
     double contentScaleFactor = GetContentScaleFactor();
+#ifdef _WIN32
+    contentScaleFactor = 1.;
+#endif // WIN32
 
     int audioChannelCount = 0;
     int audioSampleRate = 0;


### PR DESCRIPTION
Addresses https://github.com/smeighan/xLights/issues/1134

It looks like CaptureHelper and VideoExporter don't need to take GetContentScaleFactor() into account; that seems to be a fix for Windows; just want to verify it makes sense for Mac.