### PR TITLE
Use joinable threads in ListenerThread. Fixes MIDI scan

### DIFF
--- a/xSchedule/events/ListenerBase.cpp
+++ b/xSchedule/events/ListenerBase.cpp
@@ -11,7 +11,7 @@ ListenerBase::ListenerBase(ListenerManager* listenerManager)
     _isOk = false;
 }
 
-ListenerThread::ListenerThread(ListenerBase* listener)
+ListenerThread::ListenerThread(ListenerBase* listener) : wxThread(wxTHREAD_JOINABLE)
 {
     static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
 
@@ -51,8 +51,8 @@ void* ListenerThread::Entry()
         }
     }
 
-    //_listener->StopProcess();
-    //_running = false;
+    _listener->StopProcess();
+    _running = false;
 
     return nullptr;
 }

--- a/xSchedule/events/ListenerBase.h
+++ b/xSchedule/events/ListenerBase.h
@@ -47,9 +47,7 @@ public:
     void Stop()
     {
         _stop = true;
-
-        // give it 100 ms to end ... this is not perfect but as the thread self deletes I cant wait for it.
-        wxMilliSleep(100);
+        Wait();
     }
 
     virtual void* Entry() override;


### PR DESCRIPTION
Prevents crash when calling StopProcess due to deleted Listener. Instead of waiting for a fixed amount of time, we wait until the thread has finished.

Closes #1467 