### PR TITLE
Fix keyboard shortcuts not being picked up on Linux machines

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2858,7 +2858,7 @@ void LayoutPanel::OnCharHook(wxKeyEvent& event) {
   wxChar uc = event.GetKeyCode();
 
     switch(uc) {
-#ifdef __WXMSW__
+#ifndef __WXOSX__
         case 'z':
         case 'Z':
             if (event.ControlDown()) {
@@ -2904,7 +2904,7 @@ void LayoutPanel::OnCharHook(wxKeyEvent& event) {
         break;
 #endif
         case WXK_DELETE:
-#ifdef __WXMSW__
+#ifndef __WXOSX__
             if (event.ShiftDown()) // Cut
             {
                 wxCommandEvent evt(wxEVT_MENU, wxID_CUT);


### PR DESCRIPTION
As described and discussed here (amongst other things): http://nutcracker123.com/forum/index.php?PHPSESSID=gf597e91kvg8gdd26rvaoj42j5&topic=5743.0, fix keyboard shortcuts such as copy and paste not working on Linux machines by ensuring we only ignore these shortcuts if using an OSX machine (as per @dkulp's suggestion).

Currently it appears any machine that isn't detected as using the Windows GUI controls for wxWidgets will ignore these shortcuts.