### PR TITLE
Model Tree multi select

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1434,15 +1434,19 @@ void LayoutPanel::UpdateModelsForPreview(const std::string &group, LayoutGroup* 
     }
 
     // add in any models that were not in preview but belong to a group that is in the preview
-    std::string selected_group_name = "";
-    if (mSelectedGroup.IsOk() && filtering) {
-        selected_group_name = TreeListViewModels->GetItemText(mSelectedGroup);
+    wxArrayString selectedGroupNames;
+
+    if (mSelectedGroups.size() > 0 && filtering) {
+        for (int i = 0; i < mSelectedGroups.size(); i++) {
+            wxString selectedName = TreeListViewModels->GetItemText(mSelectedGroups[i]);
+            selectedGroupNames.Add(selectedName);
+        }
     }
 
     for (const auto& it : xlights->AllModels) {
         Model *model = it.second;
         bool mark_selected = false;
-        if (mSelectedGroup.IsOk() && filtering && (model->name == selected_group_name)) {
+        if (selectedGroupNames.size() > 0 && filtering && (selectedGroupNames.Index(model->name) != -1)) {
             mark_selected = true;
         }
         if (model->GetDisplayAs() == "ModelGroup") {
@@ -1540,14 +1544,15 @@ void LayoutPanel::UpdateModelsForPreview(const std::string &group, LayoutGroup* 
 
 void LayoutPanel::BulkEditDimmingCurves()
 {
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+
     // get the first dimming curve
     ModelDimmingCurveDialog dlg(this);
     std::map<std::string, std::map<std::string, std::string>> dimmingInfo;
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected)
-        {
-            wxXmlNode *f = modelPreview->GetModels()[i]->GetModelXml()->GetChildren();
+    
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            wxXmlNode *f = model->GetModelXml()->GetChildren();
             while (f != nullptr) {
                 if ("dimmingCurve" == f->GetName()) {
                     wxXmlNode *dc = f->GetChildren();
@@ -1563,17 +1568,17 @@ void LayoutPanel::BulkEditDimmingCurves()
                 }
                 f = f->GetNext();
             }
-        }
+            
+            if (model->GetModelXml()->GetAttribute("ModelBrightness", "-1") != "-1")
+            {
+                wxString b = model->GetModelXml()->GetAttribute("ModelBrightness", "0");
+                dimmingInfo["all"]["gamma"] = "1.0";
+                dimmingInfo["all"]["brightness"] = b;
+            }
 
-        if (modelPreview->GetModels()[i]->GetModelXml()->GetAttribute("ModelBrightness", "-1") != "-1")
-        {
-            wxString b = modelPreview->GetModels()[i]->GetModelXml()->GetAttribute("ModelBrightness", "0");
-            dimmingInfo["all"]["gamma"] = "1.0";
-            dimmingInfo["all"]["brightness"] = b;
-        }
-
-        if (!dimmingInfo.empty()) {
-            break;
+            if (!dimmingInfo.empty()) {
+                break;
+            }
         }
     }
 
@@ -1587,25 +1592,26 @@ void LayoutPanel::BulkEditDimmingCurves()
     if (dlg.ShowModal() == wxID_OK) {
         dimmingInfo.clear();
         dlg.Update(dimmingInfo);
-
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-        {
-            if (modelPreview->GetModels()[i]->GroupSelected|| modelPreview->GetModels()[i]->Selected)
-            {
-                wxXmlNode *f1 = modelPreview->GetModels()[i]->GetModelXml()->GetChildren();
+        
+        // remember selected tree models and paths for reselect
+        std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+        
+        for (Model* model : modelsToEdit) {
+            if (model != nullptr) {
+                wxXmlNode *f1 = model->GetModelXml()->GetChildren();
                 while (f1 != nullptr) {
                     if ("dimmingCurve" == f1->GetName()) {
-                        modelPreview->GetModels()[i]->GetModelXml()->RemoveChild(f1);
+                        model->GetModelXml()->RemoveChild(f1);
                         delete f1;
-                        f1 = modelPreview->GetModels()[i]->GetModelXml()->GetChildren();
+                        f1 = model->GetModelXml()->GetChildren();
                     }
                     else {
                         f1 = f1->GetNext();
                     }
                 }
                 f1 = new wxXmlNode(wxXML_ELEMENT_NODE, "dimmingCurve");
-                modelPreview->GetModels()[i]->GetModelXml()->AddChild(f1);
-                modelPreview->GetModels()[i]->IncrementChangeCount();
+                model->GetModelXml()->AddChild(f1);
+                model->IncrementChangeCount();
                 for (const auto& it : dimmingInfo) {
                     wxXmlNode *dc = new wxXmlNode(wxXML_ELEMENT_NODE, it.first);
                     f1->AddChild(dc);
@@ -1613,43 +1619,35 @@ void LayoutPanel::BulkEditDimmingCurves()
                         dc->AddAttribute(it2.first, it2.second);
                     }
                 }
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BulkEditDimmingCurves");
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "BulkEditDimmingCurves");
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditDimmingCurves");
             }
         }
+        
+        // If we don't do these as ImmediateWork then the Model Tree is still frozen and models don't get reselected after refresh
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BulkEditDimmingCurves");
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "BulkEditDimmingCurves");
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditDimmingCurves");
+        
+        ReselectTreeModels(selectedModelPaths);
     }
 }
 
 void LayoutPanel::BulkEditControllerConnection(int id)
 {
-    // remember the selected models
-    wxString selected = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (selected != "")
-            {
-                selected += ",";
-            }
-            selected += modelPreview->GetModels()[i]->GetName();
-        }
-    }
-
-    std::string sm = GetSelectedModelName();
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
     // get the first controller connection
     wxXmlNode *cc = nullptr;
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-        if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-            std::string protocol = modelPreview->GetModels()[i]->GetControllerProtocol();
+    
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            std::string protocol = model->GetControllerProtocol();
             if (protocol != "") {
-                cc = modelPreview->GetModels()[i]->GetControllerConnection();
+                cc = model->GetControllerConnection();
                 break;
             }
         }
     }
+
     controller_connection_bulkedit ccbe = controller_connection_bulkedit::CEBE_CONTROLLERCONNECTION;
     if (id == ID_PREVIEW_BULKEDIT_CONTROLLERDIRECTION) {
         ccbe = controller_connection_bulkedit::CEBE_CONTROLLERDIRECTION;
@@ -1677,54 +1675,34 @@ void LayoutPanel::BulkEditControllerConnection(int id)
     OptimiseDialogPosition(&dlg);
 
     if (dlg.ShowModal() == wxID_OK) {
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-            if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-                dlg.Get(modelPreview->GetModels()[i]->GetControllerConnection());
+        // remember selected tree models and paths for reselect
+        std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
+        for (Model* model: modelsToEdit) {
+            if (model != nullptr) {
+                dlg.Get(model->GetControllerConnection());
             }
         }
-
+        std::string sm = GetSelectedModelName();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerConnection", nullptr, nullptr, sm);
-        xlights->GetOutputModelManager()->ForceSelectedModel(sm);
-
-        // reselect all the models
-        wxArrayString models = wxSplit(selected, ',');
-        for (const auto& it : models)
-        {
-            for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-            {
-                if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-                {
-                    modelPreview->GetModels()[i]->GroupSelected = true;
-                }
-            }
-        }
+        
+        ReselectTreeModels(selectedModelPaths);
     }
 }
 
 void LayoutPanel::BulkEditActive(bool active)
 {
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+
     // remember the selected models
-    wxString selected = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (selected != "")
-            {
-                selected += ",";
-            }
-            selected += modelPreview->GetModels()[i]->GetName();
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            model->SetActive(active);
         }
     }
-
-    std::string sm = GetSelectedModelName();
-
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-        if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-            modelPreview->GetModels()[i]->SetActive(active);
-        }
-    }
-
+    
     for (const auto& it : xlights->AllObjects) {
 
         if (it.second->Selected || it.second->GroupSelected)
@@ -1745,52 +1723,30 @@ void LayoutPanel::BulkEditActive(bool active)
         selectedBaseObject->SetActive(active);
     }
 
-    xlights->GetOutputModelManager()->ForceSelectedModel(sm);
+    std::string sm = GetSelectedModelName();
     xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditActive", nullptr, nullptr, sm);
 
     // reselect all the models
-    wxArrayString models = wxSplit(selected, ',');
-    for (const auto& it : models)
-    {
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-        {
-            if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-            {
-                modelPreview->GetModels()[i]->GroupSelected = true;
-            }
-        }
-    }
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::BulkEditControllerName()
 {
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+
     // remember the selected models
-    wxString selected = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (selected != "")
-            {
-                selected += ",";
-            }
-            selected += modelPreview->GetModels()[i]->GetName();
-        }
-    }
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
-    std::string sm = GetSelectedModelName();
-
-    // get the first controller connection
     std::string name = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-        if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-            name = modelPreview->GetModels()[i]->GetControllerName();
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            name = model->GetControllerName();
             if (name != "") {
                 break;
             }
         }
     }
-
+    
     wxArrayString cn;
     int sel = 0;
     int i = 1;
@@ -1807,52 +1763,30 @@ void LayoutPanel::BulkEditControllerName()
 
     if (dlg.ShowModal() == wxID_OK) {
         name = dlg.GetStringSelection();
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-            if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-                modelPreview->GetModels()[i]->SetControllerName(name);
-            }
+        
+        for (Model* model : modelsToEdit) {
+            model->SetControllerName(name);
         }
 
-        xlights->GetOutputModelManager()->ForceSelectedModel(sm);
+        std::string sm = GetSelectedModelName();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerName", nullptr, nullptr, sm);
 
         // reselect all the models
-        wxArrayString models = wxSplit(selected, ',');
-        for (const auto& it : models)
-        {
-            for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-            {
-                if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-                {
-                    modelPreview->GetModels()[i]->GroupSelected = true;
-                }
-            }
-        }
+        ReselectTreeModels(selectedModelPaths);
     }
 }
 
 void LayoutPanel::BulkEditTagColour()
 {
-    // remember the selected models
-    wxString selected = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (selected != "")
-            {
-                selected += ",";
-            }
-            selected += modelPreview->GetModels()[i]->GetName();
-        }
-    }
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
-    std::string sm = GetSelectedModelName();
+    // remember the selected models
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     wxColour colour = *wxBLACK;
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-        if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-            colour = modelPreview->GetModels()[i]->GetTagColour();
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            colour = model->GetTagColour();
             if (colour != *wxBLACK) {
                 break;
             }
@@ -1868,58 +1802,34 @@ void LayoutPanel::BulkEditTagColour()
         colorData = dialog.GetColourData();
         colour = colorData.GetColour();
 
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-            if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-                modelPreview->GetModels()[i]->SetTagColour(colour);
-            }
+        for (Model* model: modelsToEdit) {
+            model->SetTagColour(colour);
         }
 
-        xlights->GetOutputModelManager()->ForceSelectedModel(sm);
+        std::string sm = GetSelectedModelName();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditTagColour", nullptr, nullptr, sm);
 
         // reselect all the models
-        wxArrayString models = wxSplit(selected, ',');
-        for (const auto& it : models)
-        {
-            for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-            {
-                if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-                {
-                    modelPreview->GetModels()[i]->GroupSelected = true;
-                }
-            }
-        }
+        ReselectTreeModels(selectedModelPaths);
     }
 }
 
 void LayoutPanel::BulkEditControllerPreview()
 {
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+
+    // remember the selected models
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
     // get the first preview
     std::string p = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected|| modelPreview->GetModels()[i]->Selected)
-        {
-            p = modelPreview->GetModels()[i]->GetLayoutGroup();
+    wxColour colour = *wxBLACK;
+    for (Model* model: modelsToEdit) {
+        if (model != nullptr) {
+            p = model->GetLayoutGroup();
             if (p != "") break;
         }
     }
-
-    // remember the selected models
-    wxString selected = "";
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (selected != "")
-            {
-                selected += ",";
-            }
-            selected += modelPreview->GetModels()[i]->GetName();
-        }
-    }
-
-    std::string sm = GetSelectedModelName();
 
     wxArrayString choices = Model::GetLayoutGroups(xlights->AllModels);
     int sel = 0;
@@ -1937,29 +1847,17 @@ void LayoutPanel::BulkEditControllerPreview()
     OptimiseDialogPosition(&dlg);
     if (dlg.ShowModal() == wxID_OK)
     {
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-        {
-            if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected)
-            {
-                modelPreview->GetModels()[i]->SetLayoutGroup(dlg.GetStringSelection().ToStdString());
+        for (Model* model : modelsToEdit) {
+            if (model != nullptr) {
+                model->SetLayoutGroup(dlg.GetStringSelection().ToStdString());
             }
         }
 
+        std::string sm = GetSelectedModelName();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerPreview", nullptr, nullptr, sm);
-        xlights->GetOutputModelManager()->ForceSelectedModel(sm);
 
         // reselect all the models
-        wxArrayString models = wxSplit(selected, ',');
-        for (const auto& it : models)
-        {
-            for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-            {
-                if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-                {
-                    modelPreview->GetModels()[i]->GroupSelected = true;
-                }
-            }
-        }
+        ReselectTreeModels(selectedModelPaths);
 
         RenderLayout();
     }
@@ -1991,51 +1889,40 @@ void LayoutPanel::CreateModelGroupFromSelected()
         wxString grp = currentLayoutGroup == "All Models" ? "Unassigned" : currentLayoutGroup;
         node->AddAttribute("LayoutGroup", grp);
 
-        bool selectedModelAdded = selectedBaseObject == nullptr;
-        wxString ModelsInGroup = "";
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-        {
-            if (modelPreview->GetModels()[i]->GroupSelected)
-            {
-                if (modelPreview->GetModels()[i] == selectedBaseObject)
-                {
-                    selectedModelAdded = true;
-                }
-                if (ModelsInGroup != "")
-                {
-                    ModelsInGroup += ",";
-                }
-                ModelsInGroup += modelPreview->GetModels()[i]->GetName();
-            }
+        wxArrayString newGroupModels;
+        
+        // add selected groups
+        for (const auto& group : mSelectedGroups) {
+            newGroupModels.Add(TreeListViewModels->GetItemText(group));
         }
-        if (!selectedModelAdded)
-        {
-            if (ModelsInGroup != "")
-            {
-                ModelsInGroup += ",";
-            }
-            ModelsInGroup += selectedBaseObject->GetName();
+        
+        // add selected models
+        for (const auto& model : mSelectedModels) {
+            newGroupModels.Add(TreeListViewModels->GetItemText(model));
         }
 
-        node->AddAttribute("models", ModelsInGroup);
+        // Need to fix. If submodels are added to the new group when we attempt to select it below
+        // the submodels somehow end up in the models passed to ModelPreview->RenderModels() as BaseObjects
+        // and are invalid causing the ASSERT to fire.  Maybe once that mystery is solved this will be fine
+        for (const auto& submodel : mSelectedSubModels) {
+            ModelTreeData *submodelData = (ModelTreeData*)TreeListViewModels->GetItemData(submodel);
+            Model* subModel = ((submodelData != nullptr) ? submodelData->GetModel() : nullptr);
+
+            if (subModel != nullptr) {
+                newGroupModels.Add(subModel->GetFullName());
+            }
+        }
+
+        wxString xmlModels = wxJoin(newGroupModels, ',');
+        node->AddAttribute("models", xmlModels);
 
         xlights->AllModels.AddModel(xlights->AllModels.CreateModel(node));
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CreateModelGroupFromSelected");
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "CreateModelGroupFromSelected", nullptr, nullptr, name.ToStdString());
-        model_grp_panel->UpdatePanel(name.ToStdString());
-        //ShowPropGrid(false);
-        //SelectBaseObject(name.ToStdString());
-        wxArrayString models = wxSplit(ModelsInGroup, ',');
-        for (const auto& it : models)
-        {
-            for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-            {
-                if (modelPreview->GetModels()[i]->GetName() == it.ToStdString())
-                {
-                    modelPreview->GetModels()[i]->GroupSelected = true;
-                }
-            }
-        }
+                
+        Model* model = xlights->GetModel(name.ToStdString());
+        SelectModelInTree(model);
+        
         //RenderLayout();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CreateModelGroupFromSelected", nullptr, nullptr, name.ToStdString());
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "CreateModelGroupFromSelected", nullptr, nullptr, name.ToStdString());
@@ -2080,6 +1967,10 @@ void LayoutPanel::UnSelectAllModels(bool addBkgProps)
     highlightedBaseObject = nullptr;
     selectedBaseObject = nullptr;
     selectionLatched = false;
+    selectedBaseTreeItem = nullptr;
+    mSelectedGroups.clear();
+    mSelectedModels.clear();
+    mSelectedSubModels.clear();
 
     // process all models
     auto models = modelPreview->GetModels();
@@ -2125,10 +2016,8 @@ void LayoutPanel::UnSelectAllModels(bool addBkgProps)
             logger_base.error("Really strange ... unselect all models returned a null view object pointer");
         }
     }
-
+    
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::UnselectAllModels");
-    selectedBaseObject = nullptr;
-    mSelectedGroup = nullptr;
 
     if (!updatingProperty && addBkgProps) {
         propertyEditor->Freeze();
@@ -2228,30 +2117,6 @@ void LayoutPanel::SelectAllModels()
     }
 
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectAllModels");
-}
-
-void LayoutPanel::SelectModels(const wxTreeListItems& selectedModels)
-{
-    for (auto selectedModel : selectedModels)
-    {
-        wxClientData* ptr = TreeListViewModels->GetItemData( selectedModel );
-        if (ptr == nullptr)
-            continue;
-        ModelTreeData* data = dynamic_cast<ModelTreeData *>( ptr );
-        if (data == nullptr)
-            continue;
-
-        // Multi-select should only work with models (no groups or submodels)
-        Model* model = data->GetModel();
-        if ( dynamic_cast<ModelGroup*>(model) != nullptr || dynamic_cast<SubModel*>(model) != nullptr )
-            TreeListViewModels->Unselect(selectedModel);
-        else
-            SelectModel(model, false);
-    }
-
-    clearPropGrid();
-
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectModels");
 }
 
 void LayoutPanel::SetupPropGrid(BaseObject *base_object) {
@@ -2858,6 +2723,7 @@ void LayoutPanel::SelectAllInBoundingRect(bool models_and_objects)
                     SelectBaseObject(modelPreview->GetModels()[i]->GetName(), false);
                 }
                 modelPreview->GetModels()[i]->GroupSelected = true;
+                SelectModelInTree(modelPreview->GetModels()[i]);
             }
         }
     }
@@ -2877,6 +2743,8 @@ void LayoutPanel::SelectAllInBoundingRect(bool models_and_objects)
             }
         }
     }
+    
+    modelPreview->SetFocus();
 }
 
 void LayoutPanel::HighlightAllInBoundingRect(bool models_and_objects)
@@ -2913,41 +2781,46 @@ bool LayoutPanel::SelectMultipleModels(int x,int y)
     int modelCount = FindModelsClicked(x, y, found);
     if (modelCount == 0)
         return false;
-
+    
+    bool treeSelectionChanged = false;
     propertyEditor->Freeze();
     clearPropGrid();
     propertyEditor->Thaw();
-    if (modelPreview->GetModels()[found[0]]->Selected)
+    
+    Model* clickedModel = modelPreview->GetModels()[found[0]];
+    
+    if (clickedModel->Selected)
     {
-        modelPreview->GetModels()[found[0]]->Selected = false;
-        modelPreview->GetModels()[found[0]]->Highlighted = false;
-        modelPreview->GetModels()[found[0]]->GroupSelected = false;
-        modelPreview->GetModels()[found[0]]->SelectHandle(-1);
-        modelPreview->GetModels()[found[0]]->GetBaseObjectScreenLocation().SetActiveHandle(-1);
+        UnSelectModelInTree(clickedModel);
+        treeSelectionChanged = true;
     }
     else if (modelPreview->GetModels()[found[0]]->GroupSelected)
     {
-        SetSelectedModelToGroupSelected();
-        modelPreview->GetModels()[found[0]]->Selected = true;
-        modelPreview->GetModels()[found[0]]->Highlighted = true;
-        SelectModel(modelPreview->GetModels()[found[0]]);
-        modelPreview->GetModels()[found[0]]->SelectHandle(-1);
-        modelPreview->GetModels()[found[0]]->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
+        clickedModel->GroupSelected = false;
+        clickedModel->Selected = true;
+        if (selectedBaseObject != nullptr) {
+            selectedBaseObject->GroupSelected = true;
+            selectedBaseObject->Selected = false;
+            selectedBaseObject->SelectHandle(-1);
+            selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(-1);
+        }
+        selectedBaseObject = clickedModel;
+        highlightedBaseObject = selectedBaseObject;
+        selectedBaseObject->SelectHandle(-1);
+        selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
     }
     else
     {
-        modelPreview->GetModels()[found[0]]->Highlighted = true;
-        if (ModelsSelectedCount() == 0) {
-            modelPreview->GetModels()[found[0]]->Selected = true;
-            SelectModel(modelPreview->GetModels()[found[0]]);
-            modelPreview->GetModels()[found[0]]->SelectHandle(-1);
-            modelPreview->GetModels()[found[0]]->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
-        } else {
-            modelPreview->GetModels()[found[0]]->GroupSelected = true;
-        }
+        SelectModelInTree(modelPreview->GetModels()[found[0]]);
+        treeSelectionChanged = true;
     }
 
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectMultipleModels");
+    if (!treeSelectionChanged) {
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectMultipleModels");
+    } else {
+        // take focus away from model tree
+        modelPreview->SetFocus();
+    }
 
     return true;
 }
@@ -2974,7 +2847,11 @@ void LayoutPanel::SetSelectedModelToGroupSelected()
 
 void LayoutPanel::OnPreviewLeftDClick(wxMouseEvent& event)
 {
-    UnSelectAllModels();
+    if (editing_models) {
+        TreeListViewModels->UnselectAll();
+    } else {
+        UnSelectAllModels();
+    }
     m_mouse_down = false;
     SetMouseStateForModels(m_mouse_down);
 }
@@ -3128,8 +3005,14 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
         if (which_object != nullptr)
         {
             if (which_object->Highlighted) {
+                bool treeSelectionChanged = false;
                 if (!which_object->GroupSelected && !which_object->Selected) {
-                    which_object->GroupSelected = true;
+                    if (editing_models) {
+                        SelectBaseObjectInTree(which_object);
+                        treeSelectionChanged = true;
+                    } else {
+                        which_object->GroupSelected = true;
+                    }
                 }
                 else if (which_object->GroupSelected) {
                     which_object->GroupSelected = false;
@@ -3146,22 +3029,10 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
                 }
                 else if (which_object->Selected) {
-                    which_object->Selected = false;
-                    which_object->Highlighted = false;
-                    which_object->SelectHandle(-1);
-                    which_object->GetBaseObjectScreenLocation().SetActiveHandle(-1);
-                    selectedBaseObject = nullptr;
-                    // select first selected model or object we find
                     if (editing_models) {
-                        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-                        {
-                            if (modelPreview->GetModels()[i]->GroupSelected) {
-                                selectedBaseObject = modelPreview->GetModels()[i];
-                                break;
-                            }
-                        }
-                    }
-                    else {
+                        UnSelectBaseObjectInTree(which_object);
+                        treeSelectionChanged = true;
+                    } else {
                         for (const auto& it : xlights->AllObjects) {
                             ViewObject* view_object = it.second;
                             if (view_object->GroupSelected) {
@@ -3169,16 +3040,22 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                                 break;
                             }
                         }
-                    }
-                    if (selectedBaseObject != nullptr) {
-                        selectedBaseObject->GroupSelected = false;
-                        selectedBaseObject->Selected = true;
-                        selectedBaseObject->SelectHandle(-1);
-                        selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
-                        highlightedBaseObject = selectedBaseObject;
+                        if (selectedBaseObject != nullptr) {
+                            selectedBaseObject->GroupSelected = false;
+                            selectedBaseObject->Selected = true;
+                            selectedBaseObject->SelectHandle(-1);
+                            selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
+                            highlightedBaseObject = selectedBaseObject;
+                        }
                     }
                 }
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::ProcessLeftMouseClick3D");
+                
+                // No need to redraw layout if tree selection changed as this work ends up being done on selection change
+                if (!treeSelectionChanged) {
+                    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::ProcessLeftMouseClick3D");
+                } else {
+                    modelPreview->SetFocus();
+                }
             }
         }
     }
@@ -5020,8 +4897,222 @@ int LayoutPanel::GetSelectedModelIndex() const
     return -1;
 }
 
+// Select a Model in the tree, currently only selects top level model if found
+void LayoutPanel::SelectModelInTree(Model* modelToSelect) {
+    for ( wxTreeListItem item = TreeListViewModels->GetFirstItem();
+          item.IsOk();
+          item = TreeListViewModels->GetNextSibling(item) )
+    {
+        if (TreeListViewModels->GetItemData(item) != nullptr)
+        {
+            ModelTreeData *mitem = dynamic_cast<ModelTreeData*>(TreeListViewModels->GetItemData(item));
+            if (mitem != nullptr && mitem->GetModel() == modelToSelect) {
+                TreeListViewModels->Select(item);
+                TreeListViewModels->EnsureVisible(item);
+                break;
+            }
+        }
+    }
+}
+
+
+// Unselect a Model in the tree, currently only unselects top level model if found
+void LayoutPanel::UnSelectModelInTree(Model* modelToUnSelect) {
+    for ( wxTreeListItem item = TreeListViewModels->GetFirstItem();
+          item.IsOk();
+          item = TreeListViewModels->GetNextSibling(item) )
+    {
+        if (TreeListViewModels->GetItemData(item) != nullptr)
+        {
+            ModelTreeData *mitem = dynamic_cast<ModelTreeData*>(TreeListViewModels->GetItemData(item));
+            if (mitem != nullptr && mitem->GetModel() == modelToUnSelect) {
+                TreeListViewModels->Unselect(item);
+                break;
+            }
+        }
+    }
+}
+
+// Select a BaseObject in the model tree
+void LayoutPanel::SelectBaseObjectInTree(BaseObject* baseObjectToSelect) {
+    Model* modelToSelect = dynamic_cast<Model*>(baseObjectToSelect);
+    SelectModelInTree(modelToSelect);
+}
+
+// Perform unselect of tree item by BaseObject
+void LayoutPanel::UnSelectBaseObjectInTree(BaseObject* baseObjectToUnSelect) {
+    Model* modelToUnSelect = dynamic_cast<Model*>(baseObjectToUnSelect);
+    UnSelectModelInTree(modelToUnSelect);
+}
+
+// Shortcut to get model pointer from tree item
+Model* LayoutPanel::GetModelFromTreeItem(wxTreeListItem treeItem) {
+    ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(treeItem);
+    Model* model = ((data != nullptr) ? data->GetModel() : nullptr);
+    return model;
+}
+
+// Get first tree item for a model, 'first' is the key word as a model pointer could exist in numerous
+// places in model tree.
+wxTreeListItem LayoutPanel::GetTreeItemFromModel(Model* model) {
+    wxTreeListItem modelTreeItem = nullptr;
+    for (wxTreeListItem item = TreeListViewModels->GetFirstItem(); item.IsOk(); item = TreeListViewModels->GetNextItem(item)) {
+        ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(item);
+        Model* itemModel = ((data != nullptr) ? data->GetModel() : nullptr);
+        if (model == itemModel) {
+            modelTreeItem = item;
+            break;
+        }
+    }
+    
+    return modelTreeItem;
+}
+
+// Get unique models from selected tree model group included those deeply nested
+std::vector<Model *> LayoutPanel::GetSelectedModelsFromGroup(wxTreeListItem groupItem, bool nested) {
+    std::vector<Model *> groupModels;
+    
+    if (groupItem.IsOk()) {
+        for (wxTreeListItem item = TreeListViewModels->GetFirstChild(groupItem);
+              item.IsOk();
+              item = TreeListViewModels->GetNextSibling(item) )
+        {
+            ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(item);
+            Model* model = ((data != nullptr) ? data->GetModel() : nullptr);
+            
+            if (model->GetDisplayAs() == "ModelGroup" && nested == true) {
+                std::vector<Model *> nestedModels = GetSelectedModelsFromGroup(item, true);
+                for (Model* nestedModel: nestedModels) {
+                    if (std::find(groupModels.begin(), groupModels.end(), nestedModel) != groupModels.end()) {
+                        groupModels.push_back(nestedModel);
+                    }
+                }
+            } else {
+                if (std::find(groupModels.begin(), groupModels.end(), model) == groupModels.end()) {
+                    groupModels.push_back(model);
+                }
+            }
+        }
+
+    }
+    
+    return groupModels;
+}
+
+// The will return unique selected models for edit, useful when groups are also selected in model tree
+std::vector<Model*> LayoutPanel::GetSelectedModelsForEdit() {
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    wxStopWatch sw;
+    std::vector<Model*> modelsForEdit;
+
+    for (const auto& groupItem : mSelectedGroups) {
+        std::vector<Model*> groupModels = GetSelectedModelsFromGroup(groupItem);
+        for (Model* model: groupModels) {
+            if (std::find(modelsForEdit.begin(), modelsForEdit.end(), model) == modelsForEdit.end()) {
+                if (model->GetDisplayAs() != "SubModel") {
+                    modelsForEdit.push_back(model);
+                }
+            }
+        }
+    }
+    
+    for (const auto& modelItem : mSelectedModels) {
+        Model* model = GetModelFromTreeItem(modelItem);
+        if (std::find(modelsForEdit.begin(), modelsForEdit.end(), model) == modelsForEdit.end()) {
+            modelsForEdit.push_back(model);
+        }
+    }
+    
+    logger_base.debug("GetSelectedModelsForEdit found in %ldms", sw.Time());
+    
+    return modelsForEdit;
+}
+
+// Get paths for selected models in tree so they can be reselected after refresh
+std::vector<std::list<std::string>> LayoutPanel::GetSelectedTreeModelPaths() {
+    std::vector<std::list<std::string>> modelPaths;
+    
+    // Add selectedBaseTreeItem first if exists
+    if (selectedBaseTreeItem != nullptr && selectedBaseTreeItem.IsOk()) {
+        std::list<std::string> baseItemPath = GetTreeItemPath(selectedBaseTreeItem);
+        modelPaths.push_back(baseItemPath);
+    }
+    
+    for (const auto& item : mSelectedGroups) {
+        std::list<std::string> modelPath = GetTreeItemPath(item);
+        modelPaths.push_back(modelPath);
+    }
+
+    for (const auto& item : mSelectedModels) {
+        std::list<std::string> modelPath = GetTreeItemPath(item);
+        modelPaths.push_back(modelPath);
+    }
+
+    for (const auto& item : mSelectedSubModels) {
+        std::list<std::string> modelPath = GetTreeItemPath(item);
+        modelPaths.push_back(modelPath);
+    }
+
+    return modelPaths;
+}
+
+std::list<std::string> LayoutPanel::GetTreeItemPath(wxTreeListItem item) {
+    std::list<std::string> itemPath;
+    wxTreeListItem root = TreeListViewModels->GetRootItem();
+    itemPath.push_back(TreeListViewModels->GetItemText(item));
+    wxTreeListItem parent = TreeListViewModels->GetItemParent(item);
+    while (parent.IsOk() && parent != root) {
+        itemPath.push_front(TreeListViewModels->GetItemText(parent));
+        parent = TreeListViewModels->GetItemParent(parent);
+    }
+    
+    return itemPath;
+}
+
+wxTreeListItem LayoutPanel::GetTreeItemBranch(wxTreeListItem parent, std::string branchName) {
+    wxTreeListItem branch = TreeListViewModels->GetFirstChild(parent);
+    bool branchFound = false;
+    while(branch.IsOk() && !branchFound) {
+        if (branchName == TreeListViewModels->GetItemText(branch)) {
+            branchFound = true;
+        } else {
+            branch = TreeListViewModels->GetNextSibling(branch);
+        }
+    }
+    
+    return branch;
+}
+
+void LayoutPanel::ReselectTreeModels(std::vector<std::list<std::string>> modelPaths) {
+    static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    
+    for (auto path : modelPaths) {
+        // model name is last string in path
+        std::string modelName = path.back();
+        path.pop_back();
+        wxTreeListItem branch = TreeListViewModels->GetRootItem();
+        for (auto part : path) {
+            branch = GetTreeItemBranch(branch, part);
+        }
+        
+        if (branch != nullptr && branch.IsOk()) {
+            for (wxTreeListItem child = TreeListViewModels->GetFirstChild(branch); child.IsOk(); child = TreeListViewModels->GetNextSibling(child)) {
+                std::string childName = TreeListViewModels->GetItemText(child);
+                if (TreeListViewModels->GetItemText(child) == modelName) {
+                    TreeListViewModels->Select(child);
+                }
+            }
+        } else {
+            logger_base.crit("LayoutPanel::ReselectTreeModels Model could not be found in tree... this shouldn't happen.");
+        }
+    }
+}
+
 int LayoutPanel::ModelsSelectedCount() const
 {
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    wxStopWatch sw;
     int selectedModelCount = 0;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
@@ -5030,6 +5121,9 @@ int LayoutPanel::ModelsSelectedCount() const
             selectedModelCount++;
         }
     }
+    
+    logger_base.debug("ModelsSelectedCount() found in %ldms", sw.Time());
+    
     return selectedModelCount;
 }
 
@@ -5560,14 +5654,14 @@ void LayoutPanel::OnCharHook(wxKeyEvent& event) {
             else
 #endif
 				if (editing_models)
-					DeleteSelectedModel();
+					DeleteSelectedModels();
 				else
 					DeleteSelectedObject();
             event.StopPropagation();
             break;
         case WXK_BACK:
 			if (editing_models)
-				DeleteSelectedModel();
+				DeleteSelectedModels();
 			else
 				DeleteSelectedObject();
             event.StopPropagation();
@@ -5635,47 +5729,44 @@ ModelGroup* LayoutPanel::GetSelectedModelGroup() const
     return res;
 }
 
-void LayoutPanel::DeleteSelectedModel() {
+void LayoutPanel::DeleteSelectedModels() {
 
-    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-
-    if( selectedBaseObject != nullptr && !selectedBaseObject->GetBaseObjectScreenLocation().IsLocked()) {
+    if (selectedBaseObject != nullptr && !selectedBaseObject->GetBaseObjectScreenLocation().IsLocked()) {
 
         xlights->AddTraceMessage("LayoutPanel::Delete Selected Model");
 
-        // we suspend deferred work because if the delete model pops a dialog then the ASAP work gets done prematurely
-        xlights->GetOutputModelManager()->SuspendDeferredWork(true);
-        xlights->UnselectEffect(); // we do this just in case the effect is on the model we are deleting
-
-        CreateUndoPoint("All", selectedBaseObject->name);
-
-        // This should delete all selected models
-        bool selectedModelFound = false;
-        for (size_t i = 0; i<modelPreview->GetModels().size(); i++) {
-            if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected) {
-                // Trying to trace a crash that shows up in RemoveModelFromLists
-                xlights->AddTraceMessage(wxString::Format("LayoutPanel::Delete Selected Model : %s", modelPreview->GetModels()[i]->name));
-                if (!selectedModelFound && modelPreview->GetModels()[i] == selectedBaseObject) {
-                    selectedModelFound = true;
-                }
-                xlights->GetDisplayElementsPanel()->RemoveModelFromLists(modelPreview->GetModels()[i]->name);
-                xlights->AllModels.Delete(modelPreview->GetModels()[i]->name);
+        wxArrayString modelsToDelete;
+        wxString modelsToConfirm = "";
+        for (const auto& item : mSelectedModels) {
+            if (item.IsOk()) {
+                wxString modelName = TreeListViewModels->GetItemText(item);
+                modelsToDelete.Add(modelName);
+                modelsToConfirm = modelsToConfirm + wxString::Format("%s- %s\n", "    ", modelName);
             }
         }
+                
+        if (wxMessageBox("Are you sure you want to delete the folowing model(s)?:\n\n" + modelsToConfirm, "Confirm Delete?", wxICON_QUESTION | wxYES_NO) == wxYES) {
+            
+            // we suspend deferred work because if the delete model pops a dialog then the ASAP work gets done prematurely
+            xlights->GetOutputModelManager()->SuspendDeferredWork(true);
+            xlights->UnselectEffect(); // we do this just in case the effect is on the model we are deleting
+            
+            CreateUndoPoint("All", wxJoin(modelsToDelete, ','));
+                    
+            for (const auto& it: modelsToDelete) {
+                xlights->GetDisplayElementsPanel()->RemoveModelFromLists(it);
+                xlights->AllModels.Delete(it);
+                xlights->AddTraceMessage(wxString::Format("LayoutPanel::Delete Selected Model : %s", it));
+            }
 
-        if (!selectedModelFound){
-            logger_base.debug("This is really suspicious ... why did we not find the selected model when we went through the list ... maybe this will crash");
-            xlights->GetDisplayElementsPanel()->RemoveModelFromLists(selectedBaseObject->name);
-            xlights->AllModels.Delete(selectedBaseObject->name);
+            selectedBaseObject = nullptr;
+
+            xlights->GetOutputModelManager()->SuspendDeferredWork(false);
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::DeleteSelectedModels");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DeleteSelectedModels");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::DeleteSelectedModels");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "LayoutPanel::DeleteSelectedModels");
         }
-
-        selectedBaseObject = nullptr;
-
-        xlights->GetOutputModelManager()->SuspendDeferredWork(false);
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::DeleteSelectedModel");
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DeleteSelectedModel");
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::DeleteSelectedModel");
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "LayoutPanel::DeleteSelectedModel");
     }
 }
 
@@ -5751,23 +5842,11 @@ void LayoutPanel::ReplaceModel()
 
 void LayoutPanel::LockSelectedModels(bool lock)
 {
-    bool selectedModelFound = false;
-    for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GroupSelected)
-        {
-            if (!selectedModelFound && modelPreview->GetModels()[i]->name == selectedBaseObject->name)
-            {
-                selectedModelFound = true;
-            }
+    for (const auto& modelItem : mSelectedModels) {
+        Model* model = GetModelFromTreeItem(modelItem);
+        model->Lock(lock);
+    }
 
-            modelPreview->GetModels()[i]->Lock(lock);
-        }
-    }
-    if (!selectedModelFound)
-    {
-        selectedBaseObject->Lock(lock);
-    }
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::LockSelectedModels");
 }
 
@@ -5794,7 +5873,7 @@ void LayoutPanel::DoCut(wxCommandEvent& event) {
     } else if (selectedBaseObject != nullptr) {
         DoCopy(event);
 		if (editing_models)
-			DeleteSelectedModel();
+			DeleteSelectedModels();
 		else
 			DeleteSelectedObject();
     }
@@ -6215,25 +6294,38 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
     if (id == ID_MNU_DELETE_MODEL)
     {
         logger_base.debug("LayoutPanel::OnModelsPopup DELETE_MODEL");
-        DeleteSelectedModel();
+        DeleteSelectedModels();
     }
     else if (id == ID_MNU_DELETE_MODEL_GROUP)
     {
         logger_base.debug("LayoutPanel::OnModelsPopup DELETE_MODEL_GROUP");
-        if (mSelectedGroup.IsOk()) {
-            wxString name = TreeListViewModels->GetItemText(mSelectedGroup);
-            if (wxMessageBox("Are you sure you want to remove the " + name + " group?", "Confirm Remove?", wxICON_QUESTION | wxYES_NO) == wxYES) {
-                xlights->UnselectEffect(); // we do this just in case the effect is on the model we are deleting
-                xlights->AllModels.Delete(name.ToStdString());
-                selectedBaseObject = nullptr;
-                mSelectedGroup = nullptr;
-                UnSelectAllModels();
-                //ShowPropGrid(true);
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
-                xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::OnPreviewModelPopup::ID_MNU_DELETE_MODEL_GROUP");
+        
+        wxArrayString groupsToDelete;
+        wxString groupsToConfirm = "";
+        for (const auto& item : mSelectedGroups) {
+            if (item.IsOk()) {
+                wxString groupName = TreeListViewModels->GetItemText(item);
+                groupsToDelete.Add(groupName);
+                groupsToConfirm = groupsToConfirm + wxString::Format("%s- %s\n", "    ", groupName);
             }
+        }
+        
+        wxString namesToDelete = wxJoin(groupsToDelete, ',');
+        
+        if (wxMessageBox("Are you sure you want to delete the following group(s)?:\n\n" + groupsToConfirm, "Confirm Remove?", wxICON_QUESTION | wxYES_NO) == wxYES) {
+            
+            CreateUndoPoint("All", wxJoin(groupsToDelete, ','));
+
+            xlights->UnselectEffect(); // we do this just in case the effect is on the model we are deleting
+            for (const auto& it: groupsToDelete) {
+                xlights->AllModels.Delete(it.ToStdString());
+            }
+            UnSelectAllModels();
+            
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_MODEL_GROUP");
+            xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::OnPreviewModelPopup::ID_MNU_DELETE_MODEL_GROUP");
         }
     }
     else if (id == ID_MNU_DELETE_EMPTY_MODEL_GROUPS)
@@ -6266,9 +6358,8 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
             }
         }
 
-        mSelectedGroup = nullptr;
         UnSelectAllModels();
-        //ShowPropGrid(true);
+
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_EMPTY_MODEL_GROUPS");
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_EMPTY_MODEL_GROUPS");
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::OnModelsPopup::ID_MNU_DELETE_EMPTY_MODEL_GROUPS");
@@ -6307,8 +6398,7 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
                     }
                 }
             }
-            //xlights->RecalcModels(true);
-            //xlights->UpdateModelsList();
+
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCVALID");
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCVALID");
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCVALID");
@@ -6348,8 +6438,7 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
                     }
                 }
             }
-            //xlights->RecalcModels(true);
-            //xlights->UpdateModelsList();
+
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCNOTOVERLAPPING");
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCNOTOVERLAPPING");
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnModelsPopup::ID_MNU_MAKEALLSCNOTOVERLAPPING");
@@ -6392,8 +6481,8 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
     else if (id == ID_MNU_RENAME_MODEL_GROUP)
     {
         logger_base.debug("LayoutPanel::OnModelsPopup RENAME_MODEL_GROUP");
-        if (mSelectedGroup.IsOk()) {
-            wxString sel = TreeListViewModels->GetItemText(mSelectedGroup);
+        if (mSelectedGroups[0].IsOk()) {
+            wxString sel = TreeListViewModels->GetItemText(mSelectedGroups[0]);
             wxTextEntryDialog dlg(this, "Enter new name for group " + sel, "Rename " + sel, sel);
             OptimiseDialogPosition(&dlg);
             if (dlg.ShowModal() == wxID_OK) {
@@ -6413,11 +6502,9 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
                 xlights->RenameModel(sel.ToStdString(), name.ToStdString());
                 model_grp_panel->UpdatePanel(name.ToStdString());
 
-                //xlights->UpdateModelsList();
                 xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::OnModelsPopup::ID_MNU_RENAME_MODEL_GROUP", nullptr, nullptr, name.ToStdString());
                 xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::OnModelsPopup::ID_MNU_RENAME_MODEL_GROUP");
                 xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnModelsPopup::ID_MNU_RENAME_MODEL_GROUP");
-                //model_grp_panel->UpdatePanel(name.ToStdString());
             }
         }
     }
@@ -6462,7 +6549,7 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
     {
         logger_base.debug("LayoutPanel::OnModelsPopup CLONE_MODEL_GROUP");
 
-        wxString sel = TreeListViewModels->GetItemText(mSelectedGroup);
+        wxString sel = TreeListViewModels->GetItemText(mSelectedGroups[0]);
         ModelGroup* mg = dynamic_cast<ModelGroup*>(xlights->AllModels.GetModel(sel));
         if (mg == nullptr) return;
         std::string name = xlights->AllModels.GenerateModelName(sel);
@@ -6913,48 +7000,48 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
     }
 
     wxMenu mnuContext;
-    wxTreeListItem item = event.GetItem();
-    if (item.IsOk()) {
-        ModelTreeData* data = dynamic_cast<ModelTreeData*>(TreeListViewModels->GetItemData(item));
-        Model* model = data != nullptr ? data->GetModel() : nullptr;
-        if (model != nullptr) {
-            if (model->GetDisplayAs() == "ModelGroup") {
-                mSelectedGroup = item;
-            }
-            else {
-                mSelectedGroup = nullptr;
-                SelectModel(model, false);
-            }
-        }
-    }
-    else {
-        return;
-    }
 
-    Model* selectedModel = dynamic_cast<Model*>(selectedBaseObject);
-    if (selectedModel != nullptr && selectedModel->GetDisplayAs() != "SubModel") {
-        mnuContext.Append(ID_MNU_DELETE_MODEL, "Delete");
-        mnuContext.AppendSeparator();
+    if (mSelectedGroups.size() == 0 && mSelectedSubModels.size() == 0) {
+        if (mSelectedModels.size() == 1) {
+            mnuContext.Append(ID_MNU_DELETE_MODEL, "Delete Model");
+            mnuContext.AppendSeparator();
+        }
+        
+        if (mSelectedModels.size() > 1) {
+            mnuContext.Append(ID_MNU_DELETE_MODEL, "Delete Models");
+            mnuContext.AppendSeparator();
+        }
     }
 
     mnuContext.Append(ID_MNU_ADD_MODEL_GROUP, "Add Group");
-    if (mSelectedGroup.IsOk()) {
-        mnuContext.Append(ID_MNU_DELETE_MODEL_GROUP, "Delete Group");
-        mnuContext.Append(ID_MNU_RENAME_MODEL_GROUP, "Rename Group");
-        mnuContext.Append(ID_MNU_CLONE_MODEL_GROUP, "Clone Group");
+
+    if (mSelectedModels.size() == 0 && mSelectedSubModels.size() == 0) {
+        if (mSelectedGroups.size() > 1) {
+            mnuContext.Append(ID_MNU_DELETE_MODEL_GROUP, "Delete Groups");
+        }
+        
+        if (mSelectedGroups.size() == 1) {
+            mnuContext.Append(ID_MNU_DELETE_MODEL_GROUP, "Delete Group");
+            mnuContext.Append(ID_MNU_RENAME_MODEL_GROUP, "Rename Group");
+            mnuContext.Append(ID_MNU_CLONE_MODEL_GROUP, "Clone Group");
+        }
     }
+
     mnuContext.Append(ID_MNU_DELETE_EMPTY_MODEL_GROUPS, "Delete Empty Groups");
 
     bool foundInvalid = false;
     bool foundOverlapping = false;
-    if (selectedModel != nullptr && selectedModel->GetDisplayAs() != "SubModel" && selectedModel->GetDisplayAs() != "ModelGroup")
-    {
-        if (!selectedModel->CouldComputeStartChannel || !selectedModel->IsValidStartChannelString())
+
+    if (mSelectedModels.size() == 1 && mSelectedSubModels.size() == 0 && mSelectedGroups.size() == 0) {
+        ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(mSelectedModels[0]);
+        Model* model = ((data != nullptr) ? data->GetModel() : nullptr);
+
+        if (!model->CouldComputeStartChannel || !model->IsValidStartChannelString())
         {
             mnuContext.Append(ID_MNU_MAKESCVALID, "Make Start Channel Valid");
             foundInvalid = true;
         }
-        if (xlights->AllModels.IsModelOverlapping(selectedModel))
+        if (xlights->AllModels.IsModelOverlapping(model))
         {
             foundOverlapping = true;
             mnuContext.Append(ID_MNU_MAKESCVALID, "Make Start Channel Not Overlapping");
@@ -7005,64 +7092,143 @@ static inline void SetToolTipForTreeList(wxTreeListCtrl *tv, const std::string &
 
 void LayoutPanel::OnSelectionChanged(wxTreeListEvent& event)
 {
+    // Even when Tree is Frozen which happens during full refresh this event is still fired for the individual DeleteItem()
+    // calls that happen in UpdateModelList() and ModelGroupUpdate() and randomly causes a crash when SelectModel() below is called,
+    // so we need to bail when Frozen.  If DeleteAllItems() is called then this check doesn't seem to be need.  We also make sure tooltip
+    // is empty and property grid is shown so background props show after full refresh since we are bailing before logic below.
+    if (TreeListViewModels->IsFrozen()) {
+        ShowPropGrid(true);
+        SetToolTipForTreeList(TreeListViewModels, "");
+        return;
+    }
+    
+    BaseObject* lastSelectedBaseObject = selectedBaseObject;
     UnSelectAllModels(false);
+
     if (editing_models) {
         wxTreeListItems selectedItems;
-        unsigned numSelected = TreeListViewModels->GetSelections( selectedItems );
-        if (numSelected > 1)
-        {
-            SelectModels(selectedItems);
-            return;
-        }
-
-        // with multiple selection enabled, event's item may be one that is unselected
-        wxTreeListItem item = ( numSelected == 1 ) ? selectedItems[0] : event.GetItem();
-        if (item.IsOk()) {
-
-            ModelTreeData *data = (ModelTreeData*)TreeListViewModels->GetItemData(item);
-            Model *model = ((data != nullptr) ? data->GetModel() : nullptr);
-            if (model != nullptr) {
-#ifdef __LINUX__
-                // This seems to happen only on Linux so prevent the crash
-                if (!xlights->AllModels.IsModelValid(model)) {
-                    log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-                    logger_base.debug("LINUX ONLY Error: LayoutPanel::OnSelectionChanged Model is Not Valid pointer. This would have crashed. Ignoring.");
-                    return;
+        TreeListViewModels->GetSelections(selectedItems);
+        wxTreeListItem item = event.GetItem();
+        
+        Model* lastSelectedModel = dynamic_cast<Model*>(lastSelectedBaseObject);
+        Model* baseObjectToSelect = nullptr;
+        bool updateModelList = false;
+        
+        if (item.IsOk() && selectedItems.size() > 0) {
+            for (const auto& item : selectedItems) {
+                Model* model = GetModelFromTreeItem(item);
+                if (model != nullptr) {
+                    #ifdef __LINUX__
+                                    // This seems to happen only on Linux so prevent the crash
+                                    if (!xlights->AllModels.IsModelValid(model)) {
+                                        log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+                                        logger_base.debug("LINUX ONLY Error: LayoutPanel::OnSelectionChanged Model is Not Valid pointer. This would have crashed. Ignoring.");
+                                        return;
+                                    }
+                    #elif defined(__WXOSX__)
+                                    // Given I am seeing these crashes on OSX but not windows I suspect like LINUX these crashes occur
+                                    // If is likely due to differences in the order messages arrive on the different platforms that results in invalid pointers
+                                    // This code will prove that theory
+                                    if (!xlights->AllModels.IsModelValid(model)) {
+                                        log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+                                        logger_base.crit("LayoutPanel::OnSelectionChanged model was not valid ... this is going to crash.");
+                                    }
+                    #else
+                                    wxASSERT(xlights->AllModels.IsModelValid(model));
+                    #endif
+                    if (model->GetDisplayAs() == "ModelGroup") {
+                        mSelectedGroups.push_back(item);
+                        updateModelList = true;
+                    } else if (model->GetDisplayAs() == "SubModel") {
+                        mSelectedSubModels.push_back(item);
+                        model->GroupSelected = true;
+                    } else {
+                        mSelectedModels.push_back(item);
+                        if (model == lastSelectedModel || lastSelectedBaseObject == nullptr) {
+                            baseObjectToSelect = model;
+                            selectedBaseTreeItem = item;
+                        } else {
+                            model->Selected = false;
+                            model->Highlighted = true;
+                            model->GroupSelected = true;
+                            model->SelectHandle(-1);
+                            model->GetBaseObjectScreenLocation().SetActiveHandle(-1);
+                        }
+                    }
                 }
-#elif defined(__WXOSX__)
-                // Given I am seeing these crashes on OSX but not windows I suspect like LINUX these crashes occur
-                // If is likely due to differences in the order messages arrive on the different platforms that results in invalid pointers
-                // This code will prove that theory
-                if (!xlights->AllModels.IsModelValid(model)) {
-                    log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-                    logger_base.crit("LayoutPanel::OnSelectionChanged model was not valid ... this is going to crash.");
-                }
-#else
-                wxASSERT(xlights->AllModels.IsModelValid(model));
-#endif
-                if (model->GetDisplayAs() == "ModelGroup") {
-                    mSelectedGroup = item;
-                    ShowPropGrid(false);
-                    UpdateModelList(false);
-                    model_grp_panel->UpdatePanel(model->name);
-                } else {
-                    mSelectedGroup = nullptr;
-                    ShowPropGrid(true);
-                    SelectModel(model, false);
-                    SetToolTipForTreeList(TreeListViewModels,
-                        xlights->GetChannelToControllerMapping(model->GetNumberFromChannelString(model->ModelStartChannel)) + "Nodes: " + wxString::Format("%d", (int)model->GetNodeCount()).ToStdString());
-                }
-            } else {
-                mSelectedGroup = nullptr;
-                selectedBaseObject = nullptr;
-                ShowPropGrid(true);
-                UnSelectAllModels(true);
-                SetToolTipForTreeList(TreeListViewModels, "");
             }
+            
+            // base selection has changed, see if we have another model to select
+            if (!baseObjectToSelect) {
+                if (mSelectedModels.size() > 0) {
+                    for (const auto& item : selectedItems) {
+                        if (item == mSelectedModels[0]) {
+                            baseObjectToSelect = GetModelFromTreeItem(mSelectedModels[0]);
+                            selectedBaseTreeItem = item;
+                        }
+                    }
+                } else if (mSelectedSubModels.size() > 0) {
+                    for (const auto& item : selectedItems) {
+                        if (item == mSelectedSubModels[0]) {
+                            baseObjectToSelect = GetModelFromTreeItem(mSelectedSubModels[0]);
+                        }
+                    }
+                }
+
+            }
+                      
+            // determine which panel and tooltip to show if any
+            int mSize = mSelectedModels.size();
+            int gSize = mSelectedGroups.size();
+            int smSize = mSelectedSubModels.size();
+            int totalSelections = mSize + smSize + gSize;
+            std::string tooltip = "";
+            
+            if (totalSelections > 1) {
+                ShowPropGrid(false);
+                model_grp_panel->UpdatePanel("");
+                model_grp_panel->Hide();
+                tooltip = wxString::Format("Selected Items:\n -Groups: %d\n -Models: %d\n -SubModels: %d\n", gSize, mSize, smSize);
+            } else if (gSize == 1) {
+                ShowPropGrid(false);
+                model_grp_panel->UpdatePanel(TreeListViewModels->GetItemText(mSelectedGroups[0]));
+                model_grp_panel->Show();
+            } else if (smSize == 1) {
+                model_grp_panel->Hide();
+                ShowPropGrid(true);
+            } else if (mSize == 1) {
+                model_grp_panel->Hide();
+                Model* model = GetModelFromTreeItem(mSelectedModels[0]);
+                if (model != nullptr) {
+                    tooltip = xlights->GetChannelToControllerMapping(model->GetNumberFromChannelString(model->ModelStartChannel)) + "Nodes: " + wxString::Format("%d", (int)model->GetNodeCount()).ToStdString();
+                    ShowPropGrid(true);
+                }
+            }
+            
+            SetToolTipForTreeList(TreeListViewModels, tooltip);
+            
+            // Update model list if 1 or more groups have been selected
+            if (updateModelList == true) {
+                UpdateModelList(false);
+            }
+            
+            // Select base model last so we are sure all changes to selections have been handled before WORK_REDRAW_LAYOUTPREVIEW is performed by SelectModel()
+            if (baseObjectToSelect != nullptr) {
+                SelectModel(baseObjectToSelect, false);
+                if (baseObjectToSelect->GetDisplayAs() == "SubModel") {
+                    baseObjectToSelect->Selected = false;
+                }
+            }
+            
             #ifndef LINUX
             TreeListViewModels->SetFocus();
             #endif
+            
+            //xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::OnSelectionChanged");
         } else {
+            selectedBaseObject = nullptr;
+            UnSelectAllModels(true);
+            ShowPropGrid(true);
             SetToolTipForTreeList(TreeListViewModels, "");
         }
     } else {
@@ -7085,7 +7251,7 @@ void LayoutPanel::ModelGroupUpdated(ModelGroup *grp, bool full_refresh) {
     std::vector<Model *> models;
     UpdateModelList(full_refresh, models);
 
-    UnSelectAllModels();
+    // UnSelectAllModels();
 
     if (full_refresh) return;
 

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -330,6 +330,9 @@ class LayoutPanel: public wxPanel
         wxTreeListItem GetTreeItemFromModel(Model* model);
         std::vector<Model*> GetSelectedModelsFromGroup(wxTreeListItem groupItem, bool nested = true);
         std::vector<Model*> GetSelectedModelsForEdit();
+        void SetTreeModelSelected(Model* model, bool isPrimary);
+        void SetTreeGroupModelsSelected(Model* model, bool isPrimary);
+        void SetTreeSubModelSelected(Model* model, bool isPrimary);
         std::vector<std::list<std::string>> GetSelectedTreeModelPaths();
         std::list<std::string> GetTreeItemPath(wxTreeListItem item);
         wxTreeListItem GetTreeItemBranch(wxTreeListItem parent, std::string branchName);
@@ -369,17 +372,15 @@ class LayoutPanel: public wxPanel
         int mHitTestNextSelectModelIndex;
         int mNumGroups;
         bool mPropGridActive;
-        wxTreeListItem mSelectedGroup;
-        wxTreeListItems mSelectedGroups;
-        wxTreeListItems mSelectedModels;
-        wxTreeListItems mSelectedSubModels;
-        wxTreeListItems selectedTreeViewObjects;
+        wxTreeListItems selectedTreeGroups;
+        wxTreeListItems selectedTreeModels;
+        wxTreeListItems selectedTreeSubModels;
 
         wxPropertyGrid *propertyEditor = nullptr;
         bool updatingProperty;
         BaseObject *selectedBaseObject = nullptr;
         BaseObject *highlightedBaseObject = nullptr;
-        wxTreeListItem selectedBaseTreeItem = nullptr;
+        wxTreeListItem selectedPrimaryTreeItem = nullptr;
         bool selectionLatched;
         int over_handle;
         glm::vec3 last_centerpos;

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -33,6 +33,7 @@ class wxStaticText;
 
 #include <vector>
 #include <list>
+#include <map>
 
 class xLightsFrame;
 class ModelPreview;
@@ -246,7 +247,7 @@ class LayoutPanel: public wxPanel
         void DoCut(wxCommandEvent& event);
         void DoPaste(wxCommandEvent& event);
         void DoUndo(wxCommandEvent& event);
-        void DeleteSelectedModel();
+        void DeleteSelectedModels();
 		void DeleteSelectedObject();
         void LockSelectedModels(bool lock);
         void PreviewSaveImage();
@@ -325,6 +326,18 @@ class LayoutPanel: public wxPanel
         int ModelsSelectedCount() const;
         int ViewObjectsSelectedCount() const;
         int GetSelectedModelIndex() const;
+        Model* GetModelFromTreeItem(wxTreeListItem treeItem);
+        wxTreeListItem GetTreeItemFromModel(Model* model);
+        std::vector<Model*> GetSelectedModelsFromGroup(wxTreeListItem groupItem, bool nested = true);
+        std::vector<Model*> GetSelectedModelsForEdit();
+        std::vector<std::list<std::string>> GetSelectedTreeModelPaths();
+        std::list<std::string> GetTreeItemPath(wxTreeListItem item);
+        wxTreeListItem GetTreeItemBranch(wxTreeListItem parent, std::string branchName);
+        void ReselectTreeModels(std::vector<std::list<std::string>> modelPaths);
+        void SelectModelInTree(Model* modelToSelect);
+        void SelectBaseObjectInTree(BaseObject* baseObjectToSelect);
+        void UnSelectModelInTree(Model* modelToUnSelect);
+        void UnSelectBaseObjectInTree(BaseObject* baseObjectToUnSelect);
         std::list<BaseObject*> GetSelectedBaseObjects() const;
         void PreviewModelAlignWithGround();
         void PreviewModelAlignTops();
@@ -357,11 +370,16 @@ class LayoutPanel: public wxPanel
         int mNumGroups;
         bool mPropGridActive;
         wxTreeListItem mSelectedGroup;
+        wxTreeListItems mSelectedGroups;
+        wxTreeListItems mSelectedModels;
+        wxTreeListItems mSelectedSubModels;
+        wxTreeListItems selectedTreeViewObjects;
 
         wxPropertyGrid *propertyEditor = nullptr;
         bool updatingProperty;
         BaseObject *selectedBaseObject = nullptr;
         BaseObject *highlightedBaseObject = nullptr;
+        wxTreeListItem selectedBaseTreeItem = nullptr;
         bool selectionLatched;
         int over_handle;
         glm::vec3 last_centerpos;


### PR DESCRIPTION
Add multi-select for tree view for all types, model/group/submodel, and keep in sync with model preview selections.  There is a lot here, I think it's pretty solid and but will monitor any issues closely after the next release.

Aside from the obvious, multi-select for all tree view items synced with preview selections, there are a few minor changes/fixes/enhancements whatever you want to call them...

- context menu in tree is aware of multiselect, delete group vs delete groups etc.
- prior context menu 'Delete Group' actually deleted all models in the group as well which I don't think was the intent as it bit me a few times on accident vs 'Delete Group'.  It is now labeled 'Delete Model / Delete Model's' and will only show up if models are selected and will only delete models, not groups.
- Prompt to confirm Model / Group delete with a list of models/groups that will be deleted in prompt.
- SubModels when selected in tree now highlight in preview, prior sub models would only highlight if they were part of a group and the group was selected
- Submodels can be selected in tree and if 'Create Group' is selected with at least 1 model selected they will be added to the newly created group.  I plan to change logic in context menu to allow group creation when only subs are selected which may be more convenient then finding them in the model group panel for large displays.
- Create Group takes all tree selections into consideration vs only the models selected in preview so if you selected 2 groups in tree, 2 submodels and 2 models all will be added to the new group.
- Besides group creation, selected submodels are ignored for all other preview right click actions, bulk edit, align, active, etc as would be expected.
- Non-3D multi-select now mirrors the same 3-click approach that Gil did for 3d, before if you had a model selected in 2D, CTRL+Click another model and then CTRL+clicked the second model without the handles prior selection was lost, now this mirrors what happens in 3D world.

TODO
- Add in appropriate model preview right click options to model tree menu
- 3D Objects tab.  I made sure business as usual on the objects tab until multi-select on Models tab is deemed stable, will adopt multi-select for ViewObjectList when it is.
- Build a new panel for when multiple selections exist which shows the currently selected items, right now if multiple selections are made the group panel and property grid are hidden so there is just a blank space.  Tooltip for Model List does show a summary of current selections for now.
- Monitor and fix any bugs I may have caused ;)