### PR TITLE
Ignore selection of invalid model when editing layout

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -6812,6 +6812,11 @@ void LayoutPanel::OnSelectionChanged(wxTreeListEvent& event)
             ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(item);
             Model *model = ((data != nullptr) ? data->GetModel() : nullptr);
             if (model != nullptr) {
+                if (!xlights->AllModels.IsModelValid(model))
+                {
+                    logger_base.debug("Warning: Model at %p is Not Valid. This would have crashed. Ignoring.\n", model);
+                    return;
+                }
                 wxASSERT(xlights->AllModels.IsModelValid(model));
                 if (model->GetDisplayAs() == "ModelGroup") {
                     mSelectedGroup = item;


### PR DESCRIPTION
When adding or deleting items from the Layout, OnSelectionChanged() will
be called pointing to invalid models which was causing an assert.
Change to log and ignore.
This appears to be a similar problem to that described in wxWidgets ticket #18045.
This addresses one item in Issue #1933.
@cjd please consider.