### PR TITLE
Simplify video export

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -3184,9 +3184,7 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
     }
     );
 
-    captureHelper.SetActive(true);
     bool exportStatus = videoExporter.Export(path.c_str());
-    captureHelper.SetActive(false);
 
     mainSequencer->SetPlayStatus(playStatus);
 
@@ -3194,10 +3192,6 @@ void xLightsFrame::OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event)
     {
         m_mgr->GetPane("HousePreview").Hide();
         m_mgr->Update();
-    }
-    else
-    {
-       housePreview->Update();
     }
 
     if (exportStatus)

--- a/xLights/xlGLCanvas.cpp
+++ b/xLights/xlGLCanvas.cpp
@@ -74,55 +74,8 @@ xlGLCanvas::CaptureHelper::~CaptureHelper()
 		delete[] tmpBuf;
 		tmpBuf = nullptr;
 	}
-
-	if (!hasOpenGL3FramebufferObjects())
-		return;
-
-	if (fbID)
-	{
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		glDeleteFramebuffers(1, &fbID);
-		fbID = 0;
-	}
-
-	if (rbID)
-	{
-		glBindRenderbuffer(GL_RENDERBUFFER, 0);
-		glDeleteRenderbuffers(1, &rbID);
-	}
 }
 
-void xlGLCanvas::CaptureHelper::SetActive(bool active)
-{
-   if ( !hasOpenGL3FramebufferObjects() )
-   {
-      log4cpp::Category &logger_base = log4cpp::Category::getInstance( std::string( "log_base" ) );
-      logger_base.debug( "xglCanvas::CaptureHelper::SetActive() - framebuffer objects unsupported!" );
-      return;
-   }
-
-	if (active)
-	{
-		if (!fbID && !rbID)
-		{
-			int widthWithContentScaleFactor = width * contentScaleFactor;
-			int heightWithContentScaleFactor = height * contentScaleFactor;
-			glGenRenderbuffers(1, &rbID);
-			glBindRenderbuffer(GL_RENDERBUFFER, rbID);
-			glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA, widthWithContentScaleFactor, heightWithContentScaleFactor);
-
-			glGenFramebuffers(1, &fbID);
-			glBindFramebuffer(GL_FRAMEBUFFER, fbID);
-			glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rbID);
-		}
-
-		glBindFramebuffer(GL_FRAMEBUFFER, fbID);
-	}
-	else
-	{
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	}
-}
 bool xlGLCanvas::CaptureHelper::ToRGB(unsigned char *buf, unsigned int bufSize, bool padToEvenDims/*=false*/)
 {
 	int w = width * contentScaleFactor;

--- a/xLights/xlGLCanvas.h
+++ b/xLights/xlGLCanvas.h
@@ -37,15 +37,11 @@ class xlGLCanvas
 		  {
 		  public:
 			  // note: width & height without content-scale factor
-			  CaptureHelper(int i_width, int i_height, double i_contentScaleFactor) : fbID(0), rbID(0), width(i_width), height(i_height), contentScaleFactor(i_contentScaleFactor), tmpBuf(nullptr) {};
+			  CaptureHelper(int i_width, int i_height, double i_contentScaleFactor) : width(i_width), height(i_height), contentScaleFactor(i_contentScaleFactor), tmpBuf(nullptr) {};
 			  virtual ~CaptureHelper();
-
-			  void SetActive(bool active);
 
 			  bool ToRGB(unsigned char *buf, unsigned int bufSize, bool padToEvenDims=false);
 		  protected:
-			  unsigned fbID;
-			  unsigned rbID;
 			  const int width;
 			  const int height;
 			  const double contentScaleFactor;


### PR DESCRIPTION
House Preview pane is forced to be visible and we're temporarily disabling the buffer swap, so using a renderbuffer for capture isn't really necessary.

This undoes my somewhat-hacky initial fix.