### PR TITLE
fix 3d object mouse move/rotate/select/etc

### DIFF
--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -85,7 +85,7 @@ inline BaseObject *ModelManager::GetObject(const std::string &name) const {
 
 bool ModelManager::IsModelValid(const BaseObject* o) const {
 
-    const Model* m = static_cast<const Model*>(o);
+    const Model* m = dynamic_cast<const Model*>(o);
     if (m == nullptr) return true; // we dont validate objects ... just assume they are ok
 
     std::lock_guard<std::recursive_mutex> lock(_modelMutex);


### PR DESCRIPTION
Fix issue introduced by f64378faac3424d3802406e9eafbf2ee187d1356 for 3d objects, you could select 1 but couldn't do anything with the handles or select multiple.  static_cast never returns null.