### PR TITLE
 fix: index for compressionType in fseq header

### DIFF
--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -1362,7 +1362,7 @@ m_handler(nullptr)
             m_compressionType = CompressionType::zlib;
             break;
             default:
-            LogErr(VB_SEQUENCE, "Unknown compression type: %d", (int)header[32]);
+            LogErr(VB_SEQUENCE, "Unknown compression type: %d", (int)header[20]);
         }
         
         uint32_t maxBlocks = header[21];


### PR DESCRIPTION
This is a downstream duplicate of my commit to [FalconChristmas/fpp](https://github.com/FalconChristmas/fpp) that was merged into master: https://github.com/FalconChristmas/fpp/pull/636

When switching on header[20] (fseq file compression type), the default case instead prints header[32] in its error message. header[32] corresponds to 1/4th of a uint32 describing the first frame's index, which I'm assuming is not what we want to print.