### PR TITLE
lor-convert-fixes

### DIFF
--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1893,10 +1893,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         }
                         else if (EffectType == "twinkle")
                         {
-                            if (intensity == 0 && startIntensity == 0 && endIntensity == 0)
-                            {
-                                intensity = MaxIntensity;
-                            }
                             twinklestate = static_cast<int>(rand01()*2.0) & 0x01;
                             int nexttwinkle = static_cast<int>(rand01()*twinkleperiod + 100) / LORImportInterval;
                             if (intensity > 0)
@@ -1929,10 +1925,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         }
                         else if (EffectType == "shimmer")
                         {
-                            if (intensity == 0 && startIntensity == 0 && endIntensity == 0)
-                            {
-                                intensity = MaxIntensity;
-                            }
                             if (intensity > 0)
                             {
                                 for (i = 0; i < perdiff; i++)

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1492,7 +1492,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
     wxArrayString context;
     int unit, circuit, rampdiff;
     int i;
-    int twinkleperiod = 400;
     int curchannel = -1;
     int MappedChannelCnt = 0;
     int MaxIntensity = 100;
@@ -1889,6 +1888,9 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         {
                             int twinkleFrameCount = 0, twinkleState = 0;
                             
+                            const int twinkleMaxTimeMillis = 400;
+                            const int twinkleMinTimeMillis = 100;
+                            
                             int frameIntensity = intensity;
                             for (i = 0; i < perdiff; i++)
                             {
@@ -1899,7 +1901,7 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                                 if (--twinkleFrameCount <= 0)
                                 {
                                     twinkleState = !twinkleState;
-                                    twinkleFrameCount = static_cast<int>(rand01() * twinkleperiod + 100) / LORImportInterval;
+                                    twinkleFrameCount = static_cast<int>(rand01() * twinkleMaxTimeMillis + twinkleMinTimeMillis) / LORImportInterval;
                                 }
                                 if (!frameIntensity)
                                 {

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1897,7 +1897,7 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             
                             // create an initial, random twinkleState value
                             // the exact value is irrelevant since it is used as a seed
-                            int twinkleState = rand01() >= 0.5;
+                            int twinkleState = static_cast<int>(rand01() * 2.0 + curchannel) & 0x01;
                             
                             for (i = 0; i < frameCount; i++)
                             {

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1494,7 +1494,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
     int i;
     int curchannel = -1;
     int MappedChannelCnt = 0;
-    int MaxIntensity = 100;
     int EffectCnt = 0;
     int network, chindex = -1;
     long cnt = 0;
@@ -1855,10 +1854,12 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         
                         if (EffectType != "DMX intensity")
                         {
+                            const int MaxLORIntensity = 100;
+                            
                             // convert LOR's 0-100 range to xLight's 0-255 range
-                            intensity = intensity * 255 / MaxIntensity;
-                            startIntensity = startIntensity * 255 / MaxIntensity;
-                            endIntensity = endIntensity * 255 / MaxIntensity;
+                            intensity = intensity * 255 / MaxLORIntensity;
+                            startIntensity = startIntensity * 255/ MaxLORIntensity;
+                            endIntensity = endIntensity * 255 / MaxLORIntensity;
                         }
                         
                         // if startIntensity & endIntensity match, then the intensity is the same throughout the effect

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1891,7 +1891,7 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             
                             // create an initial, random twinkleState value
                             // the exact value is irrelevant since it is used as a seed
-                            int twinkleState = static_cast<int>(rand01() * 2.0) & 0x01;
+                            int twinkleState = rand01() >= 0.5;
                             
                             for (i = 0; i < frameCount; i++)
                             {
@@ -1903,6 +1903,10 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                                 {
                                     twinkleState = !twinkleState;
                                     twinkleFrameCount = static_cast<int>(rand01() * TwinkleMaxTimeMillis + TwinkleMinTimeMillis) / LORImportInterval;
+                                    
+                                    // prevent the effect subloop from exceeding the remaining frameCount
+                                    // this ensures the last frame of each effect subloop matches the desired endIntensity
+                                    twinkleFrameCount = std::min(twinkleFrameCount, frameCount - i);
                                 }
                                 if (twinkleState)
                                 {

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1920,6 +1920,10 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                                 }
                             }
                         }
+                        else
+                        {
+                            AppendConvertStatus(wxString("WARNING: unable to convert LOR effect '") + EffectType + wxString("'\n"));
+                        }
                     }
                 }
             }

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1884,8 +1884,12 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         }
                         else if (EffectType == "twinkle")
                         {
-                            const int twinkleMaxTimeMillis = 400, twinkleMinTimeMillis = 100;
-                            int twinkleFrameCount = 0, twinkleState = 0;
+                            const int TwinkleMaxTimeMillis = 400, TwinkleMinTimeMillis = 100;
+                            int twinkleFrameCount = 0;
+                            
+                            // create an initial, random twinkleState value
+                            // the exact value is irrelevant since it is used as a seed
+                            int twinkleState = static_cast<int>(rand01() * 2.0) & 0x01;
                             
                             for (i = 0; i < frameCount; i++)
                             {
@@ -1896,7 +1900,7 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                                 if (--twinkleFrameCount <= 0)
                                 {
                                     twinkleState = !twinkleState;
-                                    twinkleFrameCount = static_cast<int>(rand01() * twinkleMaxTimeMillis + twinkleMinTimeMillis) / LORImportInterval;
+                                    twinkleFrameCount = static_cast<int>(rand01() * TwinkleMaxTimeMillis + TwinkleMinTimeMillis) / LORImportInterval;
                                 }
                                 if (twinkleState)
                                 {

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1851,6 +1851,19 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
 
                     if (perdiff > 0)
                     {
+                        // ramping effects check if startIntensity > 0 || endIntensity > 0
+                        // if the difference is 0, this zeroes out both values to avoid those code paths
+                        // intensity defaults to 0, so its code paths will also be ignored
+                        if (startIntensity > 0 || endIntensity > 0)
+                        {
+                            rampdiff = endIntensity - startIntensity;
+                            if (rampdiff == 0)
+                            {
+                                startIntensity = 0;
+                                endIntensity = 0;
+                            }
+                        }
+                        
                         wxString EffectType = getAttributeValueSafe(stagEvent, "type");
                         if (EffectType != "DMX intensity")
                         {
@@ -1869,9 +1882,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             }
                             else if (startIntensity > 0 || endIntensity > 0)
                             {
-                                // ramp
-                                rampdiff = endIntensity - startIntensity;
-                                if (rampdiff == 0) logger_base.crit("This is going to crash. AAA");
                                 for (i = 0; i < perdiff; i++)
                                 {
                                     intensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
@@ -1902,8 +1912,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             }
                             else if (startIntensity > 0 || endIntensity > 0)
                             {
-                                // ramp
-                                rampdiff = endIntensity - startIntensity;
                                 for (i = 0; i < perdiff; i++)
                                 {
                                     intensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
@@ -1933,9 +1941,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             }
                             else if (startIntensity > 0 || endIntensity > 0)
                             {
-                                // ramp
-                                rampdiff = endIntensity - startIntensity;
-                                if (rampdiff == 0) logger_base.crit("This is going to crash. BBB");
                                 for (i = 0; i < perdiff; i++)
                                 {
                                     twinklestate = (startper + i) & 0x01;

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1839,9 +1839,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                     empty = false;
                     EffectCnt++;
                     
-                    int intensity = getAttributeValueAsInt(stagEvent, "intensity");
-                    int startIntensity = getAttributeValueAsInt(stagEvent, "startIntensity");
-                    int endIntensity = getAttributeValueAsInt(stagEvent, "endIntensity");
                     const int startFrameIndex = getAttributeValueAsInt(stagEvent, "startCentisecond") * 10 / LORImportInterval;
                     const int endFrameIndex = getAttributeValueAsInt(stagEvent, "endCentisecond") * 10 / LORImportInterval;
                     const int frameCount = endFrameIndex - startFrameIndex;
@@ -1850,7 +1847,12 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
 
                     if (frameCount > 0)
                     {
-                        wxString EffectType = getAttributeValueSafe(stagEvent, "type");
+                        const wxString EffectType = getAttributeValueSafe(stagEvent, "type");
+                        
+                        int intensity = getAttributeValueAsInt(stagEvent, "intensity");
+                        int startIntensity = getAttributeValueAsInt(stagEvent, "startIntensity");
+                        int endIntensity = getAttributeValueAsInt(stagEvent, "endIntensity");
+                        
                         if (EffectType != "DMX intensity")
                         {
                             // convert LOR's 0-100 range to xLight's 0-255 range

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1851,6 +1851,15 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
 
                     if (perdiff > 0)
                     {
+                        wxString EffectType = getAttributeValueSafe(stagEvent, "type");
+                        if (EffectType != "DMX intensity")
+                        {
+                            // convert LOR's 0-100 range to xLight's 0-255 range
+                            intensity = intensity * 255 / MaxIntensity;
+                            startIntensity = startIntensity * 255 / MaxIntensity;
+                            endIntensity = endIntensity * 255 / MaxIntensity;
+                        }
+                        
                         // ramping effects check if startIntensity > 0 || endIntensity > 0
                         // if the difference is 0, this zeroes out both values to avoid those code paths
                         // intensity defaults to 0, so its code paths will also be ignored
@@ -1864,13 +1873,6 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                             }
                         }
                         
-                        wxString EffectType = getAttributeValueSafe(stagEvent, "type");
-                        if (EffectType != "DMX intensity")
-                        {
-                            intensity = intensity * 255 / MaxIntensity;
-                            startIntensity = startIntensity * 255 / MaxIntensity;
-                            endIntensity = endIntensity * 255 / MaxIntensity;
-                        }
                         if (EffectType == "intensity" || EffectType == "DMX intensity")
                         {
                             if (intensity > 0)

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1486,8 +1486,6 @@ static void mapLORInfo(const LORInfo &info, std::vector< std::vector<int> > *uni
 
 void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
 {
-    static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-
     wxString NodeName, msg, deviceType, networkAsString;
     wxArrayString context;
     int unit, circuit;

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1491,7 +1491,7 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
     wxString NodeName, msg, deviceType, networkAsString;
     wxArrayString context;
     int unit, circuit, rampdiff;
-    int i, twinklestate;
+    int i;
     int twinkleperiod = 400;
     int curchannel = -1;
     int MappedChannelCnt = 0;
@@ -1887,25 +1887,25 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         }
                         else if (EffectType == "twinkle")
                         {
-                            int twinkleFrameCount = 0;
+                            int twinkleFrameCount = 0, twinkleState = 0;
                             
                             int frameIntensity = intensity;
                             for (i = 0; i < perdiff; i++)
                             {
                                 // count down twinkleFrameCount (defaults to 0)
-                                // when <= 0, flip flop twinklestate, this produces a random on/off pattern
+                                // when <= 0, flip flop twinkleState, this produces a random on/off pattern
                                 // calculate the new twinkleFrameCount value (in interations)
                                 // this produces several unique patterns within the full [0, perdiff] window
                                 if (--twinkleFrameCount <= 0)
                                 {
-                                    twinklestate = !twinklestate;
+                                    twinkleState = !twinkleState;
                                     twinkleFrameCount = static_cast<int>(rand01() * twinkleperiod + 100) / LORImportInterval;
                                 }
                                 if (!frameIntensity)
                                 {
                                     frameIntensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
                                 }
-                                SeqData[startper + i][curchannel] = frameIntensity * twinklestate;
+                                SeqData[startper + i][curchannel] = frameIntensity * twinkleState;
                             }
                         }
                         else if (EffectType == "shimmer")
@@ -1917,8 +1917,10 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                                 {
                                     frameIntensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
                                 }
-                                twinklestate = (startper + i) & 0x01;
-                                SeqData[startper + i][curchannel] = frameIntensity * twinklestate;
+                                
+                                // use bit 0 of (startper + i) to determine the output state
+                                // this creates a "random" on/off pattern using the odd/even sum
+                                SeqData[startper + i][curchannel] = frameIntensity * ((startper + i) & 0x01);
                             }
                         }
                     }

--- a/xLights/ConvertDialog.cpp
+++ b/xLights/ConvertDialog.cpp
@@ -1875,72 +1875,50 @@ void ConvertDialog::ReadLorFile(const wxString& filename, int LORImportInterval)
                         
                         if (EffectType == "intensity" || EffectType == "DMX intensity")
                         {
-                            if (intensity > 0)
+                            int frameIntensity = intensity;
+                            for (i = 0; i < perdiff; i++)
                             {
-                                for (i = 0; i < perdiff; i++)
+                                if (!frameIntensity)
                                 {
-                                    SeqData[startper + i][curchannel] = intensity;
+                                    frameIntensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
                                 }
-                            }
-                            else if (startIntensity > 0 || endIntensity > 0)
-                            {
-                                for (i = 0; i < perdiff; i++)
-                                {
-                                    intensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
-                                    SeqData[startper + i][curchannel] = intensity;
-                                }
+                                SeqData[startper + i][curchannel] = frameIntensity;
                             }
                         }
                         else if (EffectType == "twinkle")
                         {
-                            twinklestate = static_cast<int>(rand01()*2.0) & 0x01;
-                            int nexttwinkle = static_cast<int>(rand01()*twinkleperiod + 100) / LORImportInterval;
-                            if (intensity > 0)
+                            int twinkleFrameCount = 0;
+                            
+                            int frameIntensity = intensity;
+                            for (i = 0; i < perdiff; i++)
                             {
-                                for (i = 0; i < perdiff; i++)
+                                // count down twinkleFrameCount (defaults to 0)
+                                // when <= 0, flip flop twinklestate, this produces a random on/off pattern
+                                // calculate the new twinkleFrameCount value (in interations)
+                                // this produces several unique patterns within the full [0, perdiff] window
+                                if (--twinkleFrameCount <= 0)
                                 {
-                                    SeqData[startper + i][curchannel] = intensity * twinklestate;
-                                    nexttwinkle--;
-                                    if (nexttwinkle <= 0)
-                                    {
-                                        twinklestate = 1 - twinklestate;
-                                        nexttwinkle = static_cast<int>(rand01()*twinkleperiod + 100) / LORImportInterval;
-                                    }
+                                    twinklestate = !twinklestate;
+                                    twinkleFrameCount = static_cast<int>(rand01() * twinkleperiod + 100) / LORImportInterval;
                                 }
-                            }
-                            else if (startIntensity > 0 || endIntensity > 0)
-                            {
-                                for (i = 0; i < perdiff; i++)
+                                if (!frameIntensity)
                                 {
-                                    intensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
-                                    SeqData[startper + i][curchannel] = intensity * twinklestate;
-                                    nexttwinkle--;
-                                    if (nexttwinkle <= 0)
-                                    {
-                                        twinklestate = 1 - twinklestate;
-                                        nexttwinkle = static_cast<int>(rand01()*twinkleperiod + 100) / LORImportInterval;
-                                    }
+                                    frameIntensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
                                 }
+                                SeqData[startper + i][curchannel] = frameIntensity * twinklestate;
                             }
                         }
                         else if (EffectType == "shimmer")
                         {
-                            if (intensity > 0)
+                            int frameIntensity = intensity;
+                            for (i = 0; i < perdiff; i++)
                             {
-                                for (i = 0; i < perdiff; i++)
+                                if (!frameIntensity)
                                 {
-                                    twinklestate = (startper + i) & 0x01;
-                                    SeqData[startper + i][curchannel] = intensity * twinklestate;
+                                    frameIntensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
                                 }
-                            }
-                            else if (startIntensity > 0 || endIntensity > 0)
-                            {
-                                for (i = 0; i < perdiff; i++)
-                                {
-                                    twinklestate = (startper + i) & 0x01;
-                                    intensity = (int)((double)(i) / perdiff * rampdiff + startIntensity);
-                                    SeqData[startper + i][curchannel] = intensity * twinklestate;
-                                }
+                                twinklestate = (startper + i) & 0x01;
+                                SeqData[startper + i][curchannel] = frameIntensity * twinklestate;
                             }
                         }
                     }


### PR DESCRIPTION
This PR introduces several fixes to the LOR sequence conversion process, as well as some code cleanup to improve readability. Besides fixes 1, 2 & 5 which introduce slight corrections, this PR does not modify legacy behavior. No LOR sequences already converted by xLights are modified by these changes.

**Fixes**
1. LOR unit IDs are now properly clamped, and check against the upper bound limit (0xF0 - 140). A warning output has been added to prevent silent failures. The unit ID is now clamped to produce more consistent error handling instead of the legacy `+ 256` behavior that produces (effectively) random offsets.
2. `twinkleFrameCount` (previously `nexttwinkle`) is now min'd against the remaining frame count for the effect. This ensures that the last frame of the effect will *more closely* match the `endIntensity` value. Previously a twinkle effect could end at 100% intensity, even though the LOR sequence specifies a 0% `endIntensity` value. (Testing note: `twinkleState` may still be false, resulting in no output even in situations where `endIntensity` is 100%, this is expected twinkle behavior.)
3. LOR effects safely handle matching `startIntensity` & `endIntensity` values. While strange, these are harmless configuration errors. Previously this produced logger output warning of crashes.
4. Unsupported LOR effect types now produce a warning output to prevent silent failures.
5. As a potential fix to issue #2134, the initial `twinkleState` value is seeded using the previous `rand01` value now summed with `curchannel`. This introduces an additional layer of entropy to produce a better initial random state rather than relying on the output of `rand01` directly.

**Cleanup**
1. Magic numbers have been moved to named constants, with some additionally marked as `const` to hint at compiler optimizations. 
2. Several variables have been renamed - for example, `perdiff` -> `frameCount`.
3. `MaxIntensity`, `nexttwinkle`, `twinklestate` have been moved locally to better reflect their use scope.
4. The code duplication in each effect has been minimized and simplified using a predetermined step value. As a bonus, this enables the alternate code paths for intensity ramping vs. static intensity to be merged.