### PR TITLE
Bug fix for ISF shaders that use TIMEDELTA uniform var

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- bug (kevin)  Fix certain shaders from ISF failing to compile
    -- enh (gil)    Add Redo option for the sequencer grid.  Fixes #555.
    -- enh (dkulp)  FPP/BBB DMX strings - set minimum length to 16 channels.  Several controllers have issues with less than that
    -- enh (dkulp)  FPP Connect - use a single progress dialog to avoid stealing focus for each thing transferred

--- a/download/shaders.xml
+++ b/download/shaders.xml
@@ -553,6 +553,13 @@
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/x0qizxw7f67r8tird6cr</image>
 		<rating>3</rating>
 	</shader>
+	<shader>
+		<name>RainbowGlowRing</name>
+		<link>https://www.interactiveshaderformat.com/sketches/4947</link>
+		<download>https://www.interactiveshaderformat.com/sketches/4947/download</download>
+		<image>https://res.cloudinary.com/dgqcnpnmj/image/upload/v1571972247/RainbowGlowRing_gwdgb3.png</image>
+		<rating>4</rating>
+	</shader>
 	<!--shader>
 		<name></name>
 		<link>https://www.interactiveshaderformat.com/sketches/xxx</link>

--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -757,6 +757,12 @@ void ShaderEffect::Render(Effect* eff, SettingsMap& SettingsMap, RenderBuffer& b
             logger_base.warn("Unable to bind to TIME\n%s", (const char*)_shaderConfig->GetCode().c_str());
     }
 
+    loc = glGetUniformLocation(programId, "TIMEDELTA");
+    if (loc >= 0) {
+        float delta = buffer.frameTimeInMs /1000.f;
+        glUniform1f(loc, delta);
+    }
+
     loc = glGetUniformLocation(programId, "DATE");
     if (loc >= 0) {
         wxDateTime dt = wxDateTime::Now();
@@ -1133,6 +1139,7 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     // and the uniforms that correspond to user-visible settings
     wxString prependText = _("#version 330\n\n"
     "uniform float TIME;\n"
+    "uniform float TIMEDELTA;\n"
     "uniform vec2 RENDERSIZE;\n"
     "uniform bool clearBuffer;\n"
     "uniform bool resetNow;\n"


### PR DESCRIPTION
* passing the timing down from RenderBuffer to the shader
* also added a somewhat-useful ISF shader that uses it to the downloads xml