### PR TITLE
fix/restore 2d msw and osx click behavior

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2696,6 +2696,7 @@ bool LayoutPanel::SelectMultipleModels(int x,int y)
     propertyEditor->Freeze();
     clearPropGrid();
     propertyEditor->Thaw();
+    bool mmWorkRequired = false;
     Model* clickedModel = modelPreview->GetModels()[found[0]];
 
     if (clickedModel->Selected)
@@ -2704,12 +2705,28 @@ bool LayoutPanel::SelectMultipleModels(int x,int y)
     }
     else if (clickedModel->GroupSelected)
     {
-        UnSelectAllModelsInTree();
-        SelectBaseObjectInTree(clickedModel);
+        clickedModel->GroupSelected = false;
+        clickedModel->Selected = true;
+        if (selectedBaseObject != nullptr) {
+            selectedBaseObject->GroupSelected = true;
+            selectedBaseObject->Selected = false;
+            selectedBaseObject->SelectHandle(-1);
+            selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(-1);
+        }
+        
+        selectedBaseObject = clickedModel;
+        highlightedBaseObject = selectedBaseObject;
+        selectedBaseObject->SelectHandle(-1);
+        selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
+        mmWorkRequired = true;
     }
     else
     {
         SelectModelInTree(clickedModel);
+    }
+    
+    if (mmWorkRequired) {
+        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::SelectMultipleModels");
     }
 
     return true;


### PR DESCRIPTION
This should fix 2d click and mirror the same behavior of 3d across platforms.  I was trying to be very careful not to disrupt click behavior and followed osx behavior for 2d which is different than msw in current release, my apologies.  This also fixes prior bug with msw where there is no selected primary object with handles.
