### PR TITLE
Adding transition equivalents for some warp effects

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-xLights is a show sequencer and player/scheduler designed to control
+﻿xLights is a show sequencer and player/scheduler designed to control
 USB/DMX/sACN(e1.31)/ArtNET(e.1.17)/DDP controllers.
 xLights also integrates with the Falcon Player.
 xLights imports and exports sequence data from sequencers such as LOR (SE, PE & SS),
@@ -11,7 +11,8 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
-   -- bug (kevin)  Fix non-functional Reverse setting on fold transition
+   -- enh (kevin)  Add Dissolve and Circular Swirl transitions
+   -- bug (kevin)  Fix non-functional Reverse setting on Fold transition
 2019.37 July 30, 2019
    -- enh (keith)  Add option to SMS plugin to limit messages from a single number
    -- enh (keith)  Fix workflow around creation of new timing tracks

--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -2425,7 +2425,8 @@ void PixelBufferClass::CalcOutput(int EffectPeriod, const std::vector<bool> & va
             {
                RenderBuffer& currentRB(layers[ii]->buffer);
                Vec2D xy( 0.5, 0.5 );
-               float speed = interpolate( 20., 0.0, 1.0, 40.0, 9.0, LinearInterpolater() );
+               //double adjust = 0.01 * layers[ii]->inTransitionAdjust;
+               float speed = interpolate( /*adjust*/0.2, 0.0, 1.0, 40.0, 9.0, LinearInterpolater() );
                circularSwirl( currentRB, ColorBuffer( currentRB.pixels, currentRB.BufferWi, currentRB.BufferHt ), xy, speed, 1.-fadeInFactor );
             }
 
@@ -2462,7 +2463,8 @@ void PixelBufferClass::CalcOutput(int EffectPeriod, const std::vector<bool> & va
                   RenderBuffer& currentRB(layers[ii]->buffer);
                   double progress = 1. - fadeOutFactor;
                   Vec2D xy( 0.5, 0.5 );
-                  float speed = interpolate( 20., 0.0, 1.0, 40.0, 9.0, LinearInterpolater() );
+                  //double adjust = 0.01 * layers[ii]->outTransitionAdjust;
+                  float speed = interpolate( /*adjust*/0.2, 0.0, 1.0, 40.0, 9.0, LinearInterpolater() );
                   circularSwirl( currentRB, ColorBuffer( currentRB.pixels, currentRB.BufferWi, currentRB.BufferHt ), xy, speed, progress );
                }
             }

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -5,7 +5,6 @@
 #include <wx/intl.h>
 #include <wx/settings.h>
 #include <wx/string.h>
-
 //*)
 
 #include <wx/tooltip.h>
@@ -163,6 +162,8 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Slide Checks"));
 	Choice_In_Transition_Type->Append(_("Slide Bars"));
 	Choice_In_Transition_Type->Append(_("Fold"));
+	Choice_In_Transition_Type->Append(_("Dissolve"));
+	Choice_In_Transition_Type->Append(_("Circular Swirl"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -205,6 +206,8 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Slide Checks"));
 	Choice_Out_Transition_Type->Append(_("Slide Bars"));
 	Choice_Out_Transition_Type->Append(_("Fold"));
+	Choice_Out_Transition_Type->Append(_("Dissolve"));
+	Choice_Out_Transition_Type->Append(_("Circular Swirl"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -394,7 +397,9 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
 {
     if (Choice_In_Transition_Type->GetStringSelection() == "Fade" ||
         Choice_In_Transition_Type->GetStringSelection() == "Slide Bars" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Blend") {
+        Choice_In_Transition_Type->GetStringSelection() == "Blend" ||
+        Choice_In_Transition_Type->GetStringSelection() == "Dissolve" ||
+        Choice_In_Transition_Type->GetStringSelection() == "Circular Swirl" ){
         CheckBox_In_Reverse->Disable();
     } else {
         CheckBox_In_Reverse->Enable();
@@ -402,30 +407,47 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
     if (Choice_In_Transition_Type->GetStringSelection() == "Fade" ||
         Choice_In_Transition_Type->GetStringSelection() == "From Middle" ||
         Choice_In_Transition_Type->GetStringSelection() == "Square Explode" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Circle Explode") {
-        Slider_In_Adjust->Disable();
-        TextCtrl_In_Adjust->Disable();
-    } else {
+        Choice_In_Transition_Type->GetStringSelection() == "Circle Explode" ||
+        Choice_In_Transition_Type->GetStringSelection() == "Fold" ||
+        Choice_In_Transition_Type->GetStringSelection() == "Dissolve" ||
+        Choice_In_Transition_Type->GetStringSelection() == "Circular Swirl" )
+        {
+           Slider_In_Adjust->Disable();
+           TextCtrl_In_Adjust->Disable();
+    }
+    else
+    {
         Slider_In_Adjust->Enable();
         TextCtrl_In_Adjust->Enable();
     }
 
     if (Choice_Out_Transition_Type->GetStringSelection() == "Fade" ||
         Choice_Out_Transition_Type->GetStringSelection() == "Slide Bars" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Blend") {
-        CheckBox_Out_Reverse->Disable();
-    } else {
-        CheckBox_Out_Reverse->Enable();
+        Choice_Out_Transition_Type->GetStringSelection() == "Blend" ||
+        Choice_Out_Transition_Type->GetStringSelection() == "Dissolve" ||
+        Choice_Out_Transition_Type->GetStringSelection() == "Circular Swirl" )
+    {
+       CheckBox_Out_Reverse->Disable();
+    }
+    else
+    {
+       CheckBox_Out_Reverse->Enable();
     }
     if (Choice_Out_Transition_Type->GetStringSelection() == "Fade" ||
         Choice_Out_Transition_Type->GetStringSelection() == "From Middle" ||
         Choice_Out_Transition_Type->GetStringSelection() == "Square Explode" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Circle Explode") {
-        Slider_Out_Adjust->Disable();
-        TextCtrl_Out_Adjust->Disable();
-    } else {
-        Slider_Out_Adjust->Enable();
-        TextCtrl_Out_Adjust->Enable();
+        Choice_Out_Transition_Type->GetStringSelection() == "Circle Explode" ||
+        Choice_Out_Transition_Type->GetStringSelection() == "Fold" ||
+        Choice_Out_Transition_Type->GetStringSelection() == "Dissolve" ||
+        Choice_Out_Transition_Type->GetStringSelection() == "Circular Swirl" )
+    {
+       Slider_Out_Adjust->Disable();
+       TextCtrl_Out_Adjust->Disable();
+    }
+    else
+    {
+       Slider_Out_Adjust->Enable();
+       TextCtrl_Out_Adjust->Enable();
     }
 }
 

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -395,37 +395,45 @@ PANEL_EVENT_HANDLERS(TimingPanel)
 
 void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
 {
-    if (Choice_In_Transition_Type->GetStringSelection() == "Fade" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Slide Bars" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Blend" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Dissolve" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Circular Swirl" ){
-        CheckBox_In_Reverse->Disable();
-    } else {
-        CheckBox_In_Reverse->Enable();
-    }
-    if (Choice_In_Transition_Type->GetStringSelection() == "Fade" ||
-        Choice_In_Transition_Type->GetStringSelection() == "From Middle" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Square Explode" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Circle Explode" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Fold" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Dissolve" ||
-        Choice_In_Transition_Type->GetStringSelection() == "Circular Swirl" )
-        {
-           Slider_In_Adjust->Disable();
-           TextCtrl_In_Adjust->Disable();
-    }
-    else
-    {
-        Slider_In_Adjust->Enable();
-        TextCtrl_In_Adjust->Enable();
-    }
+   auto inTransitionType = Choice_In_Transition_Type->GetStringSelection();
 
-    if (Choice_Out_Transition_Type->GetStringSelection() == "Fade" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Slide Bars" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Blend" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Dissolve" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Circular Swirl" )
+   if (  inTransitionType == "Fade" ||
+         inTransitionType == "Slide Bars" ||
+         inTransitionType == "Blend" ||
+         inTransitionType == "Dissolve" ||
+         inTransitionType == "Circular Swirl" )
+   {
+      CheckBox_In_Reverse->Disable();
+   }
+   else
+   {
+      CheckBox_In_Reverse->Enable();
+   }
+
+   if ( inTransitionType == "Fade" ||
+        inTransitionType == "From Middle" ||
+        inTransitionType == "Square Explode" ||
+        inTransitionType == "Circle Explode" ||
+        inTransitionType == "Fold" ||
+        inTransitionType == "Dissolve" ||
+        inTransitionType == "Circular Swirl" )
+   {
+      Slider_In_Adjust->Disable();
+      TextCtrl_In_Adjust->Disable();
+   }
+   else
+   {
+      Slider_In_Adjust->Enable();
+      TextCtrl_In_Adjust->Enable();
+   }
+
+   auto outTransitionType = Choice_Out_Transition_Type->GetStringSelection();
+
+   if ( outTransitionType == "Fade" ||
+        outTransitionType == "Slide Bars" ||
+        outTransitionType == "Blend" ||
+        outTransitionType == "Dissolve" ||
+        outTransitionType == "Circular Swirl" )
     {
        CheckBox_Out_Reverse->Disable();
     }
@@ -433,13 +441,14 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
     {
        CheckBox_Out_Reverse->Enable();
     }
-    if (Choice_Out_Transition_Type->GetStringSelection() == "Fade" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "From Middle" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Square Explode" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Circle Explode" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Fold" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Dissolve" ||
-        Choice_Out_Transition_Type->GetStringSelection() == "Circular Swirl" )
+
+    if ( outTransitionType == "Fade" ||
+         outTransitionType == "From Middle" ||
+         outTransitionType == "Square Explode" ||
+         outTransitionType == "Circle Explode" ||
+         outTransitionType == "Fold" ||
+         outTransitionType == "Dissolve" ||
+         outTransitionType == "Circular Swirl" )
     {
        Slider_Out_Adjust->Disable();
        TextCtrl_Out_Adjust->Disable();

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -183,6 +183,8 @@
 																			<item>Slide Checks</item>
 																			<item>Slide Bars</item>
 																			<item>Fold</item>
+																			<item>Dissolve</item>
+																			<item>Circular Swirl</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -291,6 +293,8 @@
 																			<item>Slide Checks</item>
 																			<item>Slide Bars</item>
 																			<item>Fold</item>
+																			<item>Dissolve</item>
+																			<item>Circular Swirl</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />


### PR DESCRIPTION
Many of the existing warps were originally designed as video transitions (hence the 'in' and 'out' option) but some were not (wavy). So it makes sense to re-use the existing warp code as transitions, so it's not necessary to add an extra track just to effectively use the warp effect as a transition.