### PR TITLE
fixed issue 1488: Linux can get stuck in Entry() loop

### DIFF
--- a/xLights/xLightsTimer.cpp
+++ b/xLights/xLightsTimer.cpp
@@ -321,7 +321,7 @@ wxThread::ExitCode xlTimerThread::Entry()
     int fudgefactor = _fudgefactor;
     long long last = wxGetLocalTimeMillis().GetValue();
 
-    while (!stop)
+    while (!_stop)
     {
         if (_suspend)
         {


### PR DESCRIPTION
Fixes #1488 

In Linux, it is possible for this set of events to occur.
Stop() called
Entry() started
Stop() changes _stop value

Entry() needs to used the current version of _stop during the lop check rather than a cached version. 