### PR TITLE
Fix boxedmodel resize

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -4746,10 +4746,10 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
     bool isCustom3d = false;
     wxString customFingerprint = "";
     
-    // check if custom 3d and set model fingerprint if so
+    // check if custom 3d and set model fingerprint
     if (selectedType == "Custom") {
+        customFingerprint = selectedModel->GetModelXml()->GetAttribute("CustomModel", "");
         if (wxSplit(customFingerprint, '|').size() > 1) {
-            customFingerprint = selectedModel->GetModelXml()->GetAttribute("CustomModel", "");
             isCustom3d = true;
         }
     }
@@ -4773,8 +4773,18 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
             
             if ((isBoxed && selectedType == modelType && selectedType != "Custom") || custom3dPrintsMatch) {
                 // boxed model, types match and not a custom model OR custom 3d model and fingerprints matched so use scale matrix
-                glm::vec3 matrixScale = modelPreview->GetModels()[selectedindex]->GetModelScreenLocation().GetScaleMatrix();
-                modelPreview->GetModels()[i]->GetModelScreenLocation().SetScaleMatrix(matrixScale);
+                glm::vec3 matrixScale = selectedModel->GetModelScreenLocation().GetScaleMatrix();
+                if (sameWidth && sameHeight) {
+                    modelToResize->GetModelScreenLocation().SetScaleMatrix(matrixScale);
+                } else if (sameWidth) {
+                    float scaleY = ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).GetScaleY();
+                    ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).SetScale(matrixScale.x, scaleY);
+                    ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).SetScaleZ(matrixScale.z);
+                } else {
+                    float scaleX = ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).GetScaleX();
+                    ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).SetScale(scaleX, matrixScale.y);
+                    ((BoxedScreenLocation&)modelToResize->GetModelScreenLocation()).SetScaleZ(matrixScale.z);
+                }
             } else {
                 // no special resizing, same as 2020.24 and prior
                 bool z_scale = modelPreview->GetModels()[i]->GetBaseObjectScreenLocation().GetSupportsZScaling();


### PR DESCRIPTION
Another attempt at fixing resize matching issue for boxed models, thank you Gil and Keith for the feedback on my failed last attempt.

This should fix #2044 which was more than just matrix (thank you Kieth for the tip), it was all boxed models...Matrix, Cube, Sphere, Tree, Custom and DMX. I couldn't find an exact science to match size of boxed models of various types so this will only correctly match size/scale for boxed models of the same type or for custom 3d models those that have the exact same fingerprint. If there is not a match in type/fingerprint for box models OR it is not a boxed model at all it defaults to prior behavior, just set W/H.

This also fixes the following issue for DMX models where bulk edit resize wasn't working at all, any models selected that weren't the base selection were sent off into the abyss as a tiny dot.

![dmx-resize](https://user-images.githubusercontent.com/2279532/85189533-eae8c180-b27d-11ea-975f-b55c7b8fbad2.gif)

If I'm still wrong and there is a better way to go about this, that is unified across all models types I'm all ears...