### PR TITLE
Update preview when toggling 3D in Layout tab

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5750,6 +5750,8 @@ void LayoutPanel::OnCheckBox_3DClick(wxCommandEvent& event)
     }
     obj_button->Enable(is_3d);
 
+    UpdatePreview();
+
     wxConfigBase* config = wxConfigBase::Get();
     config->Write("LayoutMode3D", is_3d);
     Refresh();


### PR DESCRIPTION
Video of the bug (xLights 2019.13): https://www.dropbox.com/s/q40hw7rkeok3cbw/xLights%20bug.mov?dl=0