### PR TITLE
Add new transitions for high-density props

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- enh (kevin)  Add four new transitions for matrices / high-density props
 2020.9 March 9 2020
    -- enh (keith)  Where model knows the controller it is on apply controller limitations to the model properties
    -- enh (keith)  Copy backup folder options into the preferences tab for backup

--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -278,8 +278,8 @@ namespace
             return tex2D( cb0, uv0.x, uv0.y );
 
          if ( progress < 0.5 )
-            return tex2D( cb0, uv0.x, uv0.y );
-         xlColor c = tex2D( *rb1, 1-uv0.x, uv0.y );
+            return tex2D( *rb1, uv0.x, uv0.y );
+         xlColor c = tex2D( cb0, 1-uv0.x, uv0.y );
          return ( c != xlCLEAR ) ? c : tex2D( cb0, uv0.x, uv0.y );
       }
       return xlBLACK;

--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -489,21 +489,9 @@ namespace
    {
       return ((uv - 0.5) * (1.0-amount)) + 0.5;
    }
-   xlColor zoomTransitionIn( const ColorBuffer& cb, double s, double t, float progress )
+   xlColor zoomTransition( const ColorBuffer& cb, double s, double t, float progress )
    {
-      const float zoom_quickness = 0.8f;
-
-      return lerp( tex2D( cb, zoom( Vec2D( s, t ), SmoothStep( 0.0, zoom_quickness, progress ) ) ),
-                   tex2D( cb, Vec2D( s, t ) ),
-                   SmoothStep( zoom_quickness - 0.2, 1.0, progress ) );
-   }
-   xlColor zoomTransitionOut( const ColorBuffer& cb, double s, double t, float progress )
-   {
-      const float zoom_quickness = 0.5f;
-
-      return lerp( tex2D( cb, Vec2D( s, t ) ),
-                   tex2D( cb, zoom( Vec2D( s, t ), SmoothStep( 1.0, zoom_quickness, progress )/*1-progress*/ ) ),
-                   SmoothStep( zoom_quickness - 0.2, 1.0, progress )/*1-progress*/ );
+      return tex2D( cb, zoom( Vec2D( s, t ), 1.f-progress ) );
    }
    void zoomTransition( RenderBuffer& rb0, const ColorBuffer& cb0, double progress )
    {
@@ -513,7 +501,7 @@ namespace
          double t = double( y ) / ( rb0.BufferHt - 1 );
          for ( int x = 0; x < rb0.BufferWi; ++x ) {
             double s = double( x ) / ( rb0.BufferWi - 1 );
-            rb0.SetPixel( x, y, zoomTransitionOut( cb0, s, t, progress ) );
+            rb0.SetPixel( x, y, zoomTransition( cb0, s, t, progress ) );
          }
       }, 25);
    }

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -168,6 +168,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Circular Swirl"));
 	Choice_In_Transition_Type->Append(_("Bow Tie"));
 	Choice_In_Transition_Type->Append(_("Zoom"));
