### PR TITLE
Improve custom model load and move performance

### DIFF
--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -683,33 +683,21 @@ void CustomModel::InitRenderBufferNodes(const std::string& type, const std::stri
 int CustomModel::GetCustomMaxChannel(const std::string& customModel) const
 {
     int maxval = 0;
+    
+    std::stringstream ss(customModel);
+    std::string token;
+     
+     while(std::getline(ss, token, ',')) {
+         if (token != "" && token != ";" && token != "|") {
+             try {
+                 maxval = std::max(std::stoi(token), maxval);
+             }
+             catch (...) {
+                 // not a number, treat as 0
+             }
+         }
+     }
 
-    std::vector<std::string> layers;
-    std::vector<std::string> rows;
-    std::vector<std::string> cols;
-    layers.reserve(100);
-    rows.reserve(100);
-    cols.reserve(100);
-
-    split(customModel, '|', layers);
-
-    for (auto layer : layers) {
-        split(layer, ';', rows);
-        for (auto row : rows) {
-            cols.clear();
-            split(row, ',', cols);
-            for (auto col : cols) {
-                if (col != "") {
-                    try {
-                        maxval = std::max(std::stoi(col), maxval);
-                    }
-                    catch (...) {
-                        // not a number, treat as 0
-                    }
-                }
-            }
-        }
-    }
     return maxval;
 }
 


### PR DESCRIPTION
Improve custom model, especially large models in terms of X/Y/X size, when opening xLights and when trying to move large models around in the layout.  GetCustomMaxChannel is called twice for each custom model on open and the same when you attempt to move a model in the layout tab.  GetCustomMaxChannel was looping through all layers/rows/columns to find the max node count and was taking ~5-6 seconds on a particular 3-D model which was 100x100x100, which is attatched.  This call is now down to ~.5 seconds on the same model.

Even for normal non 3d models performance is much improved.
   
[G-Sphere.xmodel.zip](https://github.com/smeighan/xLights/files/4562293/G-Sphere.xmodel.zip)

