### PR TITLE
Force a house-preview update after video export

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -3195,6 +3195,10 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
         m_mgr->GetPane("HousePreview").Hide();
         m_mgr->Update();
     }
+    else
+    {
+       housePreview->Update();
+    }
 
     if (exportStatus)
     {
@@ -8495,7 +8499,7 @@ bool xLightsFrame::HandleAllKeyBinding(wxKeyEvent& event)
     auto k = event.GetKeyCode();
     if (k == WXK_SHIFT || k == WXK_CONTROL || k == WXK_ALT) return false;
 
-    if ((!event.ControlDown() && !event.CmdDown() && !event.AltDown()) || 
+    if ((!event.ControlDown() && !event.CmdDown() && !event.AltDown()) ||
         (k == 'A' && (event.ControlDown() || event.CmdDown()) && !event.AltDown()))
     {
         // Just a regular key ... If current focus is a control then we need to not process this


### PR DESCRIPTION
This *seems* to mostly fix the issue where if you do a video export and then immediately close the sequence, the effects grid becomes unusable, even after opening or starting a new sequence. I can still get it to get in a state sometimes though where the range selection over the waveform either doesn't draw at all or just repeatedly draws a line in the same place. So this probably isn't a complete fix but seems like an improvement over the effects grid being completely unusable, so I think it's worth merging.

Note: so far, I've only been able to repro this on Win 10 but not on the Win 7 machine that I normally build xLights on.