### PR TITLE
Fix submodel start channel always displaying as "(1)" in modellist

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2083,8 +2083,14 @@ bool Model::ModelRenamed(const std::string &oldName, const std::string &newName)
 
 bool Model::IsValidStartChannelString() const
 {
-    wxString sc = ModelXml->GetAttribute("StartChannel").Trim(true).Trim(false);
-
+    wxString sc;
+    
+    if (GetDisplayAs() == "SubModel") {
+        sc = this->ModelStartChannel;
+    } else {
+        sc = ModelXml->GetAttribute("StartChannel").Trim(true).Trim(false);
+    }
+    
     if (sc.IsNumber() && wxAtol(sc) > 0 && ! sc.Contains('.')) return true; // absolule
 
     if (!sc.Contains(':')) return false; // all other formats need a colon


### PR DESCRIPTION
Submodel start channel always displays as default "(1)" for submodel in model list.  This fix correctly displays just the start channel like end channel currently does (just the channel number).  Could switch to the same format parent model uses with controller info but when I did the model list seemed a bit cluttered and you can easily see the controller info from parent in the list.