### PR TITLE
Fix bug where some text values were not getting multiplied by the divisor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ xLights/xLights.VC.db
 lib/linux/libliquidfun.a
 *.opensdf
 *.cbp.mak.orig
+/.vs
+/xLights/Xlights.vcxproj.user

--- a/xLights/ValueCurveDialog.cpp
+++ b/xLights/ValueCurveDialog.cpp
@@ -794,6 +794,8 @@ void ValueCurveDialog::UpdateLinkedSlider(wxCommandEvent& event)
         val_str << value;
         txt->ChangeValue(val_str);
     }
+	if ((slider->GetMin() != 0) && (slider->GetMin() != 1))
+		value *= _vc->GetDivisor();
     slider->SetValue(value);
 }
 

--- a/xLights/effects/EffectPanelUtils.cpp
+++ b/xLights/effects/EffectPanelUtils.cpp
@@ -208,6 +208,10 @@ void EffectPanelUtils::OnVCButtonClick(wxCommandEvent& event)
             slideridd = true;
         }
     }
+	else if (slider != nullptr)
+	{
+		slideridd = true;
+	}
 
     name = vc->GetName();
     name.Replace("IDD_VALUECURVE_", "ID_TEXTCTRL_");


### PR DESCRIPTION
Found cases where text values and slider values were not matching.  slideridd was not getting set sometimes.  Also some cases where the multiplier factor wasn't getting set both on the text side and on the slider side.  Tested all the  types on different effects.