### PR TITLE
enh: improve V2 FSEQ header writing

### DIFF
--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -1416,6 +1416,7 @@ m_handler(nullptr)
             }
         }
         if (m_frameOffsets.size() == 0) {
+            // FSEQ files with CompressionType::none will have a (safely) empty m_frameOffsets due to maxBlocks == 0
             if (m_compressionType != CompressionType::none) {
                 //this is bad... not sure what we can do.  We'll force a "0" block to
                 //avoid a crash, but the data might not load correctly

--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -261,10 +261,10 @@ FSEQFile* FSEQFile::createFSEQFile(const std::string &fn,
     if (version == V1FSEQ_MAJOR_VERSION) {
         return new V1FSEQFile(fn);
     } else if (version == V2FSEQ_MAJOR_VERSION) {
-    	return new V2FSEQFile(fn, ct, level);
-	}
-	LogErr(VB_SEQUENCE, "Error creating FSEQ file. Unknown version: %d", version);
-	return nullptr;
+        return new V2FSEQFile(fn, ct, level);
+    }
+    LogErr(VB_SEQUENCE, "Error creating FSEQ file. Unknown version: %d", version);
+    return nullptr;
 }
 std::string FSEQFile::getMediaFilename(const std::string &fn) {
     std::unique_ptr<FSEQFile> file(FSEQFile::openFSEQFile(fn));
@@ -429,8 +429,8 @@ static const int V1FSEQ_HEADER_SIZE = 28;
 V1FSEQFile::V1FSEQFile(const std::string &fn)
   : FSEQFile(fn), m_dataBlockSize(0)
 {
-	m_seqVersionMinor = V1FSEQ_MINOR_VERSION;
-	m_seqVersionMajor = V1FSEQ_MAJOR_VERSION;
+    m_seqVersionMinor = V1FSEQ_MINOR_VERSION;
+    m_seqVersionMajor = V1FSEQ_MAJOR_VERSION;
 }
 
 void V1FSEQFile::writeHeader() {


### PR DESCRIPTION
This is a downstream duplicate of my pull request to FalconChristmas/fpp that was merged into master: https://github.com/FalconChristmas/fpp/pull/640 

Given xLights & fpp have diverged on their `FSEQFile.cpp` code, this branch is a manual clone of the original with some commits skipped since they aren't relevant.

This PR simplifies and optimizes the V2 FSEQ header writing process.
- Moves magic numbers into const fields to reduce duplication and potential mismatches.
- Builds header as a single buffer. This avoids allocating additional buffers and write calls for things like writing sparse ranges, compression blocks, variable headers and alignment bytes.
- Shuffle field assignments to be in descending order by index for code readability.
- Improve write validation to note alignment mismatches or overflows.
- Fix incorrect documentation and add new comments & references.
- Prevent defaulting behavior from matching invalid major version values to major version 2. (Since `FSEQFile.cpp`/`FSEQFile.h` are used by xLights, I've cross checked their usage and they already properly validate the version parameter input, so this is a non-issue for their implementation.)