### PR TITLE
Retain locked words/phonemes when breaking down lyrics

### DIFF
--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -1140,7 +1140,28 @@ void RowHeading::BreakdownTimingPhrases(TimingElement* element)
     EffectLayer* layer = element->GetEffectLayer(0);
     if( element->GetEffectLayerCount() > 1 )
     {
+        bool found_locked = false;
+
         for( int k = element->GetEffectLayerCount()-1; k > 0; k--)
+        {
+            EffectLayer* purge_layer = element->GetEffectLayer(k);
+            for (int ef = 0; ef < purge_layer->GetEffectCount(); ef++)
+            {
+                Effect* e = purge_layer->GetEffect(ef);
+                if (!e->IsLocked())
+                {
+                    found_locked = true;
+                    break;
+                }
+            }
+        }
+
+        if (found_locked)
+        {
+            return;
+        }
+
+        for (int k = element->GetEffectLayerCount() - 1; k > 0; k--)
         {
             element->RemoveEffectLayer(k);
         }
@@ -1158,12 +1179,32 @@ void RowHeading::BreakdownTimingPhrases(TimingElement* element)
 
 void RowHeading::BreakdownTimingWords(TimingElement* element)
 {
+    EffectLayer* word_layer = element->GetEffectLayer(1);
+    EffectLayer* phoneme_layer = nullptr;
+
     if( element->GetEffectLayerCount() > 2 )
     {
+        bool found_locked = false;
+        phoneme_layer = element->GetEffectLayer(2);
+        for (int ef = 0; ef < phoneme_layer->GetEffectCount(); ef++) {
+            Effect* e = phoneme_layer->GetEffect(ef);
+            if (!e->IsLocked())
+            {
+                found_locked = true;
+                break;
+            }
+        }
+
+        if (found_locked)
+        {
+            return;
+        }
+
         element->RemoveEffectLayer(2);
     }
-    EffectLayer* word_layer = element->GetEffectLayer(1);
-    EffectLayer* phoneme_layer = element->AddEffectLayer();
+
+    phoneme_layer = element->AddEffectLayer();
+
     for( int i = 0; i < word_layer->GetEffectCount(); i++ )
     {
         Effect* effect = word_layer->GetEffect(i);

--- a/xLights/sequencer/SequenceElements.cpp
+++ b/xLights/sequencer/SequenceElements.cpp
@@ -2064,7 +2064,18 @@ void SequenceElements::BreakdownPhrase(EffectLayer* word_layer, int start_time, 
             {
                 word_end_time = end_time;
             }
-            word_layer->AddEffect(0,words[i].ToStdString(),"","",word_start_time,word_end_time,EFFECT_NOT_SELECTED,false);
+
+            // Don't clash with any existing words - it makes a mess
+            if (!(word_layer->GetAllEffectsByTime(word_start_time, word_end_time).size()))
+            {
+                word_layer->AddEffect(0, words[i].ToStdString(), "", "", word_start_time, word_end_time, EFFECT_NOT_SELECTED, false);
+            }
+            else
+            {
+                // If there's only a clash for part of the word, can we fit this one in anyway?
+                // Semantics of this are up for grabs... TBD.
+            }
+
             word_start_time = word_end_time;
         }
     }
@@ -2135,7 +2146,16 @@ void SequenceElements::BreakdownWord(EffectLayer* phoneme_layer, int start_time,
             // only create phonemes with duration
             if (phoneme_end_time > phoneme_start_time)
             {
-                phoneme_layer->AddEffect(0, phoneme.ToStdString(), "", "", phoneme_start_time, phoneme_end_time, EFFECT_NOT_SELECTED, false);
+                // Don't overlay any existing phonemes - it makes a mess
+                if (!(phoneme_layer->GetAllEffectsByTime(phoneme_start_time, phoneme_end_time).size()))
+                {
+                    phoneme_layer->AddEffect(0, phoneme.ToStdString(), "", "", phoneme_start_time, phoneme_end_time, EFFECT_NOT_SELECTED, false);
+                }
+                else
+                {
+                    // If there's only a clash for part of the phoneme, can we fit this one in anyway?
+                    // Semantics of this are up for grabs... TBD.
+                }
             }
             phoneme_start_time = phoneme_end_time;
         }


### PR DESCRIPTION
As requested at http://nutcracker123.com/forum/index.php?topic=6931.0

Previous behaviour -
Effects layers below the current selection were deleted (words and phonemes for breakdown phrases, just phonemes for breakdown words).
New layer(s) were created and populated as appropriate.

New behaviour -
Effects layers are purged, rather than deleted. All non-locked effect elements are deleted.
Layer(s) are repopulated, although new words/phonemes that would clash with existing (locked) ones are not created.

There is an open question over the repopulation semantics here - At the moment, we just don't insert a given word/phoneme if there would be a clash. It might be possible to try to work out which words/phonemes already exist and insert others around them. This is probably difficult to work out, and not that useful... A bunch of strategies could well end up with broken down words in the wrong order, etc. I'm more than happy to discuss and implement something if anyone has strong preferences. Feel free to discuss on this PR, or open an issue assigned to me.