### PR TITLE
Fix further memory leaks

### DIFF
--- a/xLights/TraceLog.cpp
+++ b/xLights/TraceLog.cpp
@@ -12,13 +12,17 @@ thread_local std::list<std::string> *threadLog = nullptr;
 
 class TraceLogHolder {
 public:
-    TraceLogHolder() {TRACE_LOG_VALID = true;}
-    ~TraceLogHolder() {TRACE_LOG_VALID = false;}
-    
-    
     std::mutex MESSAGE_MAP_LOCK;
     std::map<std::thread::id, std::list<std::string>*> LOG_MESSAGES;
-    
+
+    TraceLogHolder() {TRACE_LOG_VALID = true;}
+    ~TraceLogHolder() {
+        TRACE_LOG_VALID = false;
+        for (auto it_thread = LOG_MESSAGES.begin(); it_thread != LOG_MESSAGES.end(); ++it_thread) {
+            delete it_thread->second;
+        }
+        LOG_MESSAGES.clear();
+    }
     
     void ClearTraceMessages() {
         if (!TRACE_LOG_VALID) {

--- a/xLights/ViewsModelsPanel.cpp
+++ b/xLights/ViewsModelsPanel.cpp
@@ -821,7 +821,18 @@ void ViewsModelsPanel::OnButton_RemoveAllClick(wxCommandEvent& event)
 void ViewsModelsPanel::Clear()
 {
     ListCtrlModels->ClearAll();
+
+    for (int i = 0; i < ListCtrlNonModels->GetItemCount(); ++i)
+    {
+        Element* e = (Element*)ListCtrlNonModels->GetItemData(i);
+        if (e != nullptr && e->GetType() == ELEMENT_TYPE_MODEL && e->GetSequenceElements() == nullptr)
+        {
+            delete e;
+            ListCtrlNonModels->SetItemPtrData(i, (wxUIntPtr)nullptr);
+        }
+    }
     ListCtrlNonModels->ClearAll();
+
     ListCtrlViews->ClearAll();
     ValidateWindow();
 }

--- a/xLights/models/ViewObjectManager.cpp
+++ b/xLights/models/ViewObjectManager.cpp
@@ -15,6 +15,7 @@ ViewObjectManager::ViewObjectManager(xLightsFrame* xl) : xlights(xl)
 ViewObjectManager::~ViewObjectManager()
 {
     //dtor
+    clear();
 }
 
 BaseObject* ViewObjectManager::GetObject(const std::string &name) const

--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -184,6 +184,7 @@ void InitialiseLogging(bool fromMain)
 
 					logger_base.info("    %s : %s", (const char *)(*it)->getName().c_str(), (const char *)levels.c_str());
 				}
+                delete categories;
 			}
             catch (log4cpp::ConfigureFailure& e) {
                 // ignore config failure ... but logging wont work

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2406,6 +2406,23 @@ xLightsFrame::~xLightsFrame()
     }
 
     delete CheckBoxLightOutput;
+    delete ButtonPasteByTime;
+    delete ButtonPasteByCell;
+
+    delete Button_ACDisabled;
+    delete Button_ACSelect;
+    delete Button_ACOn;
+    delete Button_ACOff;
+    delete Button_ACTwinkle;
+    delete Button_ACShimmer;
+    delete Button_ACIntensity;
+    delete Button_ACRampUp;
+    delete Button_ACRampDown;
+    delete Button_ACRampUpDown;
+    delete Button_ACFill;
+    delete Button_ACCascade;
+    delete Button_ACForeground;
+    delete Button_ACBackground;
 
     //(*Destroy(xLightsFrame)
     //*)
@@ -3203,6 +3220,8 @@ void xLightsFrame::SetXmlSetting(const wxString& settingName,const wxString& val
         if (e->GetName() == settingName)
         {
             SettingsNode->RemoveChild(e);
+            delete e;
+            break;
         }
     }
 


### PR DESCRIPTION
Seeing as the last one caused a few problems, I'll try
to be more explicit about the changes here.

Tracelog - The per-thread trace buffers aren't tidied up,
and some still have log messages present. These were leaking, so
they're now freed up in the destructor.

ViewObjectManager - The view objects were never removed. Invoke the
existing "clear" function from the destructor.

XLightsMain UI Elements - We're leaking button elements for some
reason - Added delete calls, matching the pattern already present for
CheckBoxLightOutput.

XLightsMain XmlSetting - Need to delete elements that we've obtained
through "RemoveChild", as per the wxWidgets docs.

Testing performed -
 - Opened layout
 - checked layout in 2d/3d
 - opened sequence
   - rendered
   - played
   - changed
   - played
   - saved
- closed xLights
- Repeated the above to verify changes saved

When I have saved a sequence, I do see an access violation on
shutdown, but that doesn't seem to be new. I see it on the current
master branch, and in local builds of released versions back to 2020.1.
Not sure if this occurs in the MinGW builds too, or if it's a VS thing,
but I'll have a poke around. Entirely understand if you don't want to
take this PR without that resolved, although I don't think it's
related to my changes.