### PR TITLE
MSW fix for multi select

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -111,7 +111,6 @@ BEGIN_EVENT_TABLE(LayoutPanel,wxPanel)
 	//*)
     EVT_TREELIST_SELECTION_CHANGED(wxID_ANY, LayoutPanel::OnSelectionChanged)
     EVT_TREELIST_ITEM_CONTEXT_MENU(wxID_ANY, LayoutPanel::OnItemContextMenu)
-    EVT_TREE_SEL_CHANGED(wxID_ANY, LayoutPanel::OnTreeSelectionChanged)
     //EVT_TREELIST_ITEM_EXPANDING(wxID_ANY, LayoutPanel::OnItemExpanding)
     //EVT_TREELIST_ITEM_EXPANDED(wxID_ANY, LayoutPanel::OnSelectionChanged)
     //EVT_TREELIST_ITEM_CHECKED(wxID_ANY, LayoutPanel::OnItemChecked)
@@ -523,7 +522,6 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     TreeListViewModels->GetView()->Connect(wxID_PASTE, wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::DoPaste, nullptr,this);
     TreeListViewModels->GetView()->Connect(wxID_UNDO, wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::DoUndo, nullptr,this);
     TreeListViewModels->GetView()->Connect(wxID_ANY, wxEVT_CHAR_HOOK, wxKeyEventHandler(LayoutPanel::OnListCharHook), nullptr, this);
-
     wxScrolledWindow *sw = new wxScrolledWindow(ModelSplitter);
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sw->SetSizer(sizer);
@@ -7277,10 +7275,6 @@ void LayoutPanel::HandleSelectionChanged() {
         ShowPropGrid(true);
         SetToolTipForTreeList(TreeListViewModels, "");
     }
-}
-
-void LayoutPanel::OnTreeSelectionChanged(wxTreeEvent& event) {
-    std::cout << "selection changed \n";
 }
 
 void LayoutPanel::ModelGroupUpdated(ModelGroup *grp, bool full_refresh) {

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -111,6 +111,7 @@ BEGIN_EVENT_TABLE(LayoutPanel,wxPanel)
 	//*)
     EVT_TREELIST_SELECTION_CHANGED(wxID_ANY, LayoutPanel::OnSelectionChanged)
     EVT_TREELIST_ITEM_CONTEXT_MENU(wxID_ANY, LayoutPanel::OnItemContextMenu)
+    EVT_TREE_SEL_CHANGED(wxID_ANY, LayoutPanel::OnTreeSelectionChanged)
     //EVT_TREELIST_ITEM_EXPANDING(wxID_ANY, LayoutPanel::OnItemExpanding)
     //EVT_TREELIST_ITEM_EXPANDED(wxID_ANY, LayoutPanel::OnSelectionChanged)
     //EVT_TREELIST_ITEM_CHECKED(wxID_ANY, LayoutPanel::OnItemChecked)
@@ -2686,6 +2687,9 @@ bool LayoutPanel::SelectSingleModel(int x, int y)
     std::vector<int> found;
     int modelCount = FindModelsClicked(x, y, found);
     TreeListViewModels->UnselectAll();
+#ifdef __WXMSW__
+    HandleSelectionChanged();
+#endif
     if (modelCount == 0) {
         return false;
     } else if (modelCount == 1) {
@@ -2840,6 +2844,9 @@ void LayoutPanel::OnPreviewLeftDClick(wxMouseEvent& event)
 {
     if (editing_models) {
         TreeListViewModels->UnselectAll();
+#ifdef __WXMSW__
+        HandleSelectionChanged();
+#endif
     } else {
         UnSelectAllModels();
     }
@@ -7270,6 +7277,10 @@ void LayoutPanel::HandleSelectionChanged() {
         ShowPropGrid(true);
         SetToolTipForTreeList(TreeListViewModels, "");
     }
+}
+
+void LayoutPanel::OnTreeSelectionChanged(wxTreeEvent& event) {
+    std::cout << "selection changed \n";
 }
 
 void LayoutPanel::ModelGroupUpdated(ModelGroup *grp, bool full_refresh) {

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -26,6 +26,7 @@ class wxStaticText;
 
 #include "wxCheckedListCtrl.h"
 #include <wx/treelist.h>
+#include <wx/treectrl.h>
 #include <wx/xml/xml.h>
 #include <glm/glm.hpp>
 
@@ -485,6 +486,7 @@ class LayoutPanel: public wxPanel
         bool mouse_state_set;
 
         void OnSelectionChanged(wxTreeListEvent& event);
+        void OnTreeSelectionChanged(wxTreeEvent& event);
         void HandleSelectionChanged();
         void OnItemContextMenu(wxTreeListEvent& event);
 

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -486,7 +486,6 @@ class LayoutPanel: public wxPanel
         bool mouse_state_set;
 
         void OnSelectionChanged(wxTreeListEvent& event);
-        void OnTreeSelectionChanged(wxTreeEvent& event);
         void HandleSelectionChanged();
         void OnItemContextMenu(wxTreeListEvent& event);
 

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -485,6 +485,7 @@ class LayoutPanel: public wxPanel
         bool mouse_state_set;
 
         void OnSelectionChanged(wxTreeListEvent& event);
+        void HandleSelectionChanged();
         void OnItemContextMenu(wxTreeListEvent& event);
 
         static const long ID_MNU_DELETE_MODEL;


### PR DESCRIPTION
The issue with MSW is when TreeListViewModels->Select(), Unselect(), SelectAll() and UnselectAll() are called they do not fire the OnSelectionChanged() Event which is where all the logic is to keep track of current selections and keep things in sync.  On MSW the only time OnSelectionChanged() will fire is if you are actually clicking in the list control.

Seems to be a bug with wxWidgets for MSW.  Maybe there is a better way to solve this, but with mutli-select we really don't need the event object as the current selections aren't event part of the event object and it doesn't tell you what has changed in terms of selections, you have to call GetSelections() on tree control to get them.

Good to know I'm not entirely crazy insisting things were working fairly well on macOS.

I have not checked Linux yet but will do tonight.