### PR TITLE
fix model list refresh on macOS on property grid changes

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1103,10 +1103,6 @@ void LayoutPanel::refreshModelList() {
 
         if (model != nullptr ) {
 
-            TreeListViewModels->SetItemText(item, TreeModelName(model, data->fullname));
-
-            int end_channel = model->GetLastChannel()+1;
-            wxString endStr = model->GetLastChannelInStartChannelFormat(xlights->GetOutputManager());
             if( model->GetDisplayAs() != "ModelGroup" ) {
                 wxString cv = TreeListViewModels->GetItemText(item, Col_StartChan);
                 wxString startStr = model->GetStartChannelInDisplayFormat(xlights->GetOutputManager());
@@ -1122,8 +1118,9 @@ void LayoutPanel::refreshModelList() {
                     }
                 }
                 cv = TreeListViewModels->GetItemText(item, Col_EndChan);
+                wxString endStr = model->GetLastChannelInStartChannelFormat(xlights->GetOutputManager());
                 if (cv != endStr) {
-                    data->endingChannel = end_channel;
+                    data->endingChannel = model->GetLastChannel()+1;;
                     TreeListViewModels->SetItemText(item, Col_EndChan, endStr);
                 }
                 cv = TreeListViewModels->GetItemText(item, Col_ControllerConnection);


### PR DESCRIPTION
This is mostly a fix for macOS for large layouts with hundreds of models and groups but should also improve refresh time for model list for all.

SetItemText was being called for all models on refresh, not just the model with property changes and it appears on macOS there is no internal check if the text is actually dirty.  I removed the call all together as it is already being handled by RenameModelInTree.

Also moving end_channel/endStr retrieval inside "ModelGroup" group check helped speed things up a bit more as these aren't needed for updating Model Groups.

Some timings for my layout (~500 models/groups) when changing a single model property which fires refresh for example brightness...

- Before fix: 60s to refresh
- After remove SetItemText: 1.5s
- After move end_channel/endStr where only needed: .7s