### PR TITLE
Allow for audio spectrogram input to shader effect

### DIFF
--- a/download/shaders.xml
+++ b/download/shaders.xml
@@ -698,6 +698,12 @@
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/bkueyyadw5k6qfmrzrou</image>
 		<rating>3</rating>
 	</shader>
+        <shader>
+		<name>Audio - Circle Wave</name>
+		<id>5ee1b2d59a2c7b00176938c6</id>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/bkueyyadw5k6qfmrzrou</image>
+		<rating>3</rating>
+        </shader>
 	<!--shader>
 		<name></name>
 		<id></id>

--- a/xLights/AudioManager.cpp
+++ b/xLights/AudioManager.cpp
@@ -1822,7 +1822,7 @@ void ProgressFunction(wxProgressDialog* pd, int p)
 }
 
 // Get the pre-prepared data for this frame
-std::list<float>* AudioManager::GetFrameData(int frame, FRAMEDATATYPE fdt, std::string timing)
+const std::list<float>* AudioManager::GetFrameData(int frame, FRAMEDATATYPE fdt, std::string timing)
 {
     log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     std::list<float>* rc = nullptr;
@@ -1899,7 +1899,7 @@ std::list<float>* AudioManager::GetFrameData(int frame, FRAMEDATATYPE fdt, std::
     return rc;
 }
 
-std::list<float>* AudioManager::GetFrameData(FRAMEDATATYPE fdt, std::string timing, long ms)
+const std::list<float>* AudioManager::GetFrameData(FRAMEDATATYPE fdt, std::string timing, long ms)
 {
     int frame = ms / _intervalMS;
     return GetFrameData(frame, fdt, timing);

--- a/xLights/AudioManager.h
+++ b/xLights/AudioManager.h
@@ -302,8 +302,8 @@ public:
 	void SetStepBlock(int step, int block);
 	void SetFrameInterval(int intervalMS);
 	int GetFrameInterval() const { return _intervalMS; }
-	std::list<float>* GetFrameData(int frame, FRAMEDATATYPE fdt, std::string timing);
-	std::list<float>* GetFrameData(FRAMEDATATYPE fdt, std::string timing, long ms);
+	const std::list<float>* GetFrameData(int frame, FRAMEDATATYPE fdt, std::string timing);
+	const std::list<float>* GetFrameData(FRAMEDATATYPE fdt, std::string timing, long ms);
 	void DoPrepareFrameData();
 	void DoPolyphonicTranscription(wxProgressDialog* dlg, AudioManagerProgressCallback progresscallback);
 	bool IsPolyphonicTranscriptionDone() const { return _polyphonicTranscriptionDone; };

--- a/xLights/OpenGLShaders.cpp
+++ b/xLights/OpenGLShaders.cpp
@@ -20,6 +20,8 @@
 
 #include "xlGLCanvas.h"
 
+#include <memory>
+
 extern PFNGLCREATESHADERPROC      glCreateShader;
 extern PFNGLSHADERSOURCEPROC      glShaderSource;
 extern PFNGLCOMPILESHADERPROC     glCompileShader;
@@ -126,7 +128,7 @@ namespace
             std::vector<char> errorMessage( infoLogLength + 1 );
             char*             messagePtr = &errorMessage[0];
             glGetShaderInfoLog( shaderID, infoLogLength, NULL, messagePtr );
-             
+
              messagePtr[infoLogLength] = 0;
              std::string m = "Shader fail message: ";
              m += messagePtr;
@@ -180,7 +182,7 @@ unsigned OpenGLShaders::compile( const std::string& vertexSource, const std::str
         AddTraceMessage("FShader failed to compile");
         LOG_GL_ERRORV(glDeleteShader(vertexShader));
         LOG_GL_ERRORV(glDeleteShader(fragmentShader));
-       
+
         static log4cpp::Category& logger_opengl = log4cpp::Category::getInstance(std::string("log_opengl"));
         logger_opengl.error("%s", (const char*)fragmentSource.c_str());
         return 0;

--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -122,7 +122,7 @@ namespace
       }
       double x, y;
    };
-   
+
    xlColor tex2D(const ColorBuffer& cb, const Vec2D& st) {
        return tex2D(cb, st.x, st.y);
    }
@@ -2784,9 +2784,9 @@ void PixelBufferClass::CalcOutput(int EffectPeriod, const std::vector<bool> & va
         if (layers[ii]->use_music_sparkle_count &&
             layers[ii]->buffer.GetMedia() != nullptr) {
             float f = 0.0;
-            std::list<float>* pf = layers[ii]->buffer.GetMedia()->GetFrameData(layers[ii]->buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = layers[ii]->buffer.GetMedia()->GetFrameData(layers[ii]->buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr) {
-                f = *pf->begin();
+                f = *pf->cbegin();
             }
             layers[ii]->music_sparkle_count_factor = f;
         } else {

--- a/xLights/effects/FireEffect.cpp
+++ b/xLights/effects/FireEffect.cpp
@@ -92,7 +92,7 @@ public:
             firePaletteColors.push_back(hsv);
             firePaletteColorsAlpha.push_back(xlColor(255, 0, 0, i * 255 / 100));
         }
-        
+
         // gives 100 hues red to yellow
         hsv.value=1.0;
         for (i=0; i<100; i++)
@@ -115,7 +115,7 @@ public:
     const xlColor &asAlphaColor(int x) const {
         return firePaletteColorsAlpha[x];
     }
-    
+
 private:
     hsvVector firePalette;
     xlColorVector firePaletteColors;
@@ -163,7 +163,7 @@ class FireRenderCache : public EffectRenderCache {
 public:
     FireRenderCache() {};
     virtual ~FireRenderCache() {};
-    
+
     std::vector<int> FireBuffer;
 };
 
@@ -211,10 +211,10 @@ void FireEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer &
         if (buffer.GetMedia() != nullptr)
         {
             float f = 0.0;
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr)
             {
-                f = *pf->begin();
+                f = *pf->cbegin();
             }
             HeightPct += 90 * f;
         }
@@ -229,7 +229,7 @@ void FireEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer &
         }
     }
     if (HeightPct<1) HeightPct=1;
-    
+
     int maxMHt = buffer.ModelBufferHt;
     int maxMWi = buffer.ModelBufferWi;
     if (loc == 2 || loc == 3) {
@@ -305,7 +305,7 @@ void FireEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer &
             SetFireBuffer(x,y,new_index, cache->FireBuffer, maxMWi, maxMHt);
         }
     }
-    
+
     //  Now play fire
     for (y=0; y<maxHt; y++)
     {

--- a/xLights/effects/FireworksEffect.cpp
+++ b/xLights/effects/FireworksEffect.cpp
@@ -335,7 +335,7 @@ std::pair<int,int> FireworksEffect::GetFireworkLocation(int width, int height, i
 
 void FireworksEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer &buffer) {
     float offset = buffer.GetEffectTimeIntervalPosition();
-    
+
     int numberOfExplosions = SettingsMap.GetInt("SLIDER_Fireworks_Explosions", 16);
     int particleCount = GetValueCurveInt("Fireworks_Count", 50, SettingsMap, offset, FIREWORKSCOUNT_MIN, FIREWORKSCOUNT_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS());
     float particleVelocity = GetValueCurveDouble("Fireworks_Velocity", 2.0, SettingsMap, offset, FIREWORKSVELOCITY_MIN, FIREWORKSVELOCITY_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS());
@@ -359,10 +359,10 @@ void FireworksEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuf
     if (useMusic)
     {
         if (buffer.GetMedia() != nullptr) {
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr)
             {
-                f = *pf->begin();
+                f = *pf->cbegin();
             }
         }
     }
@@ -372,13 +372,13 @@ void FireworksEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuf
         cache = new FireworksRenderCache();
         buffer.infoCache[id] = cache;
     }
-    
+
     auto& sinceLastTriggered = cache->_sinceLastTriggered;
     auto& fireworks = cache->_fireworks;
     auto& firePeriods = cache->_firePeriods;
 
     size_t colorcnt = buffer.GetColorCount();
-    
+
     if (buffer.needToInit) {
         buffer.needToInit = false;
         SetPanelTimingTracks();
@@ -405,7 +405,7 @@ void FireworksEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuf
             if (sinceLastTriggered == 0 || sinceLastTriggered > REPEATTRIGGER)
             {
                 auto location = GetFireworkLocation(buffer.BufferWi, buffer.BufferHt, xLocation, yLocation);
-                int colourIndex = rand() % colorcnt; 
+                int colourIndex = rand() % colorcnt;
                 fireworks.push_back(Firework(particleCount,
                     location.first, location.second,
                     xVelocity, yVelocity,
@@ -429,7 +429,7 @@ void FireworksEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuf
             sinceLastTriggered = 0;
         }
     }
-    
+
     if (useTiming)
     {
         if (mSequenceElements == nullptr)

--- a/xLights/effects/LiquidEffect.cpp
+++ b/xLights/effects/LiquidEffect.cpp
@@ -527,10 +527,10 @@ void LiquidEffect::Step(b2World* world, RenderBuffer &buffer, bool enabled[], in
         float audioLevel = 0.0001f;
         if (buffer.GetMedia() != nullptr)
         {
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr)
             {
-                audioLevel = *pf->begin();
+                audioLevel = *pf->cbegin();
             }
         }
 

--- a/xLights/effects/MeteorsEffect.cpp
+++ b/xLights/effects/MeteorsEffect.cpp
@@ -182,9 +182,9 @@ void MeteorsEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffe
     if (SettingsMap.GetBool("CHECKBOX_Meteors_UseMusic", false)) {
         float f = 0.0;
         if (buffer.GetMedia() != nullptr) {
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr) {
-                f = *pf->begin();
+                f = *pf->cbegin();
             }
         }
         Count = (float)Count * f;

--- a/xLights/effects/MusicEffect.cpp
+++ b/xLights/effects/MusicEffect.cpp
@@ -147,12 +147,12 @@ class MusicEvent
 			{
 				return 0.0;
 			}
-			
+
 			return ((float)frame - (float)_startframe) / (float)_duration;
 		}
 };
 
-class MusicRenderCache : public EffectRenderCache 
+class MusicRenderCache : public EffectRenderCache
 {
 public:
 	void ClearEvents()
@@ -168,7 +168,7 @@ public:
 		}
 		_events.clear();
 	}
-    MusicRenderCache() 
+    MusicRenderCache()
 	{
 	};
     virtual ~MusicRenderCache() {
@@ -357,11 +357,11 @@ void MusicEffect::CreateEvents(RenderBuffer& buffer, std::vector<std::list<Music
     // go through each frame and extract the data i need
     for (int f = buffer.curEffStartPer; f <= buffer.curEffEndPer; f++)
     {
-        std::list<float>* pdata = buffer.GetMedia()->GetFrameData(f, FRAMEDATATYPE::FRAMEDATA_VU, "");
+        std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(f, FRAMEDATATYPE::FRAMEDATA_VU, "");
 
         if (pdata != nullptr)
         {
-            auto pn = pdata->begin();
+            auto pn = pdata->cbegin();
 
             // skip to start note
             for (int i = 0; i < startNote && pn != pdata->end(); i++)

--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -108,6 +108,25 @@ namespace
         return texId;
     }
 
+    GLuint FFTAudioTexture()
+    {
+        GLuint texId = 0;
+
+        LOG_GL_ERRORV(glGenTextures(1, &texId));
+        LOG_GL_ERRORV(glBindTexture(GL_TEXTURE_2D, texId));
+
+        LOG_GL_ERRORV(glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, 128, 1, 0, GL_RED, GL_FLOAT, nullptr));
+
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+        LOG_GL_ERRORV(glBindTexture(GL_TEXTURE_2D, 0));
+
+        return texId;
+    }
+
     bool createOpenGLRenderBuffer(int width, int height, GLuint* rbID, GLuint* fbID)
     {
         LOG_GL_ERRORV(glGenRenderbuffers(1, rbID));
@@ -292,7 +311,7 @@ class ShaderGLCanvas : public xlGLCanvas {
 public:
     ShaderGLCanvas(wxWindow *parent) : xlGLCanvas(parent, -1) {}
     virtual ~ShaderGLCanvas() {}
-    
+
     virtual void InitializeGLContext() {}
 };
 
@@ -458,7 +477,7 @@ public:
             unsigned rbTex = s_rbTex;
             unsigned programId = s_programId;
             xlGLCanvas *preview = this->preview;
-            
+
             preview->CallAfter([preview,
                                 vertexArrayId,
                                 vertexBufferId,
@@ -474,7 +493,7 @@ public:
                                  rbTex,
                                  programId);
             });
-            
+
             s_programId = 0;
             s_vertexArrayId = 0;
             s_vertexBufferId = 0;
@@ -492,6 +511,7 @@ public:
     unsigned s_fbId = 0;
     unsigned s_rbId = 0;
     unsigned s_rbTex = 0;
+    unsigned s_audioTex = 0;
     unsigned s_programId = 0;
     int s_rbWidth = 0;
     int s_rbHeight = 0;
@@ -501,13 +521,14 @@ public:
         if (_shaderConfig != nullptr) delete _shaderConfig;
         _shaderConfig = ShaderEffect::ParseShader(filename);
     }
-    
+
     void DestroyResources() {
         DestroyResources(s_vertexArrayId,
                          s_vertexBufferId,
                          s_fbId,
                          s_rbId,
                          s_rbTex,
+                         s_audioTex,
                          s_programId);
         s_programId = 0;
         s_vertexArrayId = 0;
@@ -515,12 +536,14 @@ public:
         s_fbId = 0;
         s_rbId = 0;
         s_rbTex = 0;
+        s_audioTex = 0;
     }
     static void DestroyResources(unsigned s_vertexArrayId,
                                  unsigned s_vertexBufferId,
                                  unsigned s_fbId,
                                  unsigned s_rbId,
                                  unsigned s_rbTex,
+                                 unsigned s_audioTex,
                                  unsigned s_programId) {
         if (s_programId) {
             LOG_GL_ERRORV(glDeleteProgram(s_programId));
@@ -540,6 +563,9 @@ public:
         if (s_rbTex) {
             LOG_GL_ERRORV(glDeleteTextures(1, &s_rbTex));
         }
+        if (s_audioTex) {
+            LOG_GL_ERRORV(glDeleteTextures(1, &s_audioTex));
+        }
     }
 
 #if defined(__WXOSX__)
@@ -555,7 +581,7 @@ public:
 bool ShaderEffect::CanRenderOnBackgroundThread(Effect* effect, const SettingsMap& settings, RenderBuffer& buffer)
 {
 
-#if defined(__WXOSX__)     
+#if defined(__WXOSX__)
     // if we create a specific OpenGL context for this thread and not try to share contexts between threads,
     // the OSX GL engine is thread safe.
     //
@@ -620,7 +646,7 @@ bool ShaderEffect::SetGLContext(ShaderRenderCache *cache) {
     if (cache->glContextInfo == nullptr) {
         // we grab it here and release it when the cache is deleted
         cache->glContextInfo = GL_CONTEXT_POOL.GetContext(p->_preview);
-        
+
         cache->glContextInfo->SetCurrent();
         const GLubyte* str = glGetString(GL_VERSION);
         const GLubyte* rend = glGetString(GL_RENDERER);
@@ -629,7 +655,7 @@ bool ShaderEffect::SetGLContext(ShaderRenderCache *cache) {
                                             (const char *)str,
                                             (const char *)rend,
                                             (const char *)vend);
-        
+
         static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
         logger_base.info(configs);
     }
@@ -675,6 +701,7 @@ void ShaderEffect::Render(Effect* eff, SettingsMap& SettingsMap, RenderBuffer& b
     unsigned& s_rbId = cache->s_rbId;
     unsigned& s_programId = cache->s_programId;
     unsigned& s_rbTex = cache->s_rbTex;
+    unsigned& s_audioTex = cache->s_audioTex;
     int& s_rbWidth = cache->s_rbWidth;
     int& s_rbHeight = cache->s_rbHeight;
     long& _timeMS = cache->_timeMS;
@@ -738,9 +765,31 @@ void ShaderEffect::Render(Effect* eff, SettingsMap& SettingsMap, RenderBuffer& b
     LOG_GL_ERRORV(glClearColor(0.f, 0.f, 0.f, 0.f));
     LOG_GL_ERRORV(glClear(GL_COLOR_BUFFER_BIT));
 
-    LOG_GL_ERRORV(glActiveTexture(GL_TEXTURE0));
-    LOG_GL_ERRORV(glBindTexture(GL_TEXTURE_2D, s_rbTex));
-    LOG_GL_ERRORV(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, buffer.BufferWi, buffer.BufferHt, GL_RGBA, GL_UNSIGNED_BYTE, &buffer.pixels[0]));
+    if (_shaderConfig->IsAudioFFTShader())
+    {
+        if (s_audioTex == 0)
+            s_audioTex = FFTAudioTexture();
+
+        AudioManager* audioManager = buffer.GetMedia();
+        if (audioManager != nullptr)
+        {
+            auto fftData = audioManager->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+
+            std::vector<float> fft128(fftData->cbegin(), fftData->cend());
+            fft128.push_back( 0.f );
+
+            LOG_GL_ERRORV(glActiveTexture(GL_TEXTURE0));
+            LOG_GL_ERRORV(glBindTexture(GL_TEXTURE_2D, s_audioTex));
+            LOG_GL_ERRORV(glTexSubImage2D(GL_TEXTURE_2D, 0, 0,0, 128,1, GL_RED, GL_FLOAT, fft128.data()));
+        }
+    }
+    else
+    {
+        LOG_GL_ERRORV(glActiveTexture(GL_TEXTURE0));
+        LOG_GL_ERRORV(glBindTexture(GL_TEXTURE_2D, s_rbTex));
+        LOG_GL_ERRORV(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, buffer.BufferWi, buffer.BufferHt, GL_RGBA, GL_UNSIGNED_BYTE, &buffer.pixels[0]));
+    }
+
     LOG_GL_ERRORV(glBindVertexArray(s_vertexArrayId));
     LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, s_vertexBufferId));
 
@@ -882,7 +931,7 @@ void ShaderEffect::Render(Effect* eff, SettingsMap& SettingsMap, RenderBuffer& b
     xlColorVector& cv(buffer.pixels);
     LOG_GL_ERRORV(glReadPixels(0, 0, buffer.BufferWi, buffer.BufferHt, GL_RGBA, GL_UNSIGNED_BYTE, &cv[0]));
     LOG_GL_ERRORV(glUseProgram(0));
-    
+
     UnsetGLContext(cache);
 }
 
@@ -997,7 +1046,7 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     reader.Parse(json, &root);
     _description = root["DESCRIPTION"].AsString();
     wxJSONValue inputs = root["INPUTS"];
-    wxString canvasImgName;
+    wxString canvasImgName, audioFFTName;
     for (int i = 0; i < inputs.Size(); i++)
     {
         wxString type = inputs[i]["TYPE"].AsString();
@@ -1123,6 +1172,14 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
                 //_canvasMode = true;
             }
         }
+        else if (type == "audioFFT")
+        {
+            if (inputs[i].HasMember("NAME"))
+            {
+                audioFFTName = inputs[i]["NAME"].AsString();
+                logger_base.info("ShaderEffect - found audioFFT shader with name '%s'", static_cast<const char *>(audioFFTName.c_str()));
+            }
+        }
         else if (type == "event")
         {
             // ignore these
@@ -1246,7 +1303,12 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     }
     shaderCode.Replace("gl_FragColor", "fragmentColor");
     shaderCode.Replace("vv_FragNormCoord", "isf_FragNormCoord");
-    if (!canvasImgName.empty())
+    if (!audioFFTName.empty())
+    {
+        shaderCode.Replace(audioFFTName, "texSampler");
+        _audioFFTMode = true;
+    }
+    else if (!canvasImgName.empty())
     {
         shaderCode.Replace(canvasImgName, "texSampler");
         _canvasMode = true;

--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -1045,6 +1045,8 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     wxJSONValue root;
     reader.Parse(json, &root);
     _description = root["DESCRIPTION"].AsString();
+    if (_description == "xLights AudioFFT")
+        _audioFFTMode = true;
     wxJSONValue inputs = root["INPUTS"];
     wxString canvasImgName, audioFFTName;
     for (int i = 0; i < inputs.Size(); i++)
@@ -1111,14 +1113,6 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
                 inputs[i].HasMember("NAME") ? inputs[i]["NAME"].AsString() : "",
                 inputs[i].HasMember("LABEL") ? inputs[i]["LABEL"].AsString() : "",
                 ShaderParmType::SHADER_PARM_AUDIO
-            ));
-        }
-        else if (type == "audiofft")
-        {
-            _parms.push_back(ShaderParm(
-                inputs[i].HasMember("NAME") ? inputs[i]["NAME"].AsString() : "",
-                inputs[i].HasMember("LABEL") ? inputs[i]["LABEL"].AsString() : "",
-                ShaderParmType::SHADER_PARM_AUDIOFFT
             ));
         }
         else if (type == "bool")
@@ -1267,6 +1261,7 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     prependText += _("vec4 IMG_PIXEL_2D(sampler2D sampler, vec2 pct, vec2 loc) {\n   return IMG_NORM_PIXEL_2D(sampler, pct, loc / RENDERSIZE);\n}\n\n");
     prependText += _("vec4 IMG_PIXEL(sampler2D sampler, vec2 loc) {\n   return texture(sampler, loc / RENDERSIZE);\n}\n\n");
     prependText += _("vec4 IMG_THIS_PIXEL(sampler2D sampler) {\n   vec2 coord = isf_FragNormCoord;\n   return texture(sampler, coord);\n}\n\n");
+    prependText += _("vec4 texture2D(sampler2D sampler, vec2 loc) {\n   return texture(sampler, loc);\n}\n\n");
     prependText += _("vec4 IMG_THIS_NORM_PIXEL_2D(sampler2D sampler, vec2 pct) {\n   vec2 coord = isf_FragNormCoord;\n   return texture(sampler, coord * pct);\n}\n\n");
     prependText += _("vec4 IMG_THIS_NORM_PIXEL(sampler2D sampler) {\n   vec2 coord = isf_FragNormCoord;\n   return texture(sampler, coord);\n}\n\n");
     prependText += _("vec4 IMG_THIS_PIXEL_2D(sampler2D sampler, vec2 pct) {\n   return IMG_THIS_NORM_PIXEL_2D(sampler, pct);\n}\n\n");

--- a/xLights/effects/ShaderEffect.h
+++ b/xLights/effects/ShaderEffect.h
@@ -135,12 +135,12 @@ struct ShaderParm
         return GetId(ctrl).AfterFirst('_');
     }
     wxString GetLabel() const { if (_label != "") return _label; return _name; }
-    bool ShowParm() const 
-    { 
-        return _type == ShaderParmType::SHADER_PARM_FLOAT || 
-            _type == ShaderParmType::SHADER_PARM_BOOL || 
+    bool ShowParm() const
+    {
+        return _type == ShaderParmType::SHADER_PARM_FLOAT ||
+            _type == ShaderParmType::SHADER_PARM_BOOL ||
             _type == ShaderParmType::SHADER_PARM_LONGCHOICE ||
-            _type == ShaderParmType::SHADER_PARM_POINT2D; 
+            _type == ShaderParmType::SHADER_PARM_POINT2D;
     }
 };
 
@@ -152,6 +152,7 @@ class ShaderConfig
     std::list<ShaderPass> _passes;
     std::string _code;
     bool _canvasMode = false;
+    bool _audioFFTMode = false;
     bool _hasRendersize = false;
     bool _hasTime = false;
 
@@ -163,6 +164,7 @@ public:
     std::string GetDescription() const { return _description; }
     std::string GetCode() const { return _code; }
     bool IsCanvasShader() const { return _canvasMode; }
+    bool IsAudioFFTShader() const { return _audioFFTMode; }
     bool HasRendersize() const { return _hasRendersize; }
     bool HasTime() const { return _hasTime; }
 };
@@ -200,9 +202,9 @@ protected:
         unsigned& s_rbTex, int& s_rbWidth, int& s_rbHeight);
     void recompileFromShaderConfig(const ShaderConfig* cfg, unsigned& s_programId);
 
-    typedef struct _VertexTex
+    struct VertexTex
     {
         float v[2];
         float t[2];
-    } VertexTex;
+    };
 };

--- a/xLights/effects/ShapeEffect.cpp
+++ b/xLights/effects/ShapeEffect.cpp
@@ -369,10 +369,10 @@ void ShapeEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer 
     if (useMusic)
     {
         if (buffer.GetMedia() != nullptr) {
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr)
             {
-                f = *pf->begin();
+                f = *(pf->cbegin());
             }
         }
     }
@@ -1100,7 +1100,7 @@ void ShapeEffect::Drawemoji(RenderBuffer& buffer, int xc, int yc, double radius,
     fi.Light(font.GetWeight() == wxFONTWEIGHT_LIGHT);
     fi.AntiAliased(font.IsAntiAliased());
     fi.Encoding(font.GetEncoding());
-    
+
     context->SetFont(fi, color);
 
     wxUniChar ch = emoji;

--- a/xLights/effects/StrobeEffect.cpp
+++ b/xLights/effects/StrobeEffect.cpp
@@ -48,7 +48,7 @@ wxPanel *StrobeEffect::CreatePanel(wxWindow *parent) {
 class StrobeClass
 {
 public:
-    
+
     int x,y;
     int duration; // How frames strobe light stays on. Will be decremented each frame
     HSVValue hsv;
@@ -98,9 +98,9 @@ void StrobeEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer
     if (reactToMusic) {
         float f = 0.0;
         if (buffer.GetMedia() != nullptr) {
-            std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+            std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
             if (pf != nullptr) {
-                f = *pf->begin();
+                f = *pf->cbegin();
             }
         }
         Number_Strobes *= f;
@@ -214,5 +214,5 @@ void StrobeEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffer
             ++it;
         }
     }
-    
+
 }

--- a/xLights/effects/TendrilEffect.cpp
+++ b/xLights/effects/TendrilEffect.cpp
@@ -823,10 +823,10 @@ void TendrilEffect::Render(RenderBuffer &buffer, const std::string& movement,
             float f = 0.1f;
             if (buffer.GetMedia() != nullptr)
             {
-                std::list<float>* p = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+                std::list<float> const * const p = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
                 if (p != nullptr)
                 {
-                    f = *p->begin();
+                    f = *p->cbegin();
                 }
             }
 
@@ -853,7 +853,7 @@ void TendrilEffect::Render(RenderBuffer &buffer, const std::string& movement,
             float f = 0.1f;
             if (buffer.GetMedia() != nullptr)
             {
-                std::list<float>* p = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+                const std::list<float>* p = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
                 if (p != nullptr)
                 {
                     f = *p->begin();

--- a/xLights/effects/VUMeterEffect.cpp
+++ b/xLights/effects/VUMeterEffect.cpp
@@ -114,12 +114,12 @@ std::list<std::string> VUMeterEffect::CheckEffectSettings(const SettingsMap& set
 
     wxString type = settings.Get("E_CHOICE_VUMeter_Type", "Waveform");
 
-    if (media == nullptr && 
+    if (media == nullptr &&
         (type == "Spectrogram" ||
-         type == "Spectrogram Peak" || 
-         type == "Volume Bars" || 
+         type == "Spectrogram Peak" ||
+         type == "Volume Bars" ||
          type == "Waveform" ||
-         type == "On" || 
+         type == "On" ||
         type == "Intensity Wave" ||
             type == "Level Bar" ||
             type == "Note Level Bar" ||
@@ -132,7 +132,7 @@ std::list<std::string> VUMeterEffect::CheckEffectSettings(const SettingsMap& set
         type == "Note On" ||
         type == "Note Level Pulse" ||
         type == "Timing Event Jump" ||
-            type == "Dominant Frequency Colour" || 
+            type == "Dominant Frequency Colour" ||
             type == "Dominant Frequency Colour Gradient"
             ))
     {
@@ -217,7 +217,7 @@ void VUMeterEffect::SetPanelStatus(Model* cls)
     vp->ValidateWindow();
 }
 
-void VUMeterEffect::SetDefaultParameters() 
+void VUMeterEffect::SetDefaultParameters()
 {
     VUMeterPanel *vp = static_cast<VUMeterPanel*>(panel);
     if (vp == nullptr) {
@@ -269,11 +269,11 @@ void VUMeterEffect::Render(Effect *effect, SettingsMap &SettingsMap, RenderBuffe
         );
 }
 
-class VUMeterRenderCache : public EffectRenderCache 
+class VUMeterRenderCache : public EffectRenderCache
 {
 
 public:
-    VUMeterRenderCache() 
+    VUMeterRenderCache()
 	{
         _lastsize = 0;
         _colourindex = 0;
@@ -515,7 +515,7 @@ int VUMeterEffect::DecodeShape(const std::string& shape)
 	else if (shape == "Filled Present")
 	{
 		return ShapeType::FILLED_PRESENT;
-	}	
+	}
 	else if (shape == "Candy Cane")
 	{
 		return ShapeType::CANDY_CANE;;
@@ -723,10 +723,10 @@ void VUMeterEffect::Render(RenderBuffer &buffer, SequenceElements *elements, int
 void VUMeterEffect::RenderSpectrogramFrame(RenderBuffer &buffer, int usebars, std::list<float>& lastvalues, std::list<float>& lastpeaks, std::list<int>& pauseuntilpeakfall, bool slowdownfalls, int startNote, int endNote, int xoffset, int yoffset, bool peak, int peakhold, bool line, bool logarithmicX, bool circle, int gain, int sensitivity, std::list<std::vector<wxPoint>>& lineHistory) const
 {
     if (buffer.GetMedia() == nullptr) return;
-    
+
     int truexoffset = xoffset * buffer.BufferWi / 100;
     int trueyoffset = yoffset * buffer.BufferHt / 100;
-	std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+	std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     while (lineHistory.size() > sensitivity / 10)
     {
@@ -748,7 +748,7 @@ void VUMeterEffect::RenderSpectrogramFrame(RenderBuffer &buffer, int usebars, st
             }
             else
             {
-                std::list<float>::iterator newdata = pdata->begin();
+                std::list<float>::const_iterator newdata = pdata->cbegin();
                 std::list<float>::iterator olddata = lastpeaks.begin();
                 auto pause = pauseuntilpeakfall.begin();
 
@@ -787,7 +787,7 @@ void VUMeterEffect::RenderSpectrogramFrame(RenderBuffer &buffer, int usebars, st
 			}
 			else
 			{
-				std::list<float>::iterator newdata = pdata->begin();
+				std::list<float>::const_iterator newdata = pdata->cbegin();
 				std::list<float>::iterator olddata = lastvalues.begin();
 
 				while (olddata != lastvalues.end())
@@ -1031,10 +1031,10 @@ void VUMeterEffect::RenderVolumeBarsFrame(RenderBuffer &buffer, int usebars, int
 		if (start + i >= 0)
 		{
 			float f = 0.0;
-			std::list<float>* pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
+			std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
 			if (pf != nullptr)
 			{
-				f = ApplyGain(*pf->begin(), gain);
+				f = ApplyGain(*pf->cbegin(), gain);
 			}
 			for (int j = 0; j < cols; j++)
 			{
@@ -1115,16 +1115,16 @@ void VUMeterEffect::RenderWaveformFrame(RenderBuffer &buffer, int usebars, int y
             if (start + i >= 0)
             {
                 float fh = 0.0;
-                std::list<float>* pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
+                std::list<float> const * pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
                 if (pf != nullptr)
                 {
-                    fh = ApplyGain(*pf->begin(), gain);
+                    fh = ApplyGain(*pf->cbegin(), gain);
                 }
                 float fl = 0.0;
                 pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_LOW, "");
                 if (pf != nullptr)
                 {
-                    fl = ApplyGain(*pf->begin(), gain);
+                    fl = ApplyGain(*pf->cbegin(), gain);
                 }
                 int s = (1.0 - fl) * buffer.BufferHt / 2;
                 int e = (1.0 + fh) * buffer.BufferHt / 2;
@@ -1313,12 +1313,12 @@ void VUMeterEffect::RenderTimingEventTimedSweepFrame(RenderBuffer& buffer, int u
 void VUMeterEffect::RenderOnFrame(RenderBuffer& buffer, int gain)
 {
     if (buffer.GetMedia() == nullptr) return;
-   
+
     float f = 0.0;
-	std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+	std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
 	if (pf != nullptr)
 	{
-		f = ApplyGain(*pf->begin(), gain);
+		f = ApplyGain(*pf->cbegin(), gain);
 	}
 	xlColor color1;
 	buffer.palette.GetColor(0, color1);
@@ -1339,13 +1339,13 @@ void VUMeterEffect::RenderDominantFrequencyColour(RenderBuffer& buffer, int sens
 
     float sns = (float)sensitivity / 100.0;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+    std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {
         int note = -1;
         float max = -1000;
-        auto it = pdata->begin();
+        auto it = pdata->cbegin();
         for (int i = 0; i < std::min((int)pdata->size(), endnote+1); i++)
         {
             if (i >= startnote)
@@ -1389,10 +1389,10 @@ void VUMeterEffect::RenderOnColourFrame(RenderBuffer& buffer, int gain)
     if (buffer.GetMedia() == nullptr) return;
 
     float f = 0.0;
-    std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+    std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
     if (pf != nullptr)
     {
-        f = ApplyGain(*pf->begin(), gain);
+        f = ApplyGain(*pf->cbegin(), gain);
     }
 
     xlColor color1;
@@ -1467,7 +1467,7 @@ void VUMeterEffect::RenderIntensityWaveFrame(RenderBuffer &buffer, int usebars, 
 		if (start + i >= 0)
 		{
 			float f = 0.0;
-			std::list<float>* pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
+			std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(start + i, FRAMEDATA_HIGH, "");
 			if (pf != nullptr)
 			{
 				f = ApplyGain(*pf->begin(), gain);
@@ -1501,12 +1501,12 @@ void VUMeterEffect::RenderIntensityWaveFrame(RenderBuffer &buffer, int usebars, 
 void VUMeterEffect::RenderLevelPulseFrame(RenderBuffer &buffer, int fadeframes, int sensitivity, int& lasttimingmark, int gain)
 {
     if (buffer.GetMedia() == nullptr) return;
-    
+
     float f = 0.0;
-	std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+	std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
 	if (pf != nullptr)
 	{
-		f = ApplyGain(*pf->begin(), gain);
+		f = ApplyGain(*pf->cbegin(), gain);
 	}
 
 	if (f > (float)sensitivity / 100.0)
@@ -1544,10 +1544,10 @@ void VUMeterEffect::RenderLevelJumpFrame(RenderBuffer& buffer, int fadeframes, i
     if (buffer.GetMedia() == nullptr) return;
 
     float f = 0.0;
-    std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+    std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
     if (pf != nullptr)
     {
-        f = ApplyGain(*pf->begin(), gain);
+        f = ApplyGain(*pf->cbegin(), gain);
     }
 
     if (f > (float)sensitivity / 100.0)
@@ -1592,7 +1592,7 @@ void VUMeterEffect::RenderLevelPulseColourFrame(RenderBuffer &buffer, int fadefr
     if (buffer.GetMedia() == nullptr) return;
 
     float f = 0.0;
-    std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+    std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
     if (pf != nullptr)
     {
         f = ApplyGain(*pf->begin(), gain);
@@ -1642,7 +1642,7 @@ void VUMeterEffect::RenderLevelColourFrame(RenderBuffer &buffer, int& colourinde
     if (buffer.GetMedia() == nullptr) return;
 
     float f = 0.0;
-    std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+    std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
     if (pf != nullptr)
     {
         f = ApplyGain(*pf->begin(), gain);
@@ -2092,7 +2092,7 @@ void VUMeterEffect::RenderLevelShapeFrame(RenderBuffer& buffer, const std::strin
     float scaling = (float)scale / 100.0 * 7.0;
 
 	float f = 0.0;
-	std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+	std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
 	if (pf != nullptr)
 	{
 		f = ApplyGain(*pf->begin(), gain);
@@ -2384,10 +2384,10 @@ void VUMeterEffect::RenderTimingEventJumpFrame(RenderBuffer &buffer, int fallfra
                 if (useAudioLevel)
                 {
                     float f = 0.0;
-                    std::list<float>* pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+                    std::list<float> const * const pf = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
                     if (pf != nullptr)
                     {
-                        f = ApplyGain(*pf->begin(), gain);
+                        f = ApplyGain(*pf->cbegin(), gain);
                     }
                     lastsize = f;
                 }
@@ -2591,7 +2591,7 @@ void VUMeterEffect::RenderNoteOnFrame(RenderBuffer& buffer, int startNote, int e
 {
     if (buffer.GetMedia() == nullptr) return;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+    std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {
@@ -2626,7 +2626,7 @@ void VUMeterEffect::RenderNoteLevelPulseFrame(RenderBuffer& buffer, int fadefram
 {
     if (buffer.GetMedia() == nullptr) return;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+    std::list<float>const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {
@@ -2678,7 +2678,7 @@ void VUMeterEffect::RenderNoteLevelJumpFrame(RenderBuffer& buffer, int fadeframe
 {
     if (buffer.GetMedia() == nullptr) return;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+    std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {
@@ -2736,7 +2736,7 @@ void VUMeterEffect::RenderLevelBarFrame(RenderBuffer &buffer, int bars, int sens
 {
     if (buffer.GetMedia() == nullptr) return;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
+    std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_HIGH, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {
@@ -2869,7 +2869,7 @@ void VUMeterEffect::RenderNoteLevelBarFrame(RenderBuffer &buffer, int bars, int 
 {
     if (buffer.GetMedia() == nullptr) return;
 
-    std::list<float>* pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
+    std::list<float> const * const pdata = buffer.GetMedia()->GetFrameData(buffer.curPeriod, FRAMEDATA_VU, "");
 
     if (pdata != nullptr && pdata->size() != 0)
     {

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -540,7 +540,7 @@ void xLightsFrame::CheckForValidModels()
                     {
                         logger_base.debug("Sequence Element Mismatch: rename '%s' to '%s'", (const char*)name.c_str(), (const char*)newName.c_str());
                         // This does not seem to be necessary and it has some bad side effects such as removing the model from all views
-                        //mSequenceElements.DeleteElement(newName); 
+                        //mSequenceElements.DeleteElement(newName);
                         mSequenceElements.GetElement(x)->SetName(newName);
                         if (AllModels[newName] == nullptr)
                         {
@@ -2018,7 +2018,7 @@ void xLightsFrame::RandomizeEffect(wxCommandEvent& event)
                                                                        el->GetIndex(),
                                                                        el->GetEffect(j));
 
-                // Keep canvas mode if it was set as the effect is unlikely to work 
+                // Keep canvas mode if it was set as the effect is unlikely to work
                 // properly without it
                 for (const auto& it : oldSettings)
                 {
@@ -2084,7 +2084,7 @@ void xLightsFrame::OnEffectSettingsTimerTrigger(wxTimerEvent& event)
 
     // grab a copy of the pointer in case user clicks off the effect
     Effect* eff = selectedEffect;
-    
+
     // This should not be necessary but i have seen enough crashes where accessing the eff at this point bombs out that I want to check it is valid
     if (eff != nullptr)
     {
@@ -3077,7 +3077,7 @@ std::map<int, std::list<float>> xLightsFrame::LoadPolyphonicTranscription(AudioM
 
         for (size_t i = 0; i < frames; i++)
         {
-            std::list<float>* pdata = audio->GetFrameData(i, FRAMEDATA_NOTES, "");
+            std::list<float> const * const pdata = audio->GetFrameData(i, FRAMEDATA_NOTES, "");
             if (pdata != nullptr)
             {
                 res[i*intervalMS] = *pdata;


### PR DESCRIPTION
This allows for some xLights-specific shaders on https://isf.video/ to use audio input to generate their output... as opposed to some that just generate their own input and others that rely on canvas mode to pull in the frame from the track below.

Some examples here, although currently there is only one shader on the website that will work: https://vimeo.com/427249244