### PR TITLE
improve custom model dialog load time

### DIFF
--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -683,33 +683,21 @@ void CustomModel::InitRenderBufferNodes(const std::string& type, const std::stri
 int CustomModel::GetCustomMaxChannel(const std::string& customModel) const
 {
     int maxval = 0;
+    
+    std::stringstream ss(customModel);
+    std::string token;
+     
+     while(std::getline(ss, token, ',')) {
+         if (token != "" && token != ";" && token != "|") {
+             try {
+                 maxval = std::max(std::stoi(token), maxval);
+             }
+             catch (...) {
+                 // not a number, treat as 0
+             }
+         }
+     }
 
-    std::vector<std::string> layers;
-    std::vector<std::string> rows;
-    std::vector<std::string> cols;
-    layers.reserve(100);
-    rows.reserve(100);
-    cols.reserve(100);
-
-    split(customModel, '|', layers);
-
-    for (auto layer : layers) {
-        split(layer, ';', rows);
-        for (auto row : rows) {
-            cols.clear();
-            split(row, ',', cols);
-            for (auto col : cols) {
-                if (col != "") {
-                    try {
-                        maxval = std::max(std::stoi(col), maxval);
-                    }
-                    catch (...) {
-                        // not a number, treat as 0
-                    }
-                }
-            }
-        }
-    }
     return maxval;
 }
 


### PR DESCRIPTION
Improve load time for custom model dialog Setup call by eliminating redundant calls to grid to add each row/column as well as redundant for loops to set row/cell size.  Improvements in load time for dialog below taken in debug mode running source from xCode.

1: 2500 nodes, 28x27x26 custom model grid:
 - old: 33s
 - refactored: 4.4s

2: 496 nodes, 202x202x1 grid
 - old: 15s
 - refactored 6.1s

3. 500 nodes, 82x70x1 grid
 - old: 1.5s
 - refactored: .3s

4: 1052 nodes, 101x101x100 grid
- old: I gave up after 20 minutes of waiting
- refactored: 290s (yeah not great but this is extreme case and brought on by creation of new grid per layer but at least it loaded).  Only thing to fix this is for models with many layers would be to load layer date on page click in dialog, but again this is extreme case so didn't go that far.
