### PR TITLE
Model Tree MultiSelect Fixes/Cleanup

### DIFF
--- a/xLights/ControllerConnectionDialog.cpp
+++ b/xLights/ControllerConnectionDialog.cpp
@@ -459,10 +459,10 @@ void ControllerConnectionDialog::Get(wxXmlNode* node) {
             if (CheckBox_PixelDirection->IsChecked()) node->AddAttribute("reverse", wxString::Format("%d", PixelDirection->GetSelection()));
         }
     }
-    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "ControllerConnectionDialog::Get");
-    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "ControllerConnectionDialog::Get");
-    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "ControllerConnectionDialog::Get");
-    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "ControllerConnectionDialog::Get");
+//    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "ControllerConnectionDialog::Get");
+//    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "ControllerConnectionDialog::Get");
+//    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "ControllerConnectionDialog::Get");
+//    xLightsApp::GetFrame()->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "ControllerConnectionDialog::Get");
 }
 
 void ControllerConnectionDialog::OnPixelDirectionClick(wxCommandEvent& event)

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5774,8 +5774,9 @@ void LayoutPanel::ReplaceModel()
 
 void LayoutPanel::LockSelectedModels(bool lock)
 {
-    for (const auto& modelItem : selectedTreeModels) {
-        Model* model = GetModelFromTreeItem(modelItem);
+    std::vector<Model*> modelsToLock = GetSelectedModelsForEdit();
+
+    for (const auto& model : modelsToLock) {
         model->Lock(lock);
     }
 

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1687,7 +1687,9 @@ void LayoutPanel::BulkEditControllerConnection(int id)
         }
         
         // see comment in BulkEditActive()
-        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "ControllerConnectionDialog::Get");
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "ControllerConnectionDialog::Get");
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "ControllerConnectionDialog::Get");
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerConnection");
         
         ReselectTreeModels(selectedModelPaths);
@@ -1789,11 +1791,12 @@ void LayoutPanel::BulkEditControllerName()
             model->SetControllerName(name);
         }
 
-        // see comment in BulkEditActive()
-        xlights->GetOutputModelManager()->ClearSelectedModel();
+        std::string sm = xlights->GetOutputModelManager()->GetSelectedModel();
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BulkEditControllerName");
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "BulkEditControllerName");
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerName");
-
-        // reselect all the models
+        xlights->GetOutputModelManager()->ForceSelectedModel(sm);
+        
         ReselectTreeModels(selectedModelPaths);
     }
 }

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5607,7 +5607,11 @@ void LayoutPanel::OnCharHook(wxKeyEvent& event) {
                 FinalizeModel();
             }
             else if (is_3d) {
-                UnSelectAllModels();
+                if (editing_models) {
+                    UnSelectAllModelsInTree();
+                } else {
+                    UnSelectAllModels();
+                }
             }
             break;
 

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1625,8 +1625,8 @@ void LayoutPanel::BulkEditDimmingCurves()
         }
         
         // If we don't do these as ImmediateWork then the Model Tree is still frozen and models don't get reselected after refresh
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BulkEditDimmingCurves");
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "BulkEditDimmingCurves");
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BulkEditDimmingCurves");
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "BulkEditDimmingCurves");
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditDimmingCurves");
         
         ReselectTreeModels(selectedModelPaths);
@@ -4457,7 +4457,8 @@ void LayoutPanel::PreviewModelAlignWithGround()
             modelPreview->GetModels()[i]->SetBottom(0.0f);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignWithGround");
+    
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignWithGround");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4497,9 +4498,8 @@ void LayoutPanel::PreviewModelAlignTops()
             modelPreview->GetModels()[i]->SetTop(top);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignTops");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignTops");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignTops", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignTops");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4520,9 +4520,8 @@ void LayoutPanel::PreviewModelAlignBottoms()
             modelPreview->GetModels()[i]->SetBottom(bottom);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBottoms");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBottoms");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBottoms", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBottoms");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4543,9 +4542,8 @@ void LayoutPanel::PreviewModelAlignLeft()
             modelPreview->GetModels()[i]->SetLeft(left);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignLeft");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignLeft");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignLeft", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignLeft");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4566,9 +4564,8 @@ void LayoutPanel::PreviewModelAlignFronts()
             modelPreview->GetModels()[i]->SetFront(front);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignFronts");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignFronts");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignFronts", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignFronts");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4589,9 +4586,8 @@ void LayoutPanel::PreviewModelAlignBacks()
             modelPreview->GetModels()[i]->SetBack(back);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBacks");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBacks");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBacks", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBacks");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4632,9 +4628,8 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
             }
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignResize");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignResize");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignResize", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignResize");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4655,9 +4650,8 @@ void LayoutPanel::PreviewModelAlignRight()
             modelPreview->GetModels()[i]->SetRight(right);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignRight");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignRight");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignRight", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignRight");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4678,9 +4672,8 @@ void LayoutPanel::PreviewModelAlignHCenter()
             modelPreview->GetModels()[i]->SetHcenterPos(center);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignHCenter");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignHCenter");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignHCenter", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignHCenter");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4750,9 +4743,8 @@ void LayoutPanel::PreviewModelHDistribute()
             x += space;
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelHDistribute");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelHDistribute");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelHDistribute", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelHDistribute");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4806,9 +4798,8 @@ void LayoutPanel::PreviewModelVDistribute()
             y += space;
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVDistribute");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVDistribute");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -4829,9 +4820,8 @@ void LayoutPanel::PreviewModelAlignVCenter()
             modelPreview->GetModels()[i]->SetVcenterPos(center);
         }
     }
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVCenter");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVCenter");
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVCenter", nullptr, nullptr, GetSelectedModelName());
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVCenter");
     
     ReselectTreeModels(selectedModelPaths);
 }
