### PR TITLE
Force wxWidget appname to fix path issues in AppImages

### DIFF
--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -549,6 +549,8 @@ LONG WINAPI windows_exception_handler(EXCEPTION_POINTERS * ExceptionInfo)
 
 bool xLightsApp::OnInit()
 {
+    this->SetAppName("xLights");
+
     InitialiseLogging(false);
     static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     logger_base.info("******* OnInit: XLights started.");


### PR DESCRIPTION
Problem initially reported via xLights Singing Faces 3 group on Facebook.

**Reproduction**
Create a new sequence on any show directory
Add a timing track, give it some lyrics, breakdown phrases
When you select breakdown words, xLights will complain that the dictionaries aren't available

**Cause**
The search path for the dictionaries ends up at 
 wxFileName(wxStandardPaths::Get().GetResourcesDir(), filename);

GetResourcesDir winds up returning the /usr/share/[appname], where wxWidgets defaults the appname to argv[0] of the running process. This normally gives us /usr/share/xLights, which is lovely.

However, on the AppImage builds, the executable invoked is actually the AppRun thing that AppImage uses, which means that the path ends up as /usr/share/AppRun, and there's nothing there.

**Fix**
I bodged a fix during testing where I symlinked /usr/share/AppRun to /usr/share/xLights and verified that this fixes the problem. We could formalise this in the Recipe.appimage in https://github.com/cjd/xlights-build-docker, but that's a bit of a hack.

We'd be better to force the app name with a call to wxApp::SetAppName("xLights") on startup. I've tested this on Windows, which seems happy enough. I'm fairly confident MacOS should be OK, though I can't test it here.
