### PR TITLE
Fix broken transition render

### DIFF
--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -2692,10 +2692,14 @@ static bool isLeft(const wxPoint &a, const wxPoint &b, const wxPoint &test) {
 void PixelBufferClass::LayerInfo::createWipeMask(bool out)
 {
     int adjust = inTransitionAdjust;
-    bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
+    bool reverse = inTransitionReverse;
     if (out) {
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
         reverse = outTransitionReverse;
         factor = outMaskFactor;
     }
@@ -2755,12 +2759,16 @@ void PixelBufferClass::LayerInfo::createClockMask(bool out) {
     bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
     int adjust = inTransitionAdjust;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     uint8_t m1 = 255;
     uint8_t m2 = 0;
     if (out) {
         reverse = outTransitionReverse;
         factor = outMaskFactor;
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     }
 
     float startradians = 2.0 * M_PI * (float)adjust / 100.0;
@@ -2812,12 +2820,16 @@ void PixelBufferClass::LayerInfo::createBlindsMask(bool out) {
     bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
     int adjust = inTransitionAdjust;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     uint8_t m1 = 255;
     uint8_t m2 = 0;
     if (out) {
         reverse = outTransitionReverse;
         factor = outMaskFactor;
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     }
     if (adjust == 0) {
         adjust = 1;
@@ -2855,12 +2867,16 @@ void PixelBufferClass::LayerInfo::createBlendMask(bool out) {
     //bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
     int adjust = inTransitionAdjust;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     uint8_t m1 = 255;
     uint8_t m2 = 0;
     if (out) {
         //reverse = outTransitionReverse;
         factor = outMaskFactor;
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     }
 
     std::minstd_rand rng(1234);
@@ -2938,12 +2954,16 @@ void PixelBufferClass::LayerInfo::createSlideChecksMask(bool out) {
     bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
     int adjust = inTransitionAdjust;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     uint8_t m1 = 255;
     uint8_t m2 = 0;
     if (out) {
         reverse = outTransitionReverse;
         factor = outMaskFactor;
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     }
 
     if (adjust < 2) {
@@ -2989,12 +3009,16 @@ void PixelBufferClass::LayerInfo::createSlideBarsMask(bool out) {
     //bool reverse = inTransitionReverse;
     float factor = inMaskFactor;
     int adjust = inTransitionAdjust;
+    if ( InTransitionAdjustValueCurve.IsActive() )
+       adjust = static_cast<int>( InTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     uint8_t m1 = 255;
     uint8_t m2 = 0;
     if (out) {
         //reverse = outTransitionReverse;
         factor = outMaskFactor;
         adjust = outTransitionAdjust;
+        if ( OutTransitionAdjustValueCurve.IsActive() )
+           adjust = static_cast<int>( OutTransitionAdjustValueCurve.GetOutputValueAt( factor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS() ) );
     }
 
     if (adjust == 0) {

--- a/xLights/PixelBuffer.h
+++ b/xLights/PixelBuffer.h
@@ -217,7 +217,7 @@ private:
         std::vector<std::unique_ptr<RenderBuffer>> modelBuffers;
 
         std::vector<uint8_t> mask;
-        void renderTransitions(bool isFirstFrame);
+        void renderTransitions(bool isFirstFrame, const RenderBuffer* prevRB);
         void calculateMask(const std::string &type, bool mode, bool isFirstFrame);
         bool isMasked(int x, int y);
 

--- a/xLights/PixelBuffer.h
+++ b/xLights/PixelBuffer.h
@@ -217,12 +217,12 @@ private:
         std::vector<std::unique_ptr<RenderBuffer>> modelBuffers;
 
         std::vector<uint8_t> mask;
-        void calculateMask(bool isFirstFrame);
+        void renderTransitions(bool isFirstFrame);
         void calculateMask(const std::string &type, bool mode, bool isFirstFrame);
         bool isMasked(int x, int y);
-        
+
         void clear();
-        
+
     private:
         void createSquareExplodeMask(bool end);
         void createCircleExplodeMask(bool end);
@@ -284,25 +284,25 @@ public:
     RenderBuffer &BufferForLayer(int i, int idx);
     int BufferCountForLayer(int i);
     void MergeBuffersForLayer(int i);
-    
-    
+
+
     void InitBuffer(const Model &pbc, int layers, int timing, bool zeroBased=false);
     void InitStrandBuffer(const Model &pbc, int strand, int timing, int layers);
     void InitNodeBuffer(const Model &pbc, int strand, int node, int timing);
     void InitPerModelBuffers(const ModelGroup& model, int layer, int timing);
 
     void Clear(int which);
-    
+
     void SetLayerSettings(int layer, const SettingsMap &settings);
     bool IsPersistent(int layer);
-    
+
     void SetMixType(int layer, const std::string& MixName);
     void SetPalette(int layer, xlColorVector& newcolors, xlColorCurveVector& newcc);
     void SetLayer(int newlayer, int period, bool ResetState);
     void SetTimes(int layer, int startTime, int endTime);
 
     void CalcOutput(int EffectPeriod, const std::vector<bool> &validLayers, int saveLayer = 0);
-    void SetColors(int layer, const unsigned char *fdata);    
+    void SetColors(int layer, const unsigned char *fdata);
     void GetColors(unsigned char *fdata, const std::vector<bool> &restrictRange);
 };
 typedef std::unique_ptr<PixelBufferClass> PixelBufferClassPtr;


### PR DESCRIPTION
Clyde and others found some weird behavior with the recent updates to transitions. This fixes and gets PixelBufferClass::CalcOutput() closer to how it was before I made it ugly with the transition updates.

I also hooked up value curves for the other transitions that support the 'adjustment' value (I only did 'from middle' initially). I'm not sure if that's terribly useful but we should support it for consistency.