### PR TITLE
Enable timeline icon for galaxy effect / bug fix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-xLights is a show sequencer and player/scheduler designed to control
+﻿xLights is a show sequencer and player/scheduler designed to control
 USB/DMX/sACN(e1.31)/ArtNET(e.1.17)/DDP controllers.
 xLights also integrates with the Falcon Player.
 xLights imports and exports sequence data from sequencers such as LOR (SE, PE & SS),
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- enh (kevin)   Enable timeline icon for galaxy effect
 2019.09 February 2, 2019
    -- enh (keith)   Add movement to shapes effect
    -- enh (keith)   Add tool for applying reaper or xAudio edits to one or more audio files and generate a new audio file

--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
    -- bug (kevin)   Fix model/row copy effects from one sequence and pasting in another. Fixes #1450
-   -- enh (kevin)   Enable timeline icon for galaxy effect
+   -- enh (kevin)   Enable timeline icons for fan and galaxy effects
 2019.09 February 2, 2019
    -- enh (keith)   Add movement to shapes effect
    -- enh (keith)   Add tool for applying reaper or xAudio edits to one or more audio files and generate a new audio file

--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- bug (kevin)   Fix model/row copy effects from one sequence and pasting in another. Fixes #1450
    -- enh (kevin)   Enable timeline icon for galaxy effect
 2019.09 February 2, 2019
    -- enh (keith)   Add movement to shapes effect

--- a/xLights/effects/FanEffect.cpp
+++ b/xLights/effects/FanEffect.cpp
@@ -59,7 +59,7 @@ int FanEffect::DrawEffectBackground(const Effect *e, int x1, int y1, int x2, int
             backgrounds.AddHBlendedRectangle(c1, c2, cx1, y1+4, cx1+color_length, y2-4);
         }
     }
-    return 0;
+    return 2;
 }
 
 void FanEffect::SetDefaultParameters() {

--- a/xLights/effects/GalaxyEffect.cpp
+++ b/xLights/effects/GalaxyEffect.cpp
@@ -59,7 +59,7 @@ int GalaxyEffect::DrawEffectBackground(const Effect *e, int x1, int y1, int x2, 
             backgrounds.AddHBlendedRectangle(c1, c2, cx1, y1+4, cx1+color_length, y2-4);
         }
     }
-    return 1; // draw icon
+    return 2; // draw small icon
 }
 
 void GalaxyEffect::SetDefaultParameters() {

--- a/xLights/effects/GalaxyEffect.cpp
+++ b/xLights/effects/GalaxyEffect.cpp
@@ -59,7 +59,7 @@ int GalaxyEffect::DrawEffectBackground(const Effect *e, int x1, int y1, int x2, 
             backgrounds.AddHBlendedRectangle(c1, c2, cx1, y1+4, cx1+color_length, y2-4);
         }
     }
-    return 0;
+    return 1;
 }
 
 void GalaxyEffect::SetDefaultParameters() {

--- a/xLights/effects/GalaxyEffect.cpp
+++ b/xLights/effects/GalaxyEffect.cpp
@@ -59,7 +59,7 @@ int GalaxyEffect::DrawEffectBackground(const Effect *e, int x1, int y1, int x2, 
             backgrounds.AddHBlendedRectangle(c1, c2, cx1, y1+4, cx1+color_length, y2-4);
         }
     }
-    return 1;
+    return 1; // draw icon
 }
 
 void GalaxyEffect::SetDefaultParameters() {

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -4529,8 +4529,8 @@ void EffectsGrid::Paste(const wxString &data, const wxString &pasteDataVersion, 
 
     logger_base.info("mPartialCellSelected %d,   OneCellSelected: %d    paste_by_cell:  %d", (int)mPartialCellSelected, (int)OneCellSelected(), paste_by_cell);
 
-    if (mPartialCellSelected || OneCellSelected() || xlights->IsACActive()) {
-        if( ((number_of_timings + number_of_effects) > 1) || row_paste || xlights->IsACActive() )  // multi-effect paste or row_paste
+    if (mPartialCellSelected || OneCellSelected() || xlights->IsACActive() || row_paste ) {
+        if( ((number_of_timings + number_of_effects) > 1) || xlights->IsACActive() )  // multi-effect paste or row_paste
         {
             std::set<std::string> modelsToRender;
 


### PR DESCRIPTION
Tom BetGeorge requested this earlier today on FB and a few others liked it. The post has since been deleted and Tom reached out to Keith directly instead. From what I can tell, the galaxy effect has never had an icon since Gil added it back in 2015. It seems like a harmless change.

I also included a small bug fix for #1450 in this branch.