### PR TITLE
Fixes for multi select in tree

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2800,7 +2800,7 @@ bool LayoutPanel::SelectMultipleModels(int x,int y)
         modelPreview->GetModels()[found[0]]->Highlighted = true;
     }
 
-    // no need to do this work if tree selection changed as it is already done at the end of SelectionChanged();
+    // no need to do this work if tree selection changed as it is already done at the end of OnSelectionChanged();
     if (!treeSelectionChanged) {
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectMultipleModels");
     }
@@ -3033,7 +3033,7 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     }
                 }
                 
-                // no need to do this work if tree selection changed as it is already done at the end of SelectionChanged();
+                // no need to do this work if tree selection changed as it is already done at the end of OnSelectionChanged();
                 if (!treeSelectionChanged) {
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::ProcessLeftMouseClick3D");
                 }


### PR DESCRIPTION
Fixes:
- Revert 2d click behavior to what is was prior
- Check if selections > 0 in OnSelectionChange to resolve prop grid not showing issues
- Fix highlighting of deeply nested models