### PR TITLE
Default wiring, custom model and node layout dialogs to maximized

### DIFF
--- a/xLights/ChannelLayoutDialog.cpp
+++ b/xLights/ChannelLayoutDialog.cpp
@@ -66,6 +66,8 @@ ChannelLayoutDialog::ChannelLayoutDialog(wxWindow* parent,wxWindowID id,const wx
     Connect(ID_BUTTON_OPEN_IN_BROWSER,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ChannelLayoutDialog::OnButtonOpenInBrowerClick);
     //*)
     HtmlEasyPrint=new wxHtmlEasyPrinting("xLights Printing", this);
+    
+    Maximize();
 }
 
 ChannelLayoutDialog::~ChannelLayoutDialog()

--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -463,6 +463,7 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent)
     Layout();
 
     ValidateWindow();
+    Maximize();
 }
 
 CustomModelDialog::~CustomModelDialog()

--- a/xLights/WiringDialog.cpp
+++ b/xLights/WiringDialog.cpp
@@ -100,6 +100,7 @@ WiringDialog::WiringDialog(wxWindow* parent, wxString modelname, wxWindowID id,c
 
     wxConfigBase* config = wxConfigBase::Get();
     config->Read("xLightsWDFontSize", &_fontSize, 12);
+    Maximize();
 }
 
 void WiringDialog::SetColorTheme(COLORTHEMETYPE themeType) {


### PR DESCRIPTION
All 3 of these dialogs generally require maximum screen real estate.  Maybe I'm missing something as to why they are not, but I believe the first thing most do when opening these is to maximize them.