### PR TITLE
making unicast behave like other master modes

### DIFF
--- a/xSchedule/SyncFPP.cpp
+++ b/xSchedule/SyncFPP.cpp
@@ -286,7 +286,8 @@ void SyncUnicastFPP::SendFPPSync(const std::string& item, uint32_t stepMS, uint3
     }
     else
     {
-        fileType = SYNC_FILE_MEDIA;
+        sp->fileType = SYNC_FILE_MEDIA;
+        sp->frameNumber = 0;
     }
 
     if (fileType == SYNC_FILE_SEQ)
@@ -322,7 +323,8 @@ void SyncUnicastCSVFPP::SendFPPSync(const std::string& item, uint32_t stepMS, ui
     }
     else
     {
-        fileType = SYNC_FILE_MEDIA;
+        sp->fileType = SYNC_FILE_MEDIA;
+        sp->frameNumber = 0;
     }
 
     if (fileType == SYNC_FILE_SEQ)


### PR DESCRIPTION
I plan on getting involved as a contributor. But this PR is more to ask the question if the differences I am seeing are the cause of media sync information not going to remotes when in unicast mode. My guess is the answer is no, but this is my way of saying 'here I am'.