### PR TITLE
Prevent "dump render state" crash

### DIFF
--- a/xLights/Render.cpp
+++ b/xLights/Render.cpp
@@ -740,6 +740,7 @@ public:
                     FrameDone(frame);
                 }
             }
+            SetGenericStatus("%s: All done - Completed frame %d " + PrintStatusMap(), endFrame, true);
         } catch ( std::exception &ex) {
             wxASSERT(false); // so when we debug we catch them
             printf("Caught an exception %s", ex.what());


### PR DESCRIPTION
There is currently a repeatable crash, as follows:

1 - Start a batch render for a sequence files
1a - RenderJob::Process calls SetRenderingStatus with a pointer
to a local "nodeSettingsMaps". This gets stored in the RenderJob

2 - Wait for one of the jobs to complete
2a - RenderJob::Process completes and destroys the nodeSettingsMaps
local. Pointer is still embedded in RenderJob as statusMap

3 - Invoke "Dump render state" from the tools menu
3a - RenderJob::GetwxStatus calls PrintStatusMap, which crashes and
burns, as statusMap isn't null, but it's not valid either

Fix - Ensure that the RenderJob status is reset to something non-crashy
as RenderJob::Process completes.

Please note - I'm just starting to feel my way around the xLights
code, but hope to contribute in a meaningful way in future... I've tried
to check that I'm not endangering anything with this change, but please
ensure I've not done anything criminally stupid here. I won't be
in the least bit offended or disuaded if you reject this outright
with a stream of profanity :)