### PR TITLE
fix: alloc 64kb per compression block, not 128.9kb

### DIFF
--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -724,7 +724,7 @@ public:
         //determine a good number of compression blocks
         uint64_t datasize = m_file->getChannelCount() * m_file->getNumFrames();
         uint64_t numBlocks = datasize;
-        numBlocks /= (64*2014); //at least 64K per block
+        numBlocks /= (64*1024); //at least 64K per block
         if (numBlocks > 255) {
             //need a lot of blocks, use as many as we can
             numBlocks = 255;


### PR DESCRIPTION
This is a downstream duplicate of my commit to FalconChristmas/fpp that was merged into master: https://github.com/FalconChristmas/fpp/pull/638

When determining the amount of compression blocks in #computeMaxBlocks, it divides the total channel data byte length by a hard-coded allocation length. The comment allures to this being 64 kilobytes, but the value is instead, 64 * 2014 = 128,896 or 128.9 kilobytes. This results in larger than expected compression blocks, and for many small to medium sequences, the entire sequence is in a single compression block (with the exception of the 10 withheld initial frames).

This won't have an impact on any decently powerful system, but lower (or more strained) hardware will find this more optimized for buffering and decompressing channel data blocks for playback.

Larger sequences that utilized the full 255 compression block limit will still work. When exporting, they will simply increase the amount of frames per block.