### PR TITLE
FSEQ VariableHeader parsing improvements

### DIFF
--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -405,17 +405,19 @@ void FSEQFile::preload(uint64_t pos, uint64_t size) {
 }
 
 void FSEQFile::parseVariableHeaders(const std::vector<uint8_t> &header, int start) {
-    while (start < header.size() - 5) {
+    const int VariableHeaderLength = 4;
+    
+    while (start < header.size() - 5) { // todo: where is 5 from? off by one from 4?
         int len = read2ByteUInt(&header[start]);
         if (len) {
             VariableHeader vheader;
             vheader.code[0] = header[start + 2];
             vheader.code[1] = header[start + 3];
-            vheader.data.resize(len - 4);
-            memcpy(&vheader.data[0], &header[start + 4], len - 4);
+            vheader.data.resize(len - VariableHeaderLength);
+            memcpy(&vheader.data[0], &header[start + VariableHeaderLength], len - VariableHeaderLength);
             m_variableHeaders.push_back(vheader);
         } else {
-            len += 4;
+            len += VariableHeaderLength;
         }
         start += len;
     }

--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -423,7 +423,7 @@ void FSEQFile::parseVariableHeaders(const std::vector<uint8_t> &header, int read
 
         readIndex += VariableLengthSize;
 
-        if (!dataLength) {
+        if (dataLength <= 0) {
             LogErr(VB_SEQUENCE, "VariableHeader has 0 length data: %c%c", header[readIndex], header[readIndex + 1]);
             
             // empty data, advance only the length of the 2 byte code

--- a/xLights/FSEQFile.cpp
+++ b/xLights/FSEQFile.cpp
@@ -452,6 +452,13 @@ void FSEQFile::parseVariableHeaders(const std::vector<uint8_t> &header, int read
             // readIndex is now the first byte of the data
             readIndex += VariableCodeSize;
 
+            // print a warning if the data is not null terminated
+            // this is to assist debugging potential string related issues
+            // the data is not forcibly null terminated to avoid mutating unknown data
+            if (header[readIndex + dataLength] != '\0') {
+                LogErr(VB_SEQUENCE, "VariableHeader %c%c data is not NULL terminated!", vheader.code[0], vheader.code[1]);
+            }
+
             vheader.data.resize(dataLength);
             memcpy(&vheader.data[0], &header[readIndex], dataLength);
             


### PR DESCRIPTION
This PR includes several code hardening improvements for the `parseVariableHeaders` function. The goal of this is to help protect against corrupted FSEQ files (accidentally or maliciously) and improve logging output to assist with debugging potential issues.

Assuming there is interest in these changes, I'll upstream them to fpp's `FSEQFile` implementation.

- Zero length VariableHeaders are now ignored and print a warning. Some previous logic vaguely prevented this, with some issues. While xLights could parse these VariableHeaders all the same, the reason to not is simply a continuation of the current implementation and reduces needed handling.
- The data length of each VariableHeader is now checked against the `header` buffer. This prevents an incorrect length from reading out of bounds and unintentionally accessing memory, or crashing the program.
- VariableHeaders with unrecognized codes (not `mf` or `sp`) print debug messages to increase visibility into the read process for modified sequence files.
- An error is now logging if the data is not null terminated (for recognized VariableHeaders). This helps locate errors caused by wrongly encoded sequence files. 

**Misc. Changes**
- Magic number usage has been reduced and moved into a named const, `FSEQ_VARIABLE_HEADER_SIZE`. 
- Added debug output when reading VariableHeaders to improve visibility.