### PR TITLE
Retain locked words/phonemes when breaking down lyrics.

### DIFF
--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -1142,6 +1142,29 @@ void RowHeading::BreakdownTimingPhrases(TimingElement* element)
     {
         for( int k = element->GetEffectLayerCount()-1; k > 0; k--)
         {
+            EffectLayer* check_layer = element->GetEffectLayer(k);
+            bool found_locked = false;
+            for (auto&& e : check_layer->GetAllEffects())
+            {
+                if (e->IsLocked())
+                {
+                    found_locked = true;
+                    break;
+                }
+            }
+            if (found_locked)
+            {
+                wxMessageBox("Locked words/phonemes in the way - Can not break down phrases", "Error", wxOK);
+                return;
+            }
+        }
+    }
+
+    // No locked elements in the way now
+    if (element->GetEffectLayerCount() > 1)
+    {
+        for (int k = element->GetEffectLayerCount() - 1; k > 0; k--)
+        {
             element->RemoveEffectLayer(k);
         }
     }
@@ -1160,6 +1183,22 @@ void RowHeading::BreakdownTimingWords(TimingElement* element)
 {
     if( element->GetEffectLayerCount() > 2 )
     {
+        EffectLayer* phoneme_layer = element->GetEffectLayer(2);
+        bool found_locked = false;
+        for (auto&& e : phoneme_layer->GetAllEffects())
+        {
+            if (e->IsLocked())
+            {
+                found_locked = true;
+                break;
+            }
+        }
+        if (found_locked)
+        {
+            wxMessageBox("Locked phonemes in the way - Can not break down words", "Error", wxOK);
+            return;
+        }
+
         element->RemoveEffectLayer(2);
     }
     EffectLayer* word_layer = element->GetEffectLayer(1);


### PR DESCRIPTION
As requested at http://nutcracker123.com/forum/index.php?topic=6931.0

Previous full row behaviour -
Effects layers below the current selection were deleted (words and phonemes for breakdown phrases, just phonemes for breakdown words).
New layer(s) were created and populated as appropriate.

New full row behaviour -
Effects layers that would be deleted are checked for locked effects.
If any are found, abort the operation and inform the user.
Otherwise, delete them all and repopulate.

Previous individual phrase/word behaviour -
All effects in the target time range were deleted and repopulated

New individual phrase/word behaviour -
Effects in the target time range are checked.
If any are locked, abort the operation and inform the user.
Otherwise, delete them all and repopulate.

See previous discussion in #1925 