### PR TITLE
Add log4cpp CFLAGS to xSMSDaemon build

### DIFF
--- a/xSchedule/xSMSDaemon/xSMSDaemon.cbp
+++ b/xSchedule/xSMSDaemon/xSMSDaemon.cbp
@@ -154,6 +154,7 @@
 					<Add option="`wx-config --version=3.1 --cflags`" />
 					<Add option="`pkg-config --cflags libavformat libavcodec libavutil  libswresample libswscale`" />
 					<Add option="`pkg-config --cflags gstreamer-1.0 gstreamer-video-1.0`" />
+					<Add option="`pkg-config --cflags log4cpp`" />
 					<Add option="`curl-config --cflags`" />
 					<Add option="-Winvalid-pch" />
 					<Add option="-DWX_PRECOMP" />
@@ -191,6 +192,7 @@
 					<Add option="`wx-config --version=3.1 --cflags`" />
 					<Add option="`pkg-config --cflags gstreamer-1.0 gstreamer-video-1.0`" />
 					<Add option="`pkg-config --cflags libavformat libavcodec libavutil  libswresample libswscale`" />
+					<Add option="`pkg-config --cflags log4cpp`" />
 					<Add option="`curl-config --cflags`" />
 					<Add option="-Winvalid-pch" />
 					<Add option="-DWX_PRECOMP" />


### PR DESCRIPTION
The --libs are already present.  If I install log4cpp into my home directory, and set PKG_CONFIG_PATH appropriately, everything builds except xSMSDaemon, which can't find log4cpp include files.  This fixes those errors.