### PR TITLE
Updating Sync files for MIDI

### DIFF
--- a/xSchedule/SyncArtNet.cpp
+++ b/xSchedule/SyncArtNet.cpp
@@ -173,9 +173,7 @@ SyncArtNet::SyncArtNet(SyncArtNet&& from) noexcept : SyncBase(from)
 {
     _threadTimecode = from._threadTimecode;
     from._threadTimecode = nullptr; // this is a transfer of ownership
-    if (_threadTimecode != nullptr) {
-        _threadTimecode->UpdateSyncArtNet(this);
-    }
+    _threadTimecode->UpdateSyncArtNet(this);
 
     _artnetSocket = from._artnetSocket;
     from._artnetSocket = nullptr; // this is a transfer of ownership
@@ -244,7 +242,7 @@ void SyncArtNet::SendSync(uint32_t frameMS, uint32_t stepLengthMS, uint32_t step
     }
 
     buffer[17] = ms / (3600000);
-    ms = ms % 360000;
+    ms = ms % 3600000;
 
     buffer[16] = ms / 60000;
     ms = ms % 60000;

--- a/xSchedule/SyncMIDI.cpp
+++ b/xSchedule/SyncMIDI.cpp
@@ -257,16 +257,12 @@ SyncMIDI::SyncMIDI(SyncMIDI&& from) : SyncBase(from)
 {
     _threadTimecode = from._threadTimecode;
     from._threadTimecode = nullptr; // this is a transfer of ownership
-    if (_threadTimecode != nullptr) {
-        _threadTimecode->UpdateSyncMIDI(this);
-    }
+    _threadTimecode->UpdateSyncMIDI(this);
 
 #ifdef USE_CLOCK_THREAD
     _threadClock = from._threadClock;
     from._threadClock = nullptr; // this is a transfer of ownership
-    if (_threadClock != nullptr) {
-        _threadClock->UpdateSyncMIDI(this);
-    }
+    _threadClock->UpdateSyncMIDI(this);
 #endif
     _midi = from._midi;
     from._midi = nullptr; // this is a transfer of ownership
@@ -415,7 +411,7 @@ void SyncMIDI::SendSync(uint32_t frameMS, uint32_t stepLengthMS, uint32_t stepMS
         buffer[4] = 0x01;
 
         buffer[5] = (static_cast<int>(_timeCodeFormat) << 5) + ms / (3600000); // hour
-        ms = ms % 360000;
+        ms = ms % 3600000;
 
         buffer[6] = ms / 60000; // minute
         ms = ms % 60000;
@@ -454,7 +450,7 @@ void SyncMIDI::SendSync(uint32_t frameMS, uint32_t stepLengthMS, uint32_t stepMS
         ms += _timeCodeOffset;
 
         int hours = (static_cast<int>(_timeCodeFormat) << 5) + ms / (3600000);
-        ms = ms % 360000;
+        ms = ms % 3600000;
 
         int mins = ms / 60000;
         ms = ms % 60000;


### PR DESCRIPTION
MIDI sync was incorrectly calculating the hour mark by using 360,000 instead of 3,600,000 as the mod value.