+	Choice_In_Transition_Type->Append(_("Doorway"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -216,6 +217,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Circular Swirl"));
 	Choice_Out_Transition_Type->Append(_("Bow Tie"));
 	Choice_Out_Transition_Type->Append(_("Zoom"));
+	Choice_Out_Transition_Type->Append(_("Doorway"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -167,6 +167,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Dissolve"));
 	Choice_In_Transition_Type->Append(_("Circular Swirl"));
 	Choice_In_Transition_Type->Append(_("Bow Tie"));
+	Choice_In_Transition_Type->Append(_("Zoom"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -214,6 +215,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Dissolve"));
 	Choice_Out_Transition_Type->Append(_("Circular Swirl"));
 	Choice_Out_Transition_Type->Append(_("Bow Tie"));
+	Choice_Out_Transition_Type->Append(_("Zoom"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -166,6 +166,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Fold"));
 	Choice_In_Transition_Type->Append(_("Dissolve"));
 	Choice_In_Transition_Type->Append(_("Circular Swirl"));
+	Choice_In_Transition_Type->Append(_("Bow Tie"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -212,6 +213,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Fold"));
 	Choice_Out_Transition_Type->Append(_("Dissolve"));
 	Choice_Out_Transition_Type->Append(_("Circular Swirl"));
+	Choice_Out_Transition_Type->Append(_("Bow Tie"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -430,7 +432,8 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
          inTransitionType == "Slide Bars" ||
          inTransitionType == "Blend" ||
          inTransitionType == "Dissolve" ||
-         inTransitionType == "Circular Swirl" )
+         inTransitionType == "Circular Swirl" ||
+         inTransitionType == "Bow Tie" )
    {
       CheckBox_In_Reverse->Disable();
    }
@@ -444,7 +447,8 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
         inTransitionType == "Circle Explode" ||
         inTransitionType == "Fold" ||
         inTransitionType == "Dissolve" ||
-        inTransitionType == "Circular Swirl" )
+        inTransitionType == "Circular Swirl" ||
+        inTransitionType == "Bow Tie" )
    {
       Slider_In_Adjust->Disable();
       TextCtrl_In_Adjust->Disable();
@@ -461,7 +465,8 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
         outTransitionType == "Slide Bars" ||
         outTransitionType == "Blend" ||
         outTransitionType == "Dissolve" ||
-        outTransitionType == "Circular Swirl" )
+        outTransitionType == "Circular Swirl" ||
+        outTransitionType == "Bow Tie" )
     {
        CheckBox_Out_Reverse->Disable();
     }
@@ -475,7 +480,8 @@ void TimingPanel::OnTransitionTypeSelect(wxCommandEvent& event)
          outTransitionType == "Circle Explode" ||
          outTransitionType == "Fold" ||
          outTransitionType == "Dissolve" ||
-         outTransitionType == "Circular Swirl" )
+         outTransitionType == "Circular Swirl" ||
+         outTransitionType == "Bow Tie" )
     {
        Slider_Out_Adjust->Disable();
        TextCtrl_Out_Adjust->Disable();

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -169,6 +169,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Bow Tie"));
 	Choice_In_Transition_Type->Append(_("Zoom"));
 	Choice_In_Transition_Type->Append(_("Doorway"));
+	Choice_In_Transition_Type->Append(_("Blobs"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -218,6 +219,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Bow Tie"));
 	Choice_Out_Transition_Type->Append(_("Zoom"));
 	Choice_Out_Transition_Type->Append(_("Doorway"));
+	Choice_Out_Transition_Type->Append(_("Blobs"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -186,6 +186,7 @@
 																			<item>Dissolve</item>
 																			<item>Circular Swirl</item>
 																			<item>Bow Tie</item>
+																			<item>Zoom</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -306,6 +307,7 @@
 																			<item>Dissolve</item>
 																			<item>Circular Swirl</item>
 																			<item>Bow Tie</item>
+																			<item>Zoom</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -187,6 +187,7 @@
 																			<item>Circular Swirl</item>
 																			<item>Bow Tie</item>
 																			<item>Zoom</item>
+																			<item>Doorway</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -308,6 +309,7 @@
 																			<item>Circular Swirl</item>
 																			<item>Bow Tie</item>
 																			<item>Zoom</item>
+																			<item>Doorway</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -185,6 +185,7 @@
 																			<item>Fold</item>
 																			<item>Dissolve</item>
 																			<item>Circular Swirl</item>
+																			<item>Bow Tie</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -304,6 +305,7 @@
 																			<item>Fold</item>
 																			<item>Dissolve</item>
 																			<item>Circular Swirl</item>
+																			<item>Bow Tie</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -188,6 +188,7 @@
 																			<item>Bow Tie</item>
 																			<item>Zoom</item>
 																			<item>Doorway</item>
+																			<item>Blobs</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -310,6 +311,7 @@
 																			<item>Bow Tie</item>
 																			<item>Zoom</item>
 																			<item>Doorway</item>
+																			<item>Blobs</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />


### PR DESCRIPTION
Adding a few new transition types; these are mainly useful for matrices and similar high-density props:

* Bow Tie - this is another variation on some of the older transitions
* Zoom - does exactly what you probably imagine
* Doorway - a new one that has the capability to reveal the layer below in the same way as Fold
* Blobs - a new one that has the capability to reveal the layer below in the same way as Fold

None of these currently are hooked up to the Reverse or Adjustment settings; I'll tackle that for the ones where it might make sense in a later merge.

This also includes an update to the Fold transition for what I saw as a bug (when using in two-layer mode as an out transition, the from/to layers seemed reversed). I checked with Clyde Lindsey on this, as he has created sequences using this behavior, and he agreed that it seemed like a bug.