### PR TITLE
Add configurable starRatio parameter for StarModel.

### DIFF
--- a/xLights/models/StarModel.h
+++ b/xLights/models/StarModel.h
@@ -38,6 +38,8 @@ class StarModel : public ModelWithScreenLocation<BoxedScreenLocation>
 
     private:
         std::vector<int> starSizes;
+        // The ratio between the inner and outer radius of the star; default is 2.618034.
+        float starRatio;
 };
 
 #endif // STARMODEL_H


### PR DESCRIPTION
Stars in xLights currently use a ratio of 2.618034 between the inner and
outer radius.  Some stars commercially available from common supplies do
not have the same ratio.  Being able to change the ratio of the star
provides the user with a means to more accurately model these stars
without relying on a custom model definition.

Please refer to the issue below:
https://github.com/smeighan/xLights/issues/1434