### PR TITLE
Fix wiring rotate for native model with > 1 string

### DIFF
--- a/xLights/WiringDialog.cpp
+++ b/xLights/WiringDialog.cpp
@@ -607,6 +607,7 @@ void WiringDialog::RotatePoints(int rotateBy) {
             }
         }
         _points[string] = data;
+        data.clear();
         string++;
     }
 }


### PR DESCRIPTION
Fix rotate in wiring dialog for native models with > 1 string, only the last string was being drawn.