### PR TITLE
Allow the user to specify a manual X\Y position for the fireworks effect

### DIFF
--- a/xLights/effects/FireworksEffect.h
+++ b/xLights/effects/FireworksEffect.h
@@ -3,6 +3,10 @@
 
 #include "RenderableEffect.h"
 
+#define FIREWORKS_POSITIONX_MIN -250
+#define FIREWORKS_POSITIONX_MAX 250
+#define FIREWORKS_POSITIONY_MIN -250
+#define FIREWORKS_POSITIONY_MAX 250
 
 class FireworksEffect : public RenderableEffect
 {

--- a/xLights/effects/FireworksPanel.cpp
+++ b/xLights/effects/FireworksPanel.cpp
@@ -47,6 +47,18 @@ const long FireworksPanel::ID_CHECKBOX_FIRETIMING = wxNewId();
 const long FireworksPanel::ID_BITMAPBUTTON_CHECKBOX_FIRETIMING = wxNewId();
 const long FireworksPanel::ID_STATICTEXT_FIRETIMINGTRACK = wxNewId();
 const long FireworksPanel::ID_CHOICE_FIRETIMINGTRACK = wxNewId();
+const long FireworksPanel::ID_CHECKBOX_Fireworks_UseLocation = wxNewId();
+const long FireworksPanel::ID_SLIDER_Fireworks_LocationX = wxNewId();
+const long FireworksPanel::ID_SLIDER_Fireworks_LocationY = wxNewId();
+const long FireworksPanel::IDD_TEXTCTRL_Fireworks_LocationX = wxNewId();
+const long FireworksPanel::IDD_TEXTCTRL_Fireworks_LocationY = wxNewId();
+const long FireworksPanel::ID_STATICTEXT_Fireworks_LocationX = wxNewId();
+const long FireworksPanel::ID_STATICTEXT_Fireworks_LocationY = wxNewId();
+const long FireworksPanel::ID_VALUECURVE_Fireworks_LocationX = wxNewId();
+const long FireworksPanel::ID_VALUECURVE_Fireworks_LocationY = wxNewId();
+const long FireworksPanel::ID_BITMAPBUTTON_CHECKBOX_Fireworks_UseLocation = wxNewId();
+const long FireworksPanel::ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX = wxNewId();
+const long FireworksPanel::ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(FireworksPanel,wxPanel)
@@ -59,6 +71,8 @@ FireworksPanel::FireworksPanel(wxWindow* parent)
 {
 	//(*Initialize(FireworksPanel)
 	wxFlexGridSizer* FlexGridSizer73;
+    wxFlexGridSizer* FlexGridSizer74;
+    wxFlexGridSizer* FlexGridSizer75;
 
 	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
 	FlexGridSizer73 = new wxFlexGridSizer(0, 4, 0, 0);
@@ -134,7 +148,63 @@ FireworksPanel::FireworksPanel(wxWindow* parent)
 	Choice_TimingTrack = new BulkEditChoice(this, ID_CHOICE_FIRETIMINGTRACK, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_FIRETIMINGTRACK"));
 	FlexGridSizer73->Add(Choice_TimingTrack, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer73->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer73->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer73->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    FlexGridSizer73->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    CheckBox_Fireworks_UseLocation = new BulkEditCheckBox(this, ID_CHECKBOX_Fireworks_UseLocation, _("Manual explosion location"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Fireworks_UseLocation"));
+    CheckBox_Fireworks_UseLocation->SetValue(false);
+    FlexGridSizer73->Add(CheckBox_Fireworks_UseLocation, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer73->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    BitmapButton_Fireworks_UseLocation = new xlLockButton(this, ID_BITMAPBUTTON_CHECKBOX_Fireworks_UseLocation, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_PADLOCK_OPEN")),wxART_BUTTON), wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxNO_BORDER, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHECKBOX_Fireworks_UseLocation"));
+    BitmapButton_Fireworks_UseLocation->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+    FlexGridSizer73->Add(BitmapButton_Fireworks_UseLocation, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    
+    StaticText100 = new wxStaticText(this, ID_STATICTEXT_Fireworks_LocationX, _("Location X"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fireworks_LocationX"));
+    FlexGridSizer73->Add(StaticText100, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
+    
+    FlexGridSizer74 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer74->AddGrowableCol(0);
+    Slider_Fireworks_LocationX = new BulkEditSlider(this, ID_SLIDER_Fireworks_LocationX, 0, FIREWORKS_POSITIONX_MIN, FIREWORKS_POSITIONX_MAX, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Fireworks_LocationX"));
+    FlexGridSizer74->Add(Slider_Fireworks_LocationX, 1, wxALL|wxEXPAND, 2);
+    
+    ValueCurve_Fireworks_LocationX = new BulkEditValueCurveButton(this, ID_VALUECURVE_Fireworks_LocationX, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_valuecurve_notselected")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxNO_BORDER, wxDefaultValidator, _T("ID_VALUECURVE_Fireworks_LocationX"));
+    FlexGridSizer74->Add(ValueCurve_Fireworks_LocationX, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+    FlexGridSizer73->Add(FlexGridSizer74, 1, wxALL|wxEXPAND, 0);
+    
+    TextCtrl_Fireworks_LocationX = new BulkEditTextCtrl(this, IDD_TEXTCTRL_Fireworks_LocationX, _("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(25,-1)), 0, wxDefaultValidator, _T("IDD_TEXTCTRL_Fireworks_LocationX"));
+    TextCtrl_Fireworks_LocationX->SetMaxLength(3);
+    FlexGridSizer73->Add(TextCtrl_Fireworks_LocationX, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    BitmapButton_Fireworks_LocationX = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_PADLOCK_OPEN")),wxART_BUTTON), wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxNO_BORDER, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX"));
+    BitmapButton_Fireworks_LocationX->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+    FlexGridSizer73->Add(BitmapButton_Fireworks_LocationX, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    
+    
+    
+    StaticText170 = new wxStaticText(this, ID_STATICTEXT_Fireworks_LocationY, _("Location Y"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fireworks_LocationY"));
+    FlexGridSizer73->Add(StaticText170, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
+    
+    FlexGridSizer75 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer75->AddGrowableCol(0);
+    Slider_Fireworks_LocationY = new BulkEditSlider(this, ID_SLIDER_Fireworks_LocationY, 0, FIREWORKS_POSITIONY_MIN, FIREWORKS_POSITIONY_MAX, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Fireworks_LocationY"));
+    FlexGridSizer75->Add(Slider_Fireworks_LocationY, 1, wxALL|wxEXPAND, 2);
+    
+    ValueCurve_Fireworks_LocationY = new BulkEditValueCurveButton(this, ID_VALUECURVE_Fireworks_LocationY, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_valuecurve_notselected")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxNO_BORDER, wxDefaultValidator, _T("ID_VALUECURVE_Fireworks_LocationY"));
+    FlexGridSizer75->Add(ValueCurve_Fireworks_LocationY, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+    FlexGridSizer73->Add(FlexGridSizer75, 1, wxALL|wxEXPAND, 0);
+    
+    TextCtrl_Fireworks_LocationY = new BulkEditTextCtrl(this, IDD_TEXTCTRL_Fireworks_LocationY, _("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(25,-1)), 0, wxDefaultValidator, _T("IDD_TEXTCTRL_Fireworks_LocationY"));
+    TextCtrl_Fireworks_LocationY->SetMaxLength(3);
+    FlexGridSizer73->Add(TextCtrl_Fireworks_LocationY, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    BitmapButton_Fireworks_LocationY = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_PADLOCK_OPEN")),wxART_BUTTON), wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxNO_BORDER, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY"));
+    BitmapButton_Fireworks_LocationY->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+    FlexGridSizer73->Add(BitmapButton_Fireworks_LocationY, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    
+	
 	SetSizer(FlexGridSizer73);
 	FlexGridSizer73->Fit(this);
 	FlexGridSizer73->SetSizeHints(this);
@@ -149,11 +219,22 @@ FireworksPanel::FireworksPanel(wxWindow* parent)
 	Connect(ID_CHECKBOX_FIRETIMING,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnCheckBox_FireTimingClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_FIRETIMING,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnLockButtonClick);
 	Connect(ID_CHOICE_FIRETIMINGTRACK,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&FireworksPanel::OnChoice_TimingTrackSelect);
+    
+    Connect(ID_CHECKBOX_Fireworks_UseLocation,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnCheckBox_UseLocationClick);
+    Connect(ID_BITMAPBUTTON_CHECKBOX_Fireworks_UseLocation,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnLockButtonClick);
+    Connect(ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnLockButtonClick);
+    Connect(ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnLockButtonClick);
+    Connect(ID_VALUECURVE_Fireworks_LocationX,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnVCButtonClick);
+    Connect(ID_VALUECURVE_Fireworks_LocationY,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&FireworksPanel::OnVCButtonClick);
 	//*)
 
     SetName("ID_PANEL_FIREWORKS");
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&FireworksPanel::OnVCChanged, 0, this);
+    
+    ValueCurve_Fireworks_LocationX->GetValue()->SetLimits(FIREWORKS_POSITIONX_MIN, FIREWORKS_POSITIONY_MAX);
+    ValueCurve_Fireworks_LocationY->GetValue()->SetLimits(FIREWORKS_POSITIONY_MIN, FIREWORKS_POSITIONY_MAX);
+
     ValidateWindow();
 }
 
@@ -181,6 +262,29 @@ void FireworksPanel::ValidateWindow()
     {
         Choice_TimingTrack->Enable(false);
     }
+    
+    if (CheckBox_Fireworks_UseLocation->GetValue())
+    {
+        Slider_Fireworks_LocationX->Enable();
+        Slider_Fireworks_LocationY->Enable();
+        ValueCurve_Fireworks_LocationX->Enable();
+        ValueCurve_Fireworks_LocationY->Enable();
+        TextCtrl_Fireworks_LocationX->Enable();
+        TextCtrl_Fireworks_LocationY->Enable();
+        BitmapButton_Fireworks_LocationX->Enable();
+        BitmapButton_Fireworks_LocationY->Enable();
+    }
+    else
+    {
+        Slider_Fireworks_LocationX->Disable();
+        Slider_Fireworks_LocationY->Disable();
+        ValueCurve_Fireworks_LocationX->Disable();
+        ValueCurve_Fireworks_LocationY->Disable();
+        TextCtrl_Fireworks_LocationX->Disable();
+        TextCtrl_Fireworks_LocationY->Disable();
+        BitmapButton_Fireworks_LocationX->Disable();
+        BitmapButton_Fireworks_LocationY->Disable();
+    }
 }
 
 PANEL_EVENT_HANDLERS(FireworksPanel)
@@ -191,6 +295,11 @@ void FireworksPanel::OnCheckBox_Fireworks_UseMusicClick(wxCommandEvent& event)
 }
 
 void FireworksPanel::OnCheckBox_FireTimingClick(wxCommandEvent& event)
+{
+    ValidateWindow();
+}
+
+void FireworksPanel::OnCheckBox_UseLocationClick(wxCommandEvent& event)
 {
     ValidateWindow();
 }

--- a/xLights/effects/FireworksPanel.h
+++ b/xLights/effects/FireworksPanel.h
@@ -3,6 +3,7 @@
 
 //(*Headers(FireworksPanel)
 #include <wx/panel.h>
+#include "FireworksEffect.h"
 class wxBitmapButton;
 class wxCheckBox;
 class wxChoice;
@@ -27,23 +28,32 @@ class FireworksPanel: public wxPanel
 		//(*Declarations(FireworksPanel)
 		BulkEditCheckBox* CheckBox_FireTiming;
 		BulkEditCheckBox* CheckBox_Fireworks_UseMusic;
+        BulkEditCheckBox* CheckBox_Fireworks_UseLocation;
 		BulkEditChoice* Choice_TimingTrack;
 		BulkEditSlider* Slider_Fireworks_Count;
 		BulkEditSlider* Slider_Fireworks_Fade;
 		BulkEditSlider* Slider_Fireworks_Num_Explosions;
 		BulkEditSlider* Slider_Fireworks_Sensitivity;
 		BulkEditSlider* Slider_Fireworks_Velocity;
+        BulkEditSlider* Slider_Fireworks_LocationX;
+        BulkEditSlider* Slider_Fireworks_LocationY;
 		BulkEditTextCtrl* TextCtrl_Fireworks_Count;
 		BulkEditTextCtrl* TextCtrl_Fireworks_Explosions;
 		BulkEditTextCtrl* TextCtrl_Fireworks_Fade;
 		BulkEditTextCtrl* TextCtrl_Fireworks_Sensitivity;
 		BulkEditTextCtrl* TextCtrl_Fireworks_Velocity;
+        BulkEditTextCtrl* TextCtrl_Fireworks_LocationX;
+        BulkEditTextCtrl* TextCtrl_Fireworks_LocationY;
 		wxStaticText* StaticText1;
 		wxStaticText* StaticText2;
 		wxStaticText* StaticText91;
 		wxStaticText* StaticText93;
 		wxStaticText* StaticText94;
 		wxStaticText* StaticText95;
+        wxStaticText* StaticText100;
+        wxStaticText* StaticText170;
+        BulkEditValueCurveButton* ValueCurve_Fireworks_LocationX;
+        BulkEditValueCurveButton* ValueCurve_Fireworks_LocationY;
 		xlLockButton* BitmapButton1;
 		xlLockButton* BitmapButton_FireworksCount;
 		xlLockButton* BitmapButton_FireworksFade;
@@ -51,6 +61,9 @@ class FireworksPanel: public wxPanel
 		xlLockButton* BitmapButton_FireworksVelocity;
 		xlLockButton* BitmapButton_Fireworks_Sensitivity;
 		xlLockButton* BitmapButton_Fireworks_UseMusic;
+        xlLockButton* BitmapButton_Fireworks_UseLocation;
+        xlLockButton* BitmapButton_Fireworks_LocationX;
+        xlLockButton* BitmapButton_Fireworks_LocationY;
 		//*)
 
 	protected:
@@ -82,6 +95,18 @@ class FireworksPanel: public wxPanel
 		static const long ID_BITMAPBUTTON_CHECKBOX_FIRETIMING;
 		static const long ID_STATICTEXT_FIRETIMINGTRACK;
 		static const long ID_CHOICE_FIRETIMINGTRACK;
+        static const long ID_CHECKBOX_Fireworks_UseLocation;
+        static const long ID_SLIDER_Fireworks_LocationX;
+        static const long ID_SLIDER_Fireworks_LocationY;
+        static const long IDD_TEXTCTRL_Fireworks_LocationX;
+        static const long IDD_TEXTCTRL_Fireworks_LocationY;
+        static const long ID_STATICTEXT_Fireworks_LocationX;
+        static const long ID_STATICTEXT_Fireworks_LocationY;
+        static const long ID_VALUECURVE_Fireworks_LocationX;
+        static const long ID_VALUECURVE_Fireworks_LocationY;
+        static const long ID_BITMAPBUTTON_CHECKBOX_Fireworks_UseLocation;
+        static const long ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX;
+        static const long ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY;
 		//*)
 
 	public:
@@ -93,6 +118,7 @@ class FireworksPanel: public wxPanel
 		void OnVCChanged(wxCommandEvent& event);
 		void OnCheckBox_FireTimingClick(wxCommandEvent& event);
 		void OnChoice_TimingTrackSelect(wxCommandEvent& event);
+        void OnCheckBox_UseLocationClick(wxCommandEvent& event);
         //*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/FireworksPanel.wxs
+++ b/xLights/wxsmith/FireworksPanel.wxs
@@ -289,6 +289,139 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+            <object class="spacer">
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxCheckBox" name="ID_CHECKBOX_Fireworks_UseLocation" subclass="BulkEditCheckBox" variable="CheckBox_Fireworks_UseLocation" member="yes">
+                    <label>Manual explosion location</label>
+                    <handler function="OnCheckBox_UseLocationClick" entry="EVT_CHECKBOX" />
+                </object>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="spacer">
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxStaticText" name="ID_STATICTEXT_Fireworks_LocationX" variable="StaticText100" member="yes">
+                    <label>Location X</label>
+                </object>
+                <flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+                    <cols>2</cols>
+                    <growablecols>0</growablecols>
+                    <object class="sizeritem">
+                        <object class="wxSlider" name="ID_SLIDER_Fireworks_LocationX" subclass="BulkEditSlider" variable="Slider_Fireworks_LocationX" member="yes">
+                            <value>0</value>
+                            <min>-250</min>
+                            <max>250</max>
+                        </object>
+                        <flag>wxALL|wxEXPAND</flag>
+                        <border>2</border>
+                        <option>1</option>
+                    </object>
+                    <object class="sizeritem">
+                        <object class="wxBitmapButton" name="ID_VALUECURVE_Fireworks_LocationX" subclass="BulkEditValueCurveButton" variable="ValueCurve_Fireworks_LocationX" member="yes">
+                            <bitmap stock_id="xlART_valuecurve_notselected" stock_client="wxART_BUTTON" />
+                            <style>wxBU_AUTODRAW|wxNO_BORDER</style>
+                            <handler function="OnVCButtonClick" entry="EVT_BUTTON" />
+                        </object>
+                        <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <option>1</option>
+                    </object>
+                </object>
+                <flag>wxALL|wxEXPAND</flag>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxTextCtrl" name="IDD_TEXTCTRL_Fireworks_LocationX" subclass="BulkEditTextCtrl" variable="TextCtrl_Fireworks_LocationX" member="yes">
+                    <value>0</value>
+                    <maxlength>3</maxlength>
+                    <size>25,-1d</size>
+                </object>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxBitmapButton" subclass="xlLockButton" name="ID_BITMAPBUTTON_SLIDER_Fireworks_LocationX" variable="BitmapButton_Fireworks_LocationX" member="yes">
+                    <bitmap stock_id="xlART_PADLOCK_OPEN" stock_client="wxART_BUTTON" />
+                    <size>14,14</size>
+                    <bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
+                    <style>wxBU_AUTODRAW|wxNO_BORDER</style>
+                    <handler function="OnLockButtonClick" entry="EVT_BUTTON" />
+                </object>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxStaticText" name="ID_STATICTEXT_Fireworks_LocationY" variable="StaticText170" member="yes">
+                    <label>Location Y</label>
+                </object>
+                <flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+                    <cols>2</cols>
+                    <growablecols>0</growablecols>
+                    <object class="sizeritem">
+                        <object class="wxSlider" name="ID_SLIDER_Fireworks_LocationY" subclass="BulkEditSlider" variable="Slider_Fireworks_LocationY" member="yes">
+                            <value>0</value>
+                            <min>-250</min>
+                            <max>250</max>
+                        </object>
+                        <flag>wxALL|wxEXPAND</flag>
+                        <border>2</border>
+                        <option>1</option>
+                    </object>
+                    <object class="sizeritem">
+                        <object class="wxBitmapButton" name="ID_VALUECURVE_Fireworks_LocationY" subclass="BulkEditValueCurveButton" variable="ValueCurve_Fireworks_LocationY" member="yes">
+                            <bitmap stock_id="xlART_valuecurve_notselected" stock_client="wxART_BUTTON" />
+                            <style>wxBU_AUTODRAW|wxNO_BORDER</style>
+                            <handler function="OnVCButtonClick" entry="EVT_BUTTON" />
+                        </object>
+                        <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <option>1</option>
+                    </object>
+                </object>
+                <flag>wxALL|wxEXPAND</flag>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxTextCtrl" name="IDD_TEXTCTRL_Fireworks_LocationY" subclass="BulkEditTextCtrl" variable="TextCtrl_Fireworks_LocationY" member="yes">
+                    <value>0</value>
+                    <maxlength>3</maxlength>
+                    <size>25,-1d</size>
+                </object>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
+            <object class="sizeritem">
+                <object class="wxBitmapButton" subclass="xlLockButton" name="ID_BITMAPBUTTON_SLIDER_Fireworks_LocationY" variable="BitmapButton_Fireworks_LocationY" member="yes">
+                    <bitmap stock_id="xlART_PADLOCK_OPEN" stock_client="wxART_BUTTON" />
+                    <size>14,14</size>
+                    <bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
+                    <style>wxBU_AUTODRAW|wxNO_BORDER</style>
+                    <handler function="OnLockButtonClick" entry="EVT_BUTTON" />
+                </object>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <border>5</border>
+                <option>1</option>
+            </object>
 		</object>
 	</object>
 </wxsmith>


### PR DESCRIPTION
Allows the user to optionally specify a manual X\Y position for the fireworks effect, rather than the default "random" position.
If checked, you may also use the value curve option as well that can move the fireworks position over time.