### PR TITLE
don't export or import empty groups

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -1926,6 +1926,9 @@ wxString Model::SerialiseGroups() const
 
 void Model::DeserialiseGroups(wxXmlNode* n, int w, int h, const wxString& name)
 {
+    auto grpModels = n->GetAttribute("models");
+    if (grpModels.length() == 0) return;
+    
     modelManager.GetXLightsFrame()->AllModels.DeserialiseModelGroup(n, w, h, name);
 }
 

--- a/xLights/models/ModelGroup.cpp
+++ b/xLights/models/ModelGroup.cpp
@@ -204,6 +204,8 @@ bool ModelGroup::ContainsModel(Model* m, std::list<const Model*>& visited) const
 // Returns true if group only contains model and submodels of that model
 bool ModelGroup::OnlyContainsModel(const std::string& name) const
 {
+    if (modelNames.size() == 0) return false;
+
     for (const auto& it : modelNames)         {
         if (!StartsWith(it, name)) return false;
     }


### PR DESCRIPTION
Ignore empty model groups on export, also ignore them on import for all the existing xmodel files exported with empty groups.