### PR TITLE
Set MatrixScale for all models just in case

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -4641,8 +4641,9 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
 
+    std::string selectedType = modelPreview->GetModels()[selectedindex]->GetDisplayAs();
     std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
-
+    
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
 
     if (sameWidth)
@@ -4657,6 +4658,13 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
                 if (z_scale) {
                     modelPreview->GetModels()[i]->GetBaseObjectScreenLocation().SetMDepth(width);
                 }
+                
+                // if matrix is based selected object and adjusting another matrix to match width, then match scale
+                if (selectedType == "Matrix" && modelPreview->GetModels()[i]->DisplayAs == selectedType) {
+                    glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
+                    modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
+                }
+
             }
         }
     }
@@ -4669,10 +4677,17 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
             if (modelPreview->GetModels()[i]->GroupSelected)
             {
                 modelPreview->GetModels()[i]->SetHeight(height);
+                
+                // if matrix is based selected object and adjusting another matrix to match height, then match scale
+                if (selectedType == "Matrix" && modelPreview->GetModels()[i]->DisplayAs == selectedType) {
+                    glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
+                    modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
+                }
+
             }
         }
     }
-
+    
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignResize");
     
     ReselectTreeModels(selectedModelPaths);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -4641,7 +4641,6 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
     int selectedindex = GetSelectedModelIndex();
     if (selectedindex < 0) return;
 
-    std::string selectedType = modelPreview->GetModels()[selectedindex]->GetDisplayAs();
     std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
     
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
@@ -4659,12 +4658,8 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
                     modelPreview->GetModels()[i]->GetBaseObjectScreenLocation().SetMDepth(width);
                 }
                 
-                // if matrix is based selected object and adjusting another matrix to match width, then match scale
-                if (selectedType == "Matrix" && modelPreview->GetModels()[i]->DisplayAs == selectedType) {
-                    glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
-                    modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
-                }
-
+                glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
+                modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
             }
         }
     }
@@ -4677,13 +4672,9 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
             if (modelPreview->GetModels()[i]->GroupSelected)
             {
                 modelPreview->GetModels()[i]->SetHeight(height);
-                
-                // if matrix is based selected object and adjusting another matrix to match height, then match scale
-                if (selectedType == "Matrix" && modelPreview->GetModels()[i]->DisplayAs == selectedType) {
-                    glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
-                    modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
-                }
 
+                glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
+                modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
             }
         }
     }


### PR DESCRIPTION
Matrices were the only models I could visually see a difference in after resize but just in case set the ScaleMatrix props to be the same on all models being adjusted to match height/width or both, not just matrix as other models sometimes were 1/10th off, others were 3-5/100th off in scale properties which is why #2044 only reported matrix resize issues as they were not visible, but this should keep all things square on resize.