@@ -7591,7 +7581,7 @@ void LayoutPanel::HandleSelectionChanged() {
         // TreeListViewModels->SetFocus();
         // #endif
         
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::HandleSelectionChanged");
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::HandleSelectionChanged");
     } else {
         selectedBaseObject = nullptr;
         UnSelectAllModels(true);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -4774,9 +4774,12 @@ void LayoutPanel::SelectModelInTree(Model* modelToSelect) {
             ModelTreeData *mitem = dynamic_cast<ModelTreeData*>(TreeListViewModels->GetItemData(item));
             if (mitem != nullptr && mitem->GetModel() == modelToSelect) {
                 TreeListViewModels->Select(item);
-                #ifdef __WXMSW__
-                HandleSelectionChanged();
+                
+                // OnSelectionChanged() doesn't fire on MSW or GTK when Select is called
+                #if defined(__WXMSW__) || defined(__LINUX__)
+                    HandleSelectionChanged();
                 #endif
+
                 TreeListViewModels->EnsureVisible(item);
                 break;
             }
@@ -4802,7 +4805,9 @@ void LayoutPanel::UnSelectModelInTree(Model* modelToUnSelect) {
             ModelTreeData *mitem = dynamic_cast<ModelTreeData*>(TreeListViewModels->GetItemData(item));
             if (mitem != nullptr && mitem->GetModel() == modelToUnSelect) {
                 TreeListViewModels->Unselect(item);
-                #ifdef __WXMSW__
+                
+                // OnSelectionChanged() doesn't fire on MSW or GTK when Unselect is called
+                #if defined(__WXMSW__) || defined(__LINUX__)
                     HandleSelectionChanged();
                 #endif
                 break;
@@ -4841,9 +4846,12 @@ wxTreeListItem LayoutPanel::GetTreeItemFromModel(Model* model) {
 
 void LayoutPanel::UnSelectAllModelsInTree() {
         TreeListViewModels->UnselectAll();
-        #ifdef __WXMSW__
+    
+        // OnSelectionChanged() doesn't fire on MSW or GTK when unselectAll is called
+        #if defined(__WXMSW__) || defined(__LINUX__)
             HandleSelectionChanged();
         #endif
+
 }
 
 // Get unique models from selected tree model group included those deeply nested
@@ -5053,8 +5061,10 @@ void LayoutPanel::ReselectTreeModels(std::vector<std::list<std::string>> modelPa
                 std::string childName = TreeListViewModels->GetItemText(child);
                 if (TreeListViewModels->GetItemText(child) == modelName) {
                     TreeListViewModels->Select(child);
-                    #ifdef __WXMSW__
-                    HandleSelectionChanged();
+                    
+                    // OnSelectionChanged() doesn't fire on MSW or GTK when Select is called
+                    #if defined(__WXMSW__) || defined(__LINUX__)
+                        HandleSelectionChanged();
                     #endif
                 }
             }

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1685,8 +1685,10 @@ void LayoutPanel::BulkEditControllerConnection(int id)
                 dlg.Get(model->GetControllerConnection());
             }
         }
-        std::string sm = GetSelectedModelName();
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerConnection", nullptr, nullptr, sm);
+        
+        // see comment in BulkEditActive()
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerConnection");
         
         ReselectTreeModels(selectedModelPaths);
     }
@@ -1735,9 +1737,16 @@ void LayoutPanel::BulkEditActive(bool active)
         selectedBaseObject->SetActive(active);
     }
 
-    std::string sm = GetSelectedModelName();
-    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditActive", nullptr, nullptr, sm);
-
+    if (editing_models) {
+        // If we don't clear selection and bulk edits were made with models nested in groups selected then as part of the work
+        // the model is also selected in the root of the tree even though it wasn't before.  I could not find any issues with
+        // subsequent bulk edits/move/show wiring/export/etc but if this going to be a problem we can also force it to be unselected
+        // in tree/preview after. BulkEditDimming was the only one this issue didn't appear and after the work there OMM selectedmodel is "".
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+    }
+    
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditActive");
+    
     // reselect all the models
     ReselectTreeModels(selectedModelPaths);
 }
@@ -1780,8 +1789,9 @@ void LayoutPanel::BulkEditControllerName()
             model->SetControllerName(name);
         }
 
-        std::string sm = GetSelectedModelName();
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerName", nullptr, nullptr, sm);
+        // see comment in BulkEditActive()
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerName");
 
         // reselect all the models
         ReselectTreeModels(selectedModelPaths);
@@ -1818,8 +1828,9 @@ void LayoutPanel::BulkEditTagColour()
             model->SetTagColour(colour);
         }
 
-        std::string sm = GetSelectedModelName();
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditTagColour", nullptr, nullptr, sm);
+        // see comment in BulkEditActive()
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditTagColour");
 
         // reselect all the models
         ReselectTreeModels(selectedModelPaths);
@@ -1835,7 +1846,6 @@ void LayoutPanel::BulkEditControllerPreview()
 
     // get the first preview
     std::string p = "";
-    wxColour colour = *wxBLACK;
     for (Model* model: modelsToEdit) {
         if (model != nullptr) {
             p = model->GetLayoutGroup();
@@ -1865,8 +1875,9 @@ void LayoutPanel::BulkEditControllerPreview()
             }
         }
 
-        std::string sm = GetSelectedModelName();
-        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerPreview", nullptr, nullptr, sm);
+        // see comment in BulkEditActive()
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditControllerPreview");
 
         // reselect all the models
         ReselectTreeModels(selectedModelPaths);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -992,7 +992,7 @@ void LayoutPanel::UpdatePreview()
 
 void LayoutPanel::updatePropertyGrid()
 {
-    if (selectedBaseObject == nullptr || propertyEditor == nullptr) return;
+    if (selectedBaseObject == nullptr || propertyEditor == nullptr || ModelsSelectedCount() > 1) return;
 
     selectedBaseObject->UpdateProperties(propertyEditor, xlights->GetOutputManager());
 }
@@ -7101,7 +7101,8 @@ void LayoutPanel::HandleSelectionChanged() {
     // and randomly causes crash when model is nullptr, so bail when Frozen.  Also make sure tooltip is empty and property
     // grid is shown so background props show after full refresh when nothing is selected.
     if (TreeListViewModels->IsFrozen()) {
-        ShowPropGrid(true);
+        //ShowPropGrid(true);
+        showBackgroundProperties();
         SetToolTipForTreeList(TreeListViewModels, "");
         return;
     }
@@ -7145,7 +7146,6 @@ void LayoutPanel::HandleSelectionChanged() {
                 } else if (model->GetDisplayAs() == "SubModel") {
                     selectedTreeSubModels.push_back(item);
                     SetTreeSubModelSelected(model, isPrimary);
-                    SetupPropGrid(model);
                 } else {
                     selectedTreeModels.push_back(item);
                     if (model == lastSelectedModel || lastSelectedBaseObject == nullptr || isPrimary) {
@@ -7154,7 +7154,6 @@ void LayoutPanel::HandleSelectionChanged() {
                     } else {
                         SetTreeModelSelected(model, false);
                     }
-                    SetupPropGrid(model);
                 }
             }
         }
@@ -7165,15 +7164,12 @@ void LayoutPanel::HandleSelectionChanged() {
                 Model* model = GetModelFromTreeItem(selectedTreeModels[0]);
                 SetTreeModelSelected(model, true);
                 selectedPrimaryTreeItem = selectedTreeModels[0];
-                SetupPropGrid(model);
             } else if (selectedTreeSubModels.size() > 0) {
                 Model* model = GetModelFromTreeItem(selectedTreeSubModels[0]);
                 SetTreeSubModelSelected(model, true);
-                SetupPropGrid(model);
             } else if (selectedTreeGroups.size() > 0){
                 Model* model = GetModelFromTreeItem(selectedTreeGroups[0]);
                 SetTreeGroupModelsSelected(model, true);
-                SetupPropGrid(model);
             }
         }
                               
@@ -7193,6 +7189,8 @@ void LayoutPanel::HandleSelectionChanged() {
             model_grp_panel->UpdatePanel(TreeListViewModels->GetItemText(selectedTreeGroups[0]));
             model_grp_panel->Show();
         } else if (smSize == 1) {
+            Model* subModel = GetModelFromTreeItem(selectedTreeSubModels[0]);
+            SetupPropGrid(subModel);
             ShowPropGrid(true);
         } else if (mSize == 1) {
             Model* model = GetModelFromTreeItem(selectedTreeModels[0]);
@@ -7201,6 +7199,7 @@ void LayoutPanel::HandleSelectionChanged() {
             } else {
                 logger_base.crit("LayoutPanel::HandleSelectionChanged Model was selected and now is null, this should not have happened.");
             }
+            SetupPropGrid(model);
             ShowPropGrid(true);
         } else {
             logger_base.crit("LayoutPanel::HandleSelectionChanged No models selected after processing, this should not have happen, when we started there were %d selections.", selectedItems.size());
@@ -7214,7 +7213,7 @@ void LayoutPanel::HandleSelectionChanged() {
         // TreeListViewModels->SetFocus();
         // #endif
         
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::HandleSelectionChanged");
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::HandleSelectionChanged");
     } else {
         selectedBaseObject = nullptr;
         UnSelectAllModels(true);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -4447,6 +4447,9 @@ void LayoutPanel::PreviewModelAlignWithGround()
     if (selectedindex < 0) return;
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
+    
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if (modelPreview->GetModels()[i]->GroupSelected || modelPreview->GetModels()[i]->Selected)
@@ -4454,7 +4457,9 @@ void LayoutPanel::PreviewModelAlignWithGround()
             modelPreview->GetModels()[i]->SetBottom(0.0f);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignWithGround");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignWithGround");
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::ShowNodeLayout()
@@ -4481,6 +4486,8 @@ void LayoutPanel::PreviewModelAlignTops()
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex<0) return;
 
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float top = modelPreview->GetModels()[selectedindex]->GetTop();
     for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
@@ -4490,15 +4497,19 @@ void LayoutPanel::PreviewModelAlignTops()
             modelPreview->GetModels()[i]->SetTop(top);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignTops");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignTops");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignTops", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignTops");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignTops");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignTops", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignBottoms()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float bottom = modelPreview->GetModels()[selectedindex]->GetBottom();
@@ -4509,15 +4520,19 @@ void LayoutPanel::PreviewModelAlignBottoms()
             modelPreview->GetModels()[i]->SetBottom(bottom);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBottoms");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBottoms");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBottoms", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBottoms");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBottoms");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBottoms", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignLeft()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+    
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float left = modelPreview->GetModels()[selectedindex]->GetLeft();
@@ -4528,15 +4543,19 @@ void LayoutPanel::PreviewModelAlignLeft()
             modelPreview->GetModels()[i]->SetLeft(left);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignLeft");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignLeft");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignLeft", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignLeft");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignLeft");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignLeft", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignFronts()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float front = modelPreview->GetModels()[selectedindex]->GetFront();
@@ -4547,15 +4566,19 @@ void LayoutPanel::PreviewModelAlignFronts()
             modelPreview->GetModels()[i]->SetFront(front);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignFronts");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignFronts");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignFronts", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignFronts");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignFronts");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignFronts", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignBacks()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float back = modelPreview->GetModels()[selectedindex]->GetBack();
@@ -4566,15 +4589,19 @@ void LayoutPanel::PreviewModelAlignBacks()
             modelPreview->GetModels()[i]->SetBack(back);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBacks");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBacks");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBacks", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignBacks");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignBacks");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBacks", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
 
@@ -4605,15 +4632,19 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
             }
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignResize");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignResize");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignResize", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignResize");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignResize");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignResize", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignRight()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float right = modelPreview->GetModels()[selectedindex]->GetRight();
@@ -4624,15 +4655,19 @@ void LayoutPanel::PreviewModelAlignRight()
             modelPreview->GetModels()[i]->SetRight(right);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignRight");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignRight");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignRight", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignRight");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignRight");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignRight", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignHCenter()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float center = modelPreview->GetModels()[selectedindex]->GetHcenterPos();
@@ -4643,9 +4678,11 @@ void LayoutPanel::PreviewModelAlignHCenter()
             modelPreview->GetModels()[i]->SetHcenterPos(center);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignHCenter");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignHCenter");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignHCenter", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelAlignHCenter");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelAlignHCenter");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignHCenter", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 bool SortModelX(const Model* first, const Model* second)
@@ -4692,6 +4729,8 @@ void LayoutPanel::PreviewModelHDistribute()
 
     float space = (maxx - minx) / (count - 1);
 
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
     CreateUndoPoint("All", models.front()->name);
 
     float x = -1;
@@ -4711,9 +4750,11 @@ void LayoutPanel::PreviewModelHDistribute()
             x += space;
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelHDistribute");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelHDistribute");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelHDistribute", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelHDistribute");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelHDistribute");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelHDistribute", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelVDistribute()
@@ -4743,6 +4784,8 @@ void LayoutPanel::PreviewModelVDistribute()
     models.sort(SortModelY);
 
     float space = (maxy - miny) / (count - 1);
+    
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", models.front()->name);
 
@@ -4763,15 +4806,19 @@ void LayoutPanel::PreviewModelVDistribute()
             y += space;
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVDistribute");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVDistribute");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVDistribute");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVDistribute");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::PreviewModelAlignVCenter()
 {
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
+
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float center = modelPreview->GetModels()[selectedindex]->GetVcenterPos();
@@ -4782,9 +4829,11 @@ void LayoutPanel::PreviewModelAlignVCenter()
             modelPreview->GetModels()[i]->SetVcenterPos(center);
         }
     }
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVCenter");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVCenter");
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVCenter", nullptr, nullptr, GetSelectedModelName());
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "LayoutPanel::PreviewModelVCenter");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::PreviewModelVCenter");
+    xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVCenter", nullptr, nullptr, GetSelectedModelName());
+    
+    ReselectTreeModels(selectedModelPaths);
 }
 
 int LayoutPanel::GetSelectedModelIndex() const
@@ -6441,6 +6490,14 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
             PreviewModelAlignWithGround();
         } else {
             objects_panel->PreviewObjectAlignWithGround();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_TOP)
+    {
+        if(editing_models ) {
+            PreviewModelAlignTops();
+        } else {
+            objects_panel->PreviewObjectAlignTops();
         }
     }
     else if (event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION ||

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1698,10 +1698,20 @@ void LayoutPanel::BulkEditActive(bool active)
 
     // remember the selected models
     std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
-
+    
     for (Model* model: modelsToEdit) {
         if (model != nullptr) {
+            std::string preChangeName = TreeModelName(model, false);
             model->SetActive(active);
+            std::string postChangeName = TreeModelName(model, false);
+            
+            // fix name for reselect
+            for (auto& path : selectedModelPaths) {
+                if (path.back() == preChangeName) {
+                    path.pop_back();
+                    path.push_back(postChangeName);
+                }
+            }
         }
     }
     
@@ -5000,18 +5010,24 @@ std::vector<std::list<std::string>> LayoutPanel::GetSelectedTreeModelPaths() {
     }
     
     for (const auto& item : selectedTreeGroups) {
-        std::list<std::string> modelPath = GetTreeItemPath(item);
-        modelPaths.push_back(modelPath);
+        if (selectedPrimaryTreeItem != item) {
+            std::list<std::string> modelPath = GetTreeItemPath(item);
+            modelPaths.push_back(modelPath);
+        }
     }
 
     for (const auto& item : selectedTreeModels) {
-        std::list<std::string> modelPath = GetTreeItemPath(item);
-        modelPaths.push_back(modelPath);
+        if (selectedPrimaryTreeItem != item) {
+            std::list<std::string> modelPath = GetTreeItemPath(item);
+            modelPaths.push_back(modelPath);
+        }
     }
 
     for (const auto& item : selectedTreeSubModels) {
-        std::list<std::string> modelPath = GetTreeItemPath(item);
-        modelPaths.push_back(modelPath);
+        if (selectedPrimaryTreeItem != item) {
+            std::list<std::string> modelPath = GetTreeItemPath(item);
+            modelPaths.push_back(modelPath);
+        }
     }
 
     return modelPaths;
@@ -5046,7 +5062,7 @@ wxTreeListItem LayoutPanel::GetTreeItemBranch(wxTreeListItem parent, std::string
 
 void LayoutPanel::ReselectTreeModels(std::vector<std::list<std::string>> modelPaths) {
     static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-    
+
     for (auto path : modelPaths) {
         // model name is last string in path
         std::string modelName = path.back();
@@ -5066,10 +5082,11 @@ void LayoutPanel::ReselectTreeModels(std::vector<std::list<std::string>> modelPa
                     #if defined(__WXMSW__) || defined(__LINUX__)
                         HandleSelectionChanged();
                     #endif
+                    break;
                 }
             }
         } else {
-            logger_base.crit("LayoutPanel::ReselectTreeModels Model could not be found in tree... this shouldn't happen.");
+            logger_base.crit("LayoutPanel::ReselectTreeModels branch could not be found in tree... this shouldn't happen.");
         }
     }
 }

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2596,7 +2596,7 @@ Model* LayoutPanel::SelectSingleModel(int x, int y)
             if (mHitTestNextSelectModelIndex == i) {
                 mHitTestNextSelectModelIndex += 1;
                 mHitTestNextSelectModelIndex %= modelCount;
-                return modelPreview->GetModels()[found[0]];
+                return modelPreview->GetModels()[found[i]];
             }
         }
     }

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -3900,6 +3900,58 @@ bool LayoutPanel::IsAllSelectedModelsArePixelProtocol() const
     return true;
 }
 
+void LayoutPanel::AddBulkEditOptionsToMenu(wxMenu* mnuBulkEdit) {
+    mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SETACTIVE, "Active");
+    mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SETINACTIVE, "Inactive");
+    if (editing_models) {
+        if (xlights->GetOutputManager()->GetAutoLayoutControllerNames().size() > 0)
+        {
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERNAME, "Controller Name");
+        }
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_TAGCOLOUR, "Tag Color");
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION, "Controller Connection");
+        if (IsAllSelectedModelsArePixelProtocol())
+        {
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SMARTREMOTE, "Smart Remote");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERDIRECTION, "Controller Direction");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERBRIGHTNESS, "Controller Brightness");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERGAMMA, "Controller Gamma");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCOLOURORDER, "Controller Colour Order");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERNULLNODES, "Controller Null Nodes");
+            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERGROUPCOUNT, "Controller Group Count");
+        }
+    }
+    mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_PREVIEW, "Preview");
+    if (editing_models) {
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_DIMMINGCURVES, "Dimming Curves");
+    }
+}
+
+void LayoutPanel::AddAlignOptionsToMenu(wxMenu* mnuAlign) {
+    mnuAlign->Append(ID_PREVIEW_ALIGN_TOP,"Top");
+    mnuAlign->Append(ID_PREVIEW_ALIGN_BOTTOM,"Bottom");
+    mnuAlign->Append(ID_PREVIEW_ALIGN_LEFT,"Left");
+    mnuAlign->Append(ID_PREVIEW_ALIGN_RIGHT, "Right");
+    if (is_3d) {
+        mnuAlign->Append(ID_PREVIEW_ALIGN_FRONT, "Front");
+        mnuAlign->Append(ID_PREVIEW_ALIGN_BACK, "Back");
+        mnuAlign->Append(ID_PREVIEW_ALIGN_GROUND, "With Ground");
+    }
+    mnuAlign->Append(ID_PREVIEW_ALIGN_H_CENTER,"Horizontal Center");
+    mnuAlign->Append(ID_PREVIEW_ALIGN_V_CENTER,"Vertical Center");
+}
+
+void LayoutPanel::AddDistributeOptionsToMenu(wxMenu* mnuDistribute) {
+    mnuDistribute->Append(ID_PREVIEW_H_DISTRIBUTE,"Horizontal");
+    mnuDistribute->Append(ID_PREVIEW_V_DISTRIBUTE,"Vertical");
+}
+
+void LayoutPanel::AddResizeOptionsToMenu(wxMenu* mnuResize) {
+    mnuResize->Append(ID_PREVIEW_RESIZE_SAMEWIDTH, "Match Width");
+    mnuResize->Append(ID_PREVIEW_RESIZE_SAMEHEIGHT, "Match Height");
+    mnuResize->Append(ID_PREVIEW_RESIZE_SAMESIZE, "Match Size");
+}
+
 void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
 {
     modelPreview->SetFocus();
@@ -3912,55 +3964,19 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
     if (selectedObjectCnt > 1)
     {
         wxMenu* mnuBulkEdit = new wxMenu();
-        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SETACTIVE, "Active");
-        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SETINACTIVE, "Inactive");
-        if( editing_models ) {
-            if (xlights->GetOutputManager()->GetAutoLayoutControllerNames().size() > 0)
-            {
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERNAME, "Controller Name");
-            }
-            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_TAGCOLOUR, "Tag Color");
-            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION, "Controller Connection");
-            if (IsAllSelectedModelsArePixelProtocol())
-            {
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SMARTREMOTE, "Smart Remote");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERDIRECTION, "Controller Direction");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERBRIGHTNESS, "Controller Brightness");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERGAMMA, "Controller Gamma");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCOLOURORDER, "Controller Colour Order");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERNULLNODES, "Controller Null Nodes");
-                mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERGROUPCOUNT, "Controller Group Count");
-            }
-        }
-        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_PREVIEW, "Preview");
-        if( editing_models ) {
-            mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_DIMMINGCURVES, "Dimming Curves");
-        }
+        AddBulkEditOptionsToMenu(mnuBulkEdit);
         mnuBulkEdit->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
 
         wxMenu* mnuAlign = new wxMenu();
-        mnuAlign->Append(ID_PREVIEW_ALIGN_TOP,"Top");
-        mnuAlign->Append(ID_PREVIEW_ALIGN_BOTTOM,"Bottom");
-        mnuAlign->Append(ID_PREVIEW_ALIGN_LEFT,"Left");
-        mnuAlign->Append(ID_PREVIEW_ALIGN_RIGHT, "Right");
-        if (is_3d) {
-            mnuAlign->Append(ID_PREVIEW_ALIGN_FRONT, "Front");
-            mnuAlign->Append(ID_PREVIEW_ALIGN_BACK, "Back");
-            mnuAlign->Append(ID_PREVIEW_ALIGN_GROUND, "With Ground");
-        }
-        mnuAlign->Append(ID_PREVIEW_ALIGN_H_CENTER,"Horizontal Center");
-        mnuAlign->Append(ID_PREVIEW_ALIGN_V_CENTER,"Vertical Center");
+        AddAlignOptionsToMenu(mnuAlign);
         mnuAlign->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
 
         wxMenu* mnuDistribute = new wxMenu();
-        mnuDistribute->Append(ID_PREVIEW_H_DISTRIBUTE,"Horizontal");
-        mnuDistribute->Append(ID_PREVIEW_V_DISTRIBUTE,"Vertical");
+        AddDistributeOptionsToMenu(mnuDistribute);
         mnuDistribute->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
 
         wxMenu* mnuResize = new wxMenu();
-        mnuResize->Append(ID_PREVIEW_RESIZE_SAMEWIDTH, "Match Width");
-        mnuResize->Append(ID_PREVIEW_RESIZE_SAMEHEIGHT, "Match Height");
-        mnuResize->Append(ID_PREVIEW_RESIZE_SAMESIZE, "Match Size");
+        AddResizeOptionsToMenu(mnuResize);
         mnuResize->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
 
         mnu.Append(ID_PREVIEW_BULKEDIT, "Bulk Edit", mnuBulkEdit, "");
@@ -6290,6 +6306,146 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
         logger_base.debug("LayoutPanel::OnModelsPopup DELETE_MODEL");
         DeleteSelectedModels();
     }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_BOTTOM)
+    {
+        if(editing_models ) {
+            PreviewModelAlignBottoms();
+        } else {
+            objects_panel->PreviewObjectAlignBottoms();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_GROUND)
+    {
+        if(editing_models ) {
+            PreviewModelAlignWithGround();
+        } else {
+            objects_panel->PreviewObjectAlignWithGround();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERNULLNODES ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERBRIGHTNESS ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERCOLOURORDER ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERGAMMA ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERGROUPCOUNT ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERDIRECTION ||
+        event.GetId() == ID_PREVIEW_BULKEDIT_SMARTREMOTE
+        )
+    {
+        BulkEditControllerConnection(event.GetId());
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_CONTROLLERNAME)
+    {
+        BulkEditControllerName();
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_SETACTIVE)
+    {
+        BulkEditActive(true);
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_SETINACTIVE)
+    {
+        BulkEditActive(false);
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_TAGCOLOUR)
+    {
+        BulkEditTagColour();
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_PREVIEW)
+    {
+        BulkEditControllerPreview();
+    }
+    else if (event.GetId() == ID_PREVIEW_BULKEDIT_DIMMINGCURVES)
+    {
+        BulkEditDimmingCurves();
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_LEFT)
+    {
+        if(editing_models ) {
+            PreviewModelAlignLeft();
+        } else {
+            objects_panel->PreviewObjectAlignLeft();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_RIGHT)
+    {
+        if(editing_models ) {
+            PreviewModelAlignRight();
+        } else {
+            objects_panel->PreviewObjectAlignRight();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_FRONT)
+    {
+        if(editing_models ) {
+            PreviewModelAlignFronts();
+        } else {
+            objects_panel->PreviewObjectAlignFronts();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_BACK)
+    {
+        if(editing_models ) {
+            PreviewModelAlignBacks();
+        } else {
+            objects_panel->PreviewObjectAlignBacks();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_H_CENTER)
+    {
+        if(editing_models ) {
+            PreviewModelAlignHCenter();
+        } else {
+            objects_panel->PreviewObjectAlignHCenter();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_ALIGN_V_CENTER)
+    {
+        if(editing_models ) {
+            PreviewModelAlignVCenter();
+        } else {
+            objects_panel->PreviewObjectAlignVCenter();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_H_DISTRIBUTE)
+    {
+        if(editing_models ) {
+            PreviewModelHDistribute();
+        } else {
+            objects_panel->PreviewObjectHDistribute();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_V_DISTRIBUTE)
+    {
+        if(editing_models ) {
+            PreviewModelVDistribute();
+        } else {
+            objects_panel->PreviewObjectVDistribute();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_RESIZE_SAMEWIDTH)
+    {
+        if(editing_models ) {
+            PreviewModelResize(true, false);
+        } else {
+            objects_panel->PreviewObjectResize(true, false);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_RESIZE_SAMEHEIGHT)
+    {
+        if(editing_models ) {
+            PreviewModelResize(false, true);
+        } else {
+            objects_panel->PreviewObjectResize(false, true);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_RESIZE_SAMESIZE)
+    {
+        if(editing_models ) {
+            PreviewModelResize(true, true);
+        } else {
+            objects_panel->PreviewObjectResize(true, true);
+        }
+    }
     else if (id == ID_MNU_DELETE_MODEL_GROUP)
     {
         logger_base.debug("LayoutPanel::OnModelsPopup DELETE_MODEL_GROUP");
@@ -7008,6 +7164,32 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
             mnuContext.Append(ID_MNU_DELETE_MODEL, "Delete Models");
             mnuContext.AppendSeparator();
         }
+    }
+    
+    // add model menu options if only models selected and selected > 1n
+    if (selectedTreeModels.size() > 1 && selectedTreeGroups.size() + selectedTreeSubModels.size() == 0) {
+        wxMenu* mnuBulkEdit = new wxMenu();
+        AddBulkEditOptionsToMenu(mnuBulkEdit);
+        mnuBulkEdit->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
+        
+        wxMenu* mnuAlign = new wxMenu();
+        AddAlignOptionsToMenu(mnuAlign);
+        mnuAlign->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
+        
+        wxMenu* mnuDistribute = new wxMenu();
+        AddDistributeOptionsToMenu(mnuDistribute);
+        mnuDistribute->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
+        
+        wxMenu* mnuResize = new wxMenu();
+        AddResizeOptionsToMenu(mnuResize);
+        mnuResize->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
+        
+        mnuContext.Append(ID_PREVIEW_BULKEDIT, "Bulk Edit", mnuBulkEdit, "");
+        mnuContext.Append(ID_PREVIEW_ALIGN, "Align", mnuAlign, "");
+        mnuContext.Append(ID_PREVIEW_DISTRIBUTE, "Distribute", mnuDistribute, "");
+        mnuContext.Append(ID_PREVIEW_RESIZE, "Resize", mnuResize, "");
+
+        mnuContext.AppendSeparator();
     }
 
     mnuContext.Append(ID_MNU_ADD_MODEL_GROUP, "Add Group");

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -7350,6 +7350,8 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
     
     if (selectedTreeModels.size() == 1 && selectedTreeGroups.size() + selectedTreeSubModels.size() == 0) {
         AddSingleModelOptionsToBaseMenu(mnuContext);
+        // Remove preview 'Create Group' option as it may be confusing with tree list 'Create Group from Selections'
+        mnuContext.Remove(ID_PREVIEW_MODEL_CREATEGROUP);
         mnuContext.AppendSeparator();
     }
     

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -313,7 +313,10 @@ class LayoutPanel: public wxPanel
         void ShowNodeLayout();
         void ShowWiring();
         bool IsAllSelectedModelsArePixelProtocol() const;
-
+        void AddBulkEditOptionsToMenu(wxMenu* bulkEditMenu);
+        void AddAlignOptionsToMenu(wxMenu* mnuAlign);
+        void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);
+        void AddResizeOptionsToMenu(wxMenu* mnuResize);
         Model* SelectSingleModel(int x,int y);
         bool SelectMultipleModels(int x,int y);
         void SelectAllInBoundingRect(bool models_and_objects);

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -313,6 +313,7 @@ class LayoutPanel: public wxPanel
         void ShowNodeLayout();
         void ShowWiring();
         bool IsAllSelectedModelsArePixelProtocol() const;
+        void AddSingleModelOptionsToBaseMenu(wxMenu &menu);
         void AddBulkEditOptionsToMenu(wxMenu* bulkEditMenu);
         void AddAlignOptionsToMenu(wxMenu* mnuAlign);
         void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -314,7 +314,7 @@ class LayoutPanel: public wxPanel
         void ShowWiring();
         bool IsAllSelectedModelsArePixelProtocol() const;
 
-        bool SelectSingleModel(int x,int y);
+        Model* SelectSingleModel(int x,int y);
         bool SelectMultipleModels(int x,int y);
         void SelectAllInBoundingRect(bool models_and_objects);
         void HighlightAllInBoundingRect(bool models_and_objects);
@@ -335,6 +335,7 @@ class LayoutPanel: public wxPanel
         void SetTreeModelSelected(Model* model, bool isPrimary);
         void SetTreeGroupModelsSelected(Model* model, bool isPrimary);
         void SetTreeSubModelSelected(Model* model, bool isPrimary);
+        void CheckModelForOverlaps(Model* model);
         std::vector<std::list<std::string>> GetSelectedTreeModelPaths();
         std::list<std::string> GetTreeItemPath(wxTreeListItem item);
         wxTreeListItem GetTreeItemBranch(wxTreeListItem parent, std::string branchName);
@@ -343,6 +344,7 @@ class LayoutPanel: public wxPanel
         void SelectBaseObjectInTree(BaseObject* baseObjectToSelect);
         void UnSelectModelInTree(Model* modelToUnSelect);
         void UnSelectBaseObjectInTree(BaseObject* baseObjectToUnSelect);
+        void UnSelectAllModelsInTree();
         std::list<BaseObject*> GetSelectedBaseObjects() const;
         void PreviewModelAlignWithGround();
         void PreviewModelAlignTops();


### PR DESCRIPTION
lots of fixes/cleanup for model tree multi select to try and ensure there are no changes or hinderance to existing layout panel functionality and experience is business as usual for all existing preview MultiSelect capabilities across platforms.  This also adds the existing right click model preview options to tree view for single and multi selection.

There are a few open items which I have thoughts/questions on and didn't want to make the changes without feedback from the rest of you all which I'll comment on this PR shortly.