### PR TITLE
Add effects-grid representation of transitions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-xLights is a show sequencer and player/scheduler designed to control
+﻿xLights is a show sequencer and player/scheduler designed to control
 USB/DMX/sACN(e1.31)/ArtNET(e.1.17)/DDP controllers.
 xLights also integrates with the Falcon Player.
 xLights imports and exports sequence data from sequencers such as LOR (SE, PE & SS),
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
    -- enh (kevin)   Add "Fold" transition type
+   -- enh (kevin)   Add effects-grid representation of transitions
 2019.26 May 24, 2019
    -- enh (scott)   When prompting for missing audio include the original audio filename to make it easier to find
    -- enh (scott)   When audio is missing look down 1 folder and grab it from there if found

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -5826,7 +5826,8 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
        int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
        double pct = fadeInTimeMS / durationMS;
        int width = int( pct * (x2 - x1) );
-       backgrounds.AddRect( x1, y1, x1+width, y2, xlColor( 0, 0x64, 0 ) );
+       xlColor greenOverlay( 0, 0xff, 0, 0x64 );
+       backgrounds.AddHBlendedRectangle( greenOverlay, greenOverlay, x1, y1, x1+width, y2 );
     }
     double fadeOutTime = sm.GetDouble( "T_TEXTCTRL_Fadeout" );
     if ( fadeOutTime != 0. )
@@ -5835,7 +5836,8 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
        int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
        double pct = fadeOutTimeMS / durationMS;
        int width = int( pct * (x2 - x1) );
-       backgrounds.AddRect( x2-width, y1, x2, y2, xlColor( 0x64, 0, 0 ) );
+       xlColor redOverlay( 0xff, 0, 0, 0x64 );
+       backgrounds.AddHBlendedRectangle( redOverlay, redOverlay, x2-width, y1, x2, y2 );
     }
     ////
     return result;
@@ -6096,7 +6098,9 @@ void EffectsGrid::DrawEffects()
         }
     }
     backgrounds.Finish(GL_TRIANGLES);
+    LOG_GL_ERRORV( glEnable( GL_BLEND ) );
     DrawGLUtils::Draw(backgrounds);
+    LOG_GL_ERRORV( glDisable( GL_BLEND ) );
     for (auto it = textures.begin(); it != textures.end(); ++it) {
         it->second.id = it->first;
         DrawGLUtils::Draw(it->second, GL_TRIANGLES);

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -5817,29 +5817,33 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
         }
     }
     int result = ef == nullptr ? 1 : ef->DrawEffectBackground(e, x1, y1, x2, y2, backgrounds, (colorMask.IsNilColor() ? nullptr : &colorMask), xlights->IsDrawRamps());
-    ////
+
     const SettingsMap &sm( e->GetSettings() );
     double fadeInTime = sm.GetDouble( "T_TEXTCTRL_Fadein" );
     if ( fadeInTime != 0. )
     {
        double fadeInTimeMS = fadeInTime * 1000;
        int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
-       double pct = fadeInTimeMS / durationMS;
-       int width = int( pct * (x2 - x1) );
-       xlColor greenOverlay( 0, 0xff, 0, 0x64 );
-       backgrounds.AddHBlendedRectangle( greenOverlay, greenOverlay, x1, y1, x1+width, y2 );
+       if ( durationMS > 0 )
+       {
+         double pct = std::min( fadeInTimeMS / durationMS, 1. );
+         int width = int( pct * (x2 - x1) );
+         backgrounds.AddRect( x1, y1, x1+width, y1+3, xlGREEN );
+       }
     }
     double fadeOutTime = sm.GetDouble( "T_TEXTCTRL_Fadeout" );
     if ( fadeOutTime != 0. )
     {
        double fadeOutTimeMS = fadeOutTime * 1000;
        int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
-       double pct = fadeOutTimeMS / durationMS;
-       int width = int( pct * (x2 - x1) );
-       xlColor redOverlay( 0xff, 0, 0, 0x64 );
-       backgrounds.AddHBlendedRectangle( redOverlay, redOverlay, x2-width, y1, x2, y2 );
+       if ( durationMS > 0 )
+       {
+         double pct = std::min( fadeOutTimeMS / durationMS, 1. );
+         int width = int( pct * (x2 - x1) );
+         backgrounds.AddRect( x2 - width, y1, x2, y1+3, xlRED );
+       }
     }
-    ////
+
     return result;
 }
 
@@ -6098,9 +6102,7 @@ void EffectsGrid::DrawEffects()
         }
     }
     backgrounds.Finish(GL_TRIANGLES);
-    LOG_GL_ERRORV( glEnable( GL_BLEND ) );
     DrawGLUtils::Draw(backgrounds);
-    LOG_GL_ERRORV( glDisable( GL_BLEND ) );
     for (auto it = textures.begin(); it != textures.end(); ++it) {
         it->second.id = it->first;
         DrawGLUtils::Draw(it->second, GL_TRIANGLES);

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -5819,6 +5819,7 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
     int result = ef == nullptr ? 1 : ef->DrawEffectBackground(e, x1, y1, x2, y2, backgrounds, (colorMask.IsNilColor() ? nullptr : &colorMask), xlights->IsDrawRamps());
 
     const SettingsMap &sm( e->GetSettings() );
+    int inTransitionEnd = 0, outTransitionStart = 0;
     double fadeInTime = sm.GetDouble( "T_TEXTCTRL_Fadein" );
     if ( fadeInTime != 0. )
     {
@@ -5828,7 +5829,9 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
        {
          double pct = std::min( fadeInTimeMS / durationMS, 1. );
          int width = int( pct * (x2 - x1) );
-         backgrounds.AddRect( x1, y1, x1+width, y1+3, xlGREEN );
+         inTransitionEnd = x1 + width;
+         backgrounds.AddRect( x1, y1, inTransitionEnd, y1+2, xlGREEN );
+         backgrounds.AddRect( x1, y1+2, inTransitionEnd, y1+3, xlBLACK );
        }
     }
     double fadeOutTime = sm.GetDouble( "T_TEXTCTRL_Fadeout" );
@@ -5840,8 +5843,16 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
        {
          double pct = std::min( fadeOutTimeMS / durationMS, 1. );
          int width = int( pct * (x2 - x1) );
-         backgrounds.AddRect( x2 - width, y1, x2, y1+3, xlRED );
+         outTransitionStart = x2 - width;
+         backgrounds.AddRect( outTransitionStart, y1, x2, y1+2, xlRED );
+         backgrounds.AddRect( outTransitionStart, y1+2, x2, y1+3, xlBLACK );
        }
+    }
+
+    if ( fadeInTime != 0. && fadeOutTime != 0. && inTransitionEnd > outTransitionStart )
+    {
+         backgrounds.AddRect( outTransitionStart, y1, inTransitionEnd, y1+2, xlYELLOW );
+         backgrounds.AddRect( outTransitionStart, y1+2, inTransitionEnd, y1+3, xlBLACK );
     }
 
     return result;

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -5816,7 +5816,29 @@ int EffectsGrid::DrawEffectBackground(const Row_Information_Struct* ri, const Ef
             }
         }
     }
-    return ef == nullptr ? 1 : ef->DrawEffectBackground(e, x1, y1, x2, y2, backgrounds, (colorMask.IsNilColor() ? nullptr : &colorMask), xlights->IsDrawRamps());
+    int result = ef == nullptr ? 1 : ef->DrawEffectBackground(e, x1, y1, x2, y2, backgrounds, (colorMask.IsNilColor() ? nullptr : &colorMask), xlights->IsDrawRamps());
+    ////
+    const SettingsMap &sm( e->GetSettings() );
+    double fadeInTime = sm.GetDouble( "T_TEXTCTRL_Fadein" );
+    if ( fadeInTime != 0. )
+    {
+       double fadeInTimeMS = fadeInTime * 1000;
+       int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
+       double pct = fadeInTimeMS / durationMS;
+       int width = int( pct * (x2 - x1) );
+       backgrounds.AddRect( x1, y1, x1+width, y2, xlColor( 0, 0x64, 0 ) );
+    }
+    double fadeOutTime = sm.GetDouble( "T_TEXTCTRL_Fadeout" );
+    if ( fadeOutTime != 0. )
+    {
+       double fadeOutTimeMS = fadeOutTime * 1000;
+       int durationMS = e->GetEndTimeMS() - e->GetStartTimeMS();
+       double pct = fadeOutTimeMS / durationMS;
+       int width = int( pct * (x2 - x1) );
+       backgrounds.AddRect( x2-width, y1, x2, y2, xlColor( 0x64, 0, 0 ) );
+    }
+    ////
+    return result;
 }
 
 float ComputeFontSize(int &toffset, const float factor) {


### PR DESCRIPTION
This is a first stab at adding an effects-grid representation of transitions.

The intent here is not to provide any effects-grid control of the transition lengths but just to provide some indication when transitions exist on effects. My first idea here was to alpha-blend the transition representation over the effect background but that can cause goofy results over some effects... red out transition over yellow on-effect in image below shows as orange.