### PR TITLE
Add ability to pan in the X/Y plane when in 3D view.

### DIFF
--- a/xLights/ModelPreview.h
+++ b/xLights/ModelPreview.h
@@ -80,14 +80,14 @@ public:
         additionalModel = m;
         Refresh();
     }
-    
-    
+
+
     void SetPreviewPane(PreviewPane* pane) {mPreviewPane = pane;}
     void SetActive(bool show);
     bool GetActive();
     float GetZoom() { return (is_3d ? camera3d->GetZoom() : camera2d->GetZoom()); }
     float GetCameraRotation() { return (is_3d ? camera3d->GetAngleY() : camera2d->GetAngleY()); }
-    void SetPan(float deltax, float deltay);
+    void SetPan(float deltax, float deltay, float deltaz);
     void Set3D(bool value) { is_3d = value; }
     bool Is3D() { return is_3d; }
     glm::mat4& GetProjViewMatrix() { return ProjViewMatrix; }
@@ -142,13 +142,13 @@ private:
     bool allowPreviewChange;
     PreviewPane* mPreviewPane;
     DrawGLUtils::xlAccumulator accumulator;
-    
+
     xLightsFrame* xlights;
     std::string currentModel;
     std::string currentLayoutGroup;
     std::vector<Model*> tmpModelList;
     Model *additionalModel;
-    
+
 	DrawGLUtils::xl3Accumulator view_object_accumulator;
     DrawGLUtils::xl3Accumulator accumulator3d;
     bool is_3d;

--- a/xLights/ViewpointMgr.cpp
+++ b/xLights/ViewpointMgr.cpp
@@ -8,7 +8,7 @@
 
 PreviewCamera::PreviewCamera(bool is_3d_)
 : posX(0.0f), posY(0.0f), angleX(20.0f), angleY(5.0f), distance(-2000.0f), zoom(1.0f),
-  panx(0.0f), pany(0.0f), zoom_corrx(0.0f), zoom_corry(0.0f), is_3d(is_3d_), name("Name Unspecified"), menu_id(wxNewId()), deletemenu_id(wxNewId()), mat_valid(false)
+  panx(0.0f), pany(0.0f), panz(0.0f), zoom_corrx(0.0f), zoom_corry(0.0f), is_3d(is_3d_), name("Name Unspecified"), menu_id(wxNewId()), deletemenu_id(wxNewId()), mat_valid(false)
 {
 }
 
@@ -19,7 +19,7 @@ PreviewCamera::~PreviewCamera()
 // Copy constructor
 PreviewCamera::PreviewCamera(const PreviewCamera &cam)
 : posX(cam.posX), posY(cam.posY), angleX(cam.angleX), angleY(cam.angleY), distance(cam.distance), zoom(cam.zoom),
-  panx(cam.panx), pany(cam.pany), zoom_corrx(cam.zoom_corrx), zoom_corry(cam.zoom_corry), is_3d(cam.is_3d), name(cam.name), menu_id(wxNewId()), deletemenu_id(wxNewId()), mat_valid(false)
+  panx(cam.panx), pany(cam.pany), panz(cam.panz),zoom_corrx(cam.zoom_corrx), zoom_corry(cam.zoom_corry), is_3d(cam.is_3d), name(cam.name), menu_id(wxNewId()), deletemenu_id(wxNewId()), mat_valid(false)
 {
 }
 
@@ -34,6 +34,7 @@ PreviewCamera& PreviewCamera::operator= (const PreviewCamera& rhs)
     zoom = rhs.zoom;
     panx = rhs.panx;
     pany = rhs.pany;
+    panz = rhs.panz;
     zoom_corrx = rhs.zoom_corrx;
     zoom_corry = rhs.zoom_corry;
     is_3d = rhs.is_3d;
@@ -44,7 +45,7 @@ PreviewCamera& PreviewCamera::operator= (const PreviewCamera& rhs)
 glm::mat4& PreviewCamera::GetViewMatrix()
 {
     if (!mat_valid) {
-        glm::mat4 ViewTranslatePan = glm::translate(glm::mat4(1.0f), glm::vec3(posX + panx, 1.0f, posY + pany));
+        glm::mat4 ViewTranslatePan = glm::translate(glm::mat4(1.0f), glm::vec3(posX + panx, posY + pany, panz));
         glm::mat4 ViewTranslateDistance = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 1.0f, distance * zoom));
         glm::mat4 ViewRotateX = glm::rotate(glm::mat4(1.0f), glm::radians(angleX), glm::vec3(1.0f, 0.0f, 0.0f));
         glm::mat4 ViewRotateY = glm::rotate(glm::mat4(1.0f), glm::radians(angleY), glm::vec3(0.0f, 1.0f, 0.0f));
@@ -205,6 +206,7 @@ wxXmlNode* ViewpointMgr::Save() const
 	    cnode->AddAttribute("zoom", wxString::Format("%f", previewCameras3d[i]->zoom));
 	    cnode->AddAttribute("panx", wxString::Format("%f", previewCameras3d[i]->panx));
 	    cnode->AddAttribute("pany", wxString::Format("%f", previewCameras3d[i]->pany));
+	    cnode->AddAttribute("panz", wxString::Format("%f", previewCameras3d[i]->panz));
 	    cnode->AddAttribute("zoom_corrx", wxString::Format("%f", previewCameras3d[i]->zoom_corrx));
 	    cnode->AddAttribute("zoom_corry", wxString::Format("%f", previewCameras3d[i]->zoom_corry));
 	    cnode->AddAttribute("is_3d", wxString::Format("%d", previewCameras3d[i]->is_3d));
@@ -250,6 +252,10 @@ void ViewpointMgr::Load(wxXmlNode* vp_node)
             new_camera->panx = wxAtof(attr);
             c->GetAttribute("pany", &attr);
             new_camera->pany = wxAtof(attr);
+            if( is_3d ) {
+                c->GetAttribute("panz", &attr);
+                new_camera->panz = wxAtof(attr);
+            }
             c->GetAttribute("zoom_corrx", &attr);
             new_camera->zoom_corrx = wxAtof(attr);
             c->GetAttribute("zoom_corry", &attr);

--- a/xLights/ViewpointMgr.h
+++ b/xLights/ViewpointMgr.h
@@ -27,6 +27,7 @@ public:
     float GetZoom() { return zoom; }
     float GetPanX() { return panx; }
     float GetPanY() { return pany; }
+    float GetPanZ() { return panz; }
     float GetZoomCorrX() { return zoom_corrx; }
     float GetZoomCorrY() { return zoom_corry; }
     float GetIs3D() { return is_3d; }
@@ -42,6 +43,7 @@ public:
     void SetZoom(float value) { zoom = value; mat_valid = false; }
     void SetPanX(float value) { panx = value; mat_valid = false; }
     void SetPanY(float value) { pany = value; mat_valid = false; }
+    void SetPanZ(float value) { panz = value; mat_valid = false; }
     void SetZoomCorrX(float value) { zoom_corrx = value; mat_valid = false; }
     void SetZoomCorrY(float value) { zoom_corry = value; mat_valid = false; }
     void SetIs3D(bool value) { is_3d = value; mat_valid = false; }
@@ -56,6 +58,7 @@ protected:
     float zoom;
     float panx;
     float pany;
+    float panz;
     float zoom_corrx;
     float zoom_corry;
     bool is_3d;


### PR DESCRIPTION
Existing behavior of panning in the X/Z plane is retained when no modifier key is down.  This change adds the ability to hold down the CTRL key while using the middle mouse button (scroll wheel button) to pan the 3D layout or house preview views.  This provides the user with the ability to pan in the X/Y plane.

Adding X/Y plane panning handles the use case where the user wishes to move closer to a face of a mesh model they have imported (e.g. their house) and layout lights on that face.  The user would use X/Z plane panning to move close to a face of the model.  At this point, it is desirable to be able to pan across the face of the model in order to place lighting elements.  For intricate models (e.g. houses with lots of architectural details), being able to pan along the X/Y plane is helpful to move around the face of their model without having to rotate the camera and re-adjust panning in the X/Z plane.