### PR TITLE
add disperse feature to layout

### DIFF
--- a/xLights.xcodeproj/project.pbxproj
+++ b/xLights.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1ECB4F631FF4D014006D57AA /* BulkEditControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1ECB4F601FF4D013006D57AA /* BulkEditControls.cpp */; };
 		1ECB4F641FF4D014006D57AA /* BulkEditSliderDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1ECB4F611FF4D014006D57AA /* BulkEditSliderDialog.cpp */; };
 		3D585F311E7E541400A3F84F /* UtilFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D585F301E7E541400A3F84F /* UtilFunctions.cpp */; };
+		63B4360324EE23250000C90D /* DisperseOptionsDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 63B4360224EE23250000C90D /* DisperseOptionsDialog.cpp */; };
 		6701999F1CE5A03200AE9B7E /* RenderProgressDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6701999D1CE5A03200AE9B7E /* RenderProgressDialog.cpp */; };
 		67025C6E20D7E80900BF1AC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 67025C6D20D7E80900BF1AC6 /* Assets.xcassets */; };
 		67025C8C20D7E85100BF1AC6 /* SettingsDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67025C7920D7E84F00BF1AC6 /* SettingsDialog.cpp */; };
@@ -572,6 +573,8 @@
 		1ECB4F611FF4D014006D57AA /* BulkEditSliderDialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BulkEditSliderDialog.cpp; sourceTree = "<group>"; };
 		1ECB4F621FF4D014006D57AA /* BulkEditSliderDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BulkEditSliderDialog.h; sourceTree = "<group>"; };
 		3D585F301E7E541400A3F84F /* UtilFunctions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UtilFunctions.cpp; sourceTree = "<group>"; };
+		63B4360124EE23250000C90D /* DisperseOptionsDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisperseOptionsDialog.h; sourceTree = "<group>"; };
+		63B4360224EE23250000C90D /* DisperseOptionsDialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisperseOptionsDialog.cpp; sourceTree = "<group>"; };
 		6701999D1CE5A03200AE9B7E /* RenderProgressDialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderProgressDialog.cpp; sourceTree = "<group>"; };
 		6701999E1CE5A03200AE9B7E /* RenderProgressDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderProgressDialog.h; sourceTree = "<group>"; };
 		67025C6820D7E80700BF1AC6 /* xFade.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = xFade.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2489,6 +2492,8 @@
 				675878D91A89297200205A75 /* DataLayer.cpp */,
 				67D11C781BEA691900000A7F /* DimmingCurve.cpp */,
 				67D11C7B1BEA692300000A7F /* DimmingCurvePanel.cpp */,
+				63B4360224EE23250000C90D /* DisperseOptionsDialog.cpp */,
+				63B4360124EE23250000C90D /* DisperseOptionsDialog.h */,
 				674E3EEA20CEB6000087FDA1 /* DissolveTransitionPattern.cpp */,
 				674E3EEB20CEB6000087FDA1 /* DissolveTransitionPattern.h */,
 				67372760234AB2FD00C6C2F2 /* DragColoursBitmapButton.cpp */,
@@ -3195,6 +3200,7 @@
 				676D0F7E1C72BEBD009C66FC /* kiss_fftr.c in Sources */,
 				67F8A29024788E92004EC222 /* md5.cpp in Sources */,
 				67FC881623D7688300D457CB /* RandomEffectsSettingsPanel.cpp in Sources */,
+				63B4360324EE23250000C90D /* DisperseOptionsDialog.cpp in Sources */,
 				675BECE22323DA780077C764 /* CheckboxSelectDialog.cpp in Sources */,
 				679BD3391C37555C000539FE /* RenderableEffect.cpp in Sources */,
 				67B2CFEF1C3A186A003C17CA /* FireworksEffect.cpp in Sources */,

--- a/xLights/DisperseOptionsDialog.cpp
+++ b/xLights/DisperseOptionsDialog.cpp
@@ -235,7 +235,7 @@ DisperseOptionsDialog::DisperseOptionsDialog(wxWindow* parent, wxWindowID id,con
     Connect(wxEVT_SIZE,(wxObjectEventFunction)&DisperseOptionsDialog::OnResize);
     //*)
 
-    DisperseOptionsDialogTextDropTarget *mdt = new DisperseOptionsDialogTextDropTarget(this, DisperseOrderList, "Object");
+    DisperseOptionsDialogTextDropTarget *mdt = new DisperseOptionsDialogTextDropTarget(this, DisperseOrderList, "ModelOrObject");
     DisperseOrderList->SetDropTarget(mdt);
     FillDirectionCbList();
     
@@ -252,6 +252,7 @@ void DisperseOptionsDialog::Setup(SetupData data) {
     _primarySelection = data.primarySelection;
     _availableTargets = data.availableTargets;
     _objectsToDisperse = data.objectsToDisperse;
+    _selectedDirection = DisperseDirection::NONE;
     
     // no top view for 2d
     if (!_is3d) {
@@ -294,7 +295,7 @@ void DisperseOptionsDialog::Setup(SetupData data) {
 }
 
 void DisperseOptionsDialog::ValidateWindow() {
-    if ((ChoiceDisperseFrom->GetStringSelection() == "" || !CheckBoxUsePrimarySel->IsChecked()) && _selectedDirection == DisperseDirection::NONE) {
+    if (ChoiceDisperseFrom->GetStringSelection() == "" || _selectedDirection == DisperseDirection::NONE) {
         ButtonOK->Disable();
     } else {
         ButtonOK->Enable();
@@ -504,7 +505,7 @@ void DisperseOptionsDialog::MoveSelectedItems(int whereTo) {
 void DisperseOptionsDialog::OnDisperseOrderListBeginDrag(wxListEvent& event) {
     if (DisperseOrderList->GetSelectedItemCount() == 0) return;
 
-    wxString drag = "Object";
+    wxString drag = "ModelOrObject";
     wxTextDataObject my_data(drag);
     wxDropSource dragSource(this);
     dragSource.SetData(my_data);
@@ -543,7 +544,7 @@ wxDragResult DisperseOptionsDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord 
     }
     else
     {
-        if (_type == "Object" && _list->GetItemCount() > 0)
+        if (_type == "ModelOrObject" && _list->GetItemCount() > 0)
         {
             int flags = wxLIST_HITTEST_ONITEM;
             int lastItem = _list->HitTest(wxPoint(x, y), flags, nullptr);
@@ -609,9 +610,9 @@ bool DisperseOptionsDialogTextDropTarget::OnDropText(wxCoord x, wxCoord y, const
 
     wxArrayString parms = wxSplit(data, ',');
 
-    if (parms[0] == "Model")
+    if (parms[0] == "ModelOrObject")
     {
-        if (_type == "Model")
+        if (_type == "ModelOrObject")
         {
             event.SetInt(0);
             wxPostEvent(_owner, event);

--- a/xLights/DisperseOptionsDialog.cpp
+++ b/xLights/DisperseOptionsDialog.cpp
@@ -1,0 +1,707 @@
+/***************************************************************
+* This source files comes from the xLights project
+* https://www.xlights.org
+* https://github.com/smeighan/xLights
+* See the github commit history for a record of contributing
+* developers.
+* Copyright claimed based on commit dates recorded in Github
+* License: https://github.com/smeighan/xLights/blob/master/License.txt
+**************************************************************/
+
+#include "DisperseOptionsDialog.h"
+
+//(*InternalHeaders(DisperseOptionsDialog)
+#include <wx/artprov.h>
+#include <wx/bitmap.h>
+#include <wx/image.h>
+#include <wx/intl.h>
+#include <wx/string.h>
+//*)
+
+#include <wx/dnd.h>
+#include <wx/time.h>
+#include <wx/persist/toplevel.h>
+
+#include "UtilFunctions.h"
+
+wxDEFINE_EVENT(EVT_SMDROP, wxCommandEvent);
+
+//(*IdInit(DisperseOptionsDialog)
+const long DisperseOptionsDialog::ID_STATICTEXT4 = wxNewId();
+const long DisperseOptionsDialog::ID_CHOICE_DISPERSE_FROM = wxNewId();
+const long DisperseOptionsDialog::ID_CHECKBOX_USE_PRIMARY = wxNewId();
+const long DisperseOptionsDialog::ID_STATICTEXT2 = wxNewId();
+const long DisperseOptionsDialog::ID_SPINCTRL_OFFSET = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_UP_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_DOWN_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_DOWN = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_UP = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_DOWN_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_TEXTCTRL1 = wxNewId();
+const long DisperseOptionsDialog::ID_CB_FVIEW_UP_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_PANEL1 = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_BACK_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_FRONT_LEFT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_FRONT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_FRONT_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_BACK = wxNewId();
+const long DisperseOptionsDialog::ID_CB_TVIEW_BACK_RIGHT = wxNewId();
+const long DisperseOptionsDialog::ID_TEXTCTRL2 = wxNewId();
+const long DisperseOptionsDialog::ID_PANEL2 = wxNewId();
+const long DisperseOptionsDialog::ID_NOTEBOOK1 = wxNewId();
+const long DisperseOptionsDialog::ID_STATICTEXT3 = wxNewId();
+const long DisperseOptionsDialog::ID_DISPERSE_ORDER_LIST = wxNewId();
+const long DisperseOptionsDialog::ID_BUTTON_ORDER_UP = wxNewId();
+const long DisperseOptionsDialog::ID_BUTTON_ORDER_DOWN = wxNewId();
+const long DisperseOptionsDialog::ID_BUTTON_CANCEL = wxNewId();
+const long DisperseOptionsDialog::ID_BUTTON_OK = wxNewId();
+//*)
+
+BEGIN_EVENT_TABLE(DisperseOptionsDialog,wxDialog)
+    //(*EventTable(DisperseOptionsDialog)
+    //*)
+    EVT_COMMAND(wxID_ANY, EVT_SMDROP, DisperseOptionsDialog::OnDrop)
+END_EVENT_TABLE()
+
+DisperseOptionsDialog::DisperseOptionsDialog(wxWindow* parent, wxWindowID id,const wxPoint& pos,const wxSize& size) {
+    
+    //(*Initialize(DisperseOptionsDialog)
+    wxBoxSizer* BoxSizer1;
+    wxBoxSizer* BoxSizer2;
+    wxFlexGridSizer* FlexGridSizer1;
+    wxFlexGridSizer* FlexGridSizer2;
+    wxFlexGridSizer* FlexGridSizer4;
+    wxFlexGridSizer* FlexGridSizer5;
+    wxFlexGridSizer* FlexGridSizer6;
+    wxGridBagSizer* GridBagSizerTopView;
+
+    Create(parent, wxID_ANY, _("Disperse from a Target Model"), wxDefaultPosition, wxDefaultSize, wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("wxID_ANY"));
+    FlexGridSizer1 = new wxFlexGridSizer(2, 1, 0, 0);
+    FlexGridSizer1->AddGrowableCol(0);
+    FlexGridSizer1->AddGrowableRow(0);
+    FlexGridSizer2 = new wxFlexGridSizer(1, 2, 0, 0);
+    FlexGridSizer2->AddGrowableCol(1);
+    FlexGridSizer2->AddGrowableRow(0);
+    FlexGridSizer5 = new wxFlexGridSizer(2, 1, 0, 0);
+    FlexGridSizer4 = new wxFlexGridSizer(3, 2, 0, 0);
+    StaticText4 = new wxStaticText(this, ID_STATICTEXT4, _("Disperse From"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
+    FlexGridSizer4->Add(StaticText4, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ChoiceDisperseFrom = new wxChoice(this, ID_CHOICE_DISPERSE_FROM, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_DISPERSE_FROM"));
+    ChoiceDisperseFrom->SetMinSize(wxDLG_UNIT(this,wxSize(-1,-1)));
+    ChoiceDisperseFrom->SetToolTip(_("Select the Model to disperse from."));
+    FlexGridSizer4->Add(ChoiceDisperseFrom, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer4->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    CheckBoxUsePrimarySel = new wxCheckBox(this, ID_CHECKBOX_USE_PRIMARY, _("Disperse from Primary Selection"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_USE_PRIMARY"));
+    CheckBoxUsePrimarySel->SetValue(false);
+    CheckBoxUsePrimarySel->SetMinSize(wxSize(-1,-1));
+    FlexGridSizer4->Add(CheckBoxUsePrimarySel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _("Offset"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
+    FlexGridSizer4->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    SpinCtrlOffset = new wxSpinCtrlDouble(this, ID_SPINCTRL_OFFSET, _T("20"), wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT, 0, 500, 0, 1, _T("ID_SPINCTRL_OFFSET"));
+    SpinCtrlOffset->SetValue(_T("20"));
+    SpinCtrlOffset->SetToolTip(_("Offset/Spacing between dispursed items."));
+    FlexGridSizer4->Add(SpinCtrlOffset, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer5->Add(FlexGridSizer4, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionNotebook = new wxNotebook(this, ID_NOTEBOOK1, wxDefaultPosition, wxDefaultSize, 0, _T("ID_NOTEBOOK1"));
+    DirectionNotebook->SetFocus();
+    DirectionNotebook->SetToolTip(_("Select the direction in which to disperse from the Target."));
+    DirectionPanelFrontView = new wxPanel(DirectionNotebook, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL1"));
+    GridBagSizerFrontView = new wxGridBagSizer(0, wxDLG_UNIT(DirectionPanelFrontView,wxSize(1,0)).GetWidth());
+    DirectionUpLeft = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_UP_LEFT, _("Up + Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_UP_LEFT"));
+    DirectionUpLeft->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionUpLeft, wxGBPosition(0, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFviewLeft = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_LEFT, _("Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_LEFT"));
+    DirectionFviewLeft->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionFviewLeft, wxGBPosition(3, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionDownLeft = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_DOWN_LEFT, _("Down + Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_DOWN_LEFT"));
+    DirectionDownLeft->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionDownLeft, wxGBPosition(6, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionDown = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_DOWN, _("Down"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_DOWN"));
+    DirectionDown->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionDown, wxGBPosition(6, 2), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionUp = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_UP, _("Up"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_UP"));
+    DirectionUp->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionUp, wxGBPosition(0, 2), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFviewRight = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_RIGHT, _("Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_RIGHT"));
+    DirectionFviewRight->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionFviewRight, wxGBPosition(3, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionDownRight = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_DOWN_RIGHT, _("Down + Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_DOWN_RIGHT"));
+    DirectionDownRight->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionDownRight, wxGBPosition(6, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFrontLabel = new wxTextCtrl(DirectionPanelFrontView, ID_TEXTCTRL1, _("Direction to Dispurse"), wxDefaultPosition, wxSize(153,22), wxTE_READONLY|wxTE_CENTRE|wxBORDER_RAISED, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+    GridBagSizerFrontView->Add(DirectionFrontLabel, wxGBPosition(3, 2), wxDefaultSpan, wxALL|wxEXPAND, 5);
+    DirectionUpRight = new wxCheckBox(DirectionPanelFrontView, ID_CB_FVIEW_UP_RIGHT, _("Up + Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_FVIEW_UP_RIGHT"));
+    DirectionUpRight->SetValue(false);
+    GridBagSizerFrontView->Add(DirectionUpRight, wxGBPosition(0, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionPanelFrontView->SetSizer(GridBagSizerFrontView);
+    GridBagSizerFrontView->Fit(DirectionPanelFrontView);
+    GridBagSizerFrontView->SetSizeHints(DirectionPanelFrontView);
+    DirectionPanelTopView = new wxPanel(DirectionNotebook, ID_PANEL2, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL2"));
+    GridBagSizerTopView = new wxGridBagSizer(0, 4);
+    DirectionBackLeft = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_BACK_LEFT, _("Back + Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_BACK_LEFT"));
+    DirectionBackLeft->SetValue(false);
+    GridBagSizerTopView->Add(DirectionBackLeft, wxGBPosition(0, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionTviewLeft = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_LEFT, _("Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_LEFT"));
+    DirectionTviewLeft->SetValue(false);
+    GridBagSizerTopView->Add(DirectionTviewLeft, wxGBPosition(3, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFrontLeft = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_FRONT_LEFT, _("Front + Left"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_FRONT_LEFT"));
+    DirectionFrontLeft->SetValue(false);
+    GridBagSizerTopView->Add(DirectionFrontLeft, wxGBPosition(6, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFront = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_FRONT, _("Front"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_FRONT"));
+    DirectionFront->SetValue(false);
+    GridBagSizerTopView->Add(DirectionFront, wxGBPosition(6, 2), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionFrontRight = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_FRONT_RIGHT, _("Front + Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_FRONT_RIGHT"));
+    DirectionFrontRight->SetValue(false);
+    GridBagSizerTopView->Add(DirectionFrontRight, wxGBPosition(6, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionTviewRight = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_RIGHT, _("Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_RIGHT"));
+    DirectionTviewRight->SetValue(false);
+    GridBagSizerTopView->Add(DirectionTviewRight, wxGBPosition(3, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionBack = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_BACK, _("Back"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_BACK"));
+    DirectionBack->SetValue(false);
+    GridBagSizerTopView->Add(DirectionBack, wxGBPosition(0, 2), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionBackRight = new wxCheckBox(DirectionPanelTopView, ID_CB_TVIEW_BACK_RIGHT, _("Back + Right"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CB_TVIEW_BACK_RIGHT"));
+    DirectionBackRight->SetValue(false);
+    GridBagSizerTopView->Add(DirectionBackRight, wxGBPosition(0, 5), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    DirectionTopLabel = new wxTextCtrl(DirectionPanelTopView, ID_TEXTCTRL2, _("Direction to Dispurse"), wxDefaultPosition, wxSize(148,22), wxTE_READONLY|wxTE_CENTRE|wxBORDER_RAISED, wxDefaultValidator, _T("ID_TEXTCTRL2"));
+    GridBagSizerTopView->Add(DirectionTopLabel, wxGBPosition(3, 2), wxDefaultSpan, wxALL|wxEXPAND, 5);
+    DirectionPanelTopView->SetSizer(GridBagSizerTopView);
+    GridBagSizerTopView->Fit(DirectionPanelTopView);
+    GridBagSizerTopView->SetSizeHints(DirectionPanelTopView);
+    DirectionNotebook->AddPage(DirectionPanelFrontView, _("Front View"), false);
+    DirectionNotebook->AddPage(DirectionPanelTopView, _("Top View"), false);
+    FlexGridSizer5->Add(DirectionNotebook, 1, wxALL, 5);
+    FlexGridSizer2->Add(FlexGridSizer5, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer6 = new wxFlexGridSizer(2, 1, 0, 0);
+    FlexGridSizer6->AddGrowableCol(0);
+    FlexGridSizer6->AddGrowableRow(1);
+    DisperseOrderLabel = new wxStaticText(this, ID_STATICTEXT3, _("Model Disperse Order"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT3"));
+    FlexGridSizer6->Add(DisperseOrderLabel, 1, wxTOP|wxLEFT|wxRIGHT|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    DisperseOrderSizer = new wxFlexGridSizer(1, 2, 0, 0);
+    DisperseOrderSizer->AddGrowableCol(0);
+    DisperseOrderSizer->AddGrowableRow(0);
+    DisperseOrderList = new wxListView(this, ID_DISPERSE_ORDER_LIST, wxDefaultPosition, wxDLG_UNIT(this,wxSize(-1,-1)), wxLC_REPORT|wxLC_NO_HEADER|wxLC_SORT_ASCENDING|wxBORDER_SIMPLE|wxVSCROLL|wxHSCROLL|wxFULL_REPAINT_ON_RESIZE, wxDefaultValidator, _T("ID_DISPERSE_ORDER_LIST"));
+    DisperseOrderList->SetMaxSize(wxSize(-1,-1));
+    DisperseOrderSizer->Add(DisperseOrderList, 1, wxTOP|wxEXPAND, 5);
+    BoxSizer2 = new wxBoxSizer(wxVERTICAL);
+    ButtonOrderUp = new wxBitmapButton(this, ID_BUTTON_ORDER_UP, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("wxART_GO_UP")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_BUTTON_ORDER_UP"));
+    BoxSizer2->Add(ButtonOrderUp, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonOrderDown = new wxBitmapButton(this, ID_BUTTON_ORDER_DOWN, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("wxART_GO_DOWN")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_BUTTON_ORDER_DOWN"));
+    BoxSizer2->Add(ButtonOrderDown, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    DisperseOrderSizer->Add(BoxSizer2, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer6->Add(DisperseOrderSizer, 1, wxBOTTOM|wxLEFT|wxRIGHT|wxEXPAND, 5);
+    FlexGridSizer2->Add(FlexGridSizer6, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
+    BoxSizer1 = new wxBoxSizer(wxHORIZONTAL);
+    ButtonCancel = new wxButton(this, ID_BUTTON_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_CANCEL"));
+    BoxSizer1->Add(ButtonCancel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonOK = new wxButton(this, ID_BUTTON_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_OK"));
+    BoxSizer1->Add(ButtonOK, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer1->Add(BoxSizer1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    SetSizer(FlexGridSizer1);
+    FlexGridSizer1->Fit(this);
+    FlexGridSizer1->SetSizeHints(this);
+
+    Connect(ID_CHOICE_DISPERSE_FROM,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&DisperseOptionsDialog::OnChoiceTargetSelect);
+    Connect(ID_CHECKBOX_USE_PRIMARY,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnCheckBoxUsePrimarySelClick);
+    Connect(ID_CB_FVIEW_UP_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_DOWN_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_DOWN,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_UP,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_DOWN_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_FVIEW_UP_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_BACK_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_FRONT_LEFT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_FRONT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_FRONT_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_BACK,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_CB_TVIEW_BACK_RIGHT,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDirectionClick);
+    Connect(ID_DISPERSE_ORDER_LIST,wxEVT_COMMAND_LIST_BEGIN_DRAG,(wxObjectEventFunction)&DisperseOptionsDialog::OnDisperseOrderListBeginDrag);
+    Connect(ID_DISPERSE_ORDER_LIST,wxEVT_COMMAND_LIST_ITEM_SELECTED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDisperseOrderListItemSelect);
+    Connect(ID_DISPERSE_ORDER_LIST,wxEVT_COMMAND_LIST_ITEM_DESELECTED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDisperseOrderListItemDeselect);
+    Connect(ID_DISPERSE_ORDER_LIST,wxEVT_COMMAND_LIST_ITEM_ACTIVATED,(wxObjectEventFunction)&DisperseOptionsDialog::OnDisperseOrderListItemActivated);
+    Connect(ID_BUTTON_ORDER_UP,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnButtonOrderUpClick);
+    Connect(ID_BUTTON_ORDER_DOWN,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnButtonOrderDownClick);
+    Connect(ID_BUTTON_CANCEL,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnButtonCancelClick);
+    Connect(ID_BUTTON_OK,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DisperseOptionsDialog::OnButtonOKClick);
+    Connect(wxID_ANY,wxEVT_INIT_DIALOG,(wxObjectEventFunction)&DisperseOptionsDialog::OnInit);
+    Connect(wxEVT_SIZE,(wxObjectEventFunction)&DisperseOptionsDialog::OnResize);
+    //*)
+
+    DisperseOptionsDialogTextDropTarget *mdt = new DisperseOptionsDialogTextDropTarget(this, DisperseOrderList, "Object");
+    DisperseOrderList->SetDropTarget(mdt);
+    FillDirectionCbList();
+    
+    // remember dialag position and restore otherwise optimise first view of it
+    if (!wxPersistentRegisterAndRestore(this, "xLights_DisperseOptionsDialog")) {
+        OptimiseDialogPosition(this);
+    }
+    
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::Setup(SetupData data) {
+    _is3d = data.is3d;
+    _primarySelection = data.primarySelection;
+    _availableTargets = data.availableTargets;
+    _objectsToDisperse = data.objectsToDisperse;
+    
+    // no top view for 2d
+    if (!_is3d) {
+        DirectionNotebook->RemovePage(1);
+    }
+    
+    // adjust dialog text for 3d objects
+    if (!data.forModels) {
+        SetTitle("Disperse from a Target 3D Object");
+        ChoiceDisperseFrom->SetToolTip("Select the 3D Object to disperse from.");
+        DisperseOrderLabel->SetLabel("3D Object Disperse Order");
+    }
+    
+    // if all models selected then default primary as target, probably user error, but handle it
+    if (_availableTargets.size() == 0) {
+        CheckBoxUsePrimarySel->SetValue(true);
+        CheckBoxUsePrimarySel->Disable();
+        _availableTargets.push_back(_primarySelection);
+        _objectsToDisperse.Remove(_primarySelection);
+    }
+    
+    // single model/object selected, don't allow user to flag it as target
+    if (_objectsToDisperse.size() == 1) {
+        CheckBoxUsePrimarySel->Disable();
+    }
+    
+    // if primary is locked it has to be the one and only target
+    if (data.primaryLocked) {
+        CheckBoxUsePrimarySel->SetValue(true);
+        CheckBoxUsePrimarySel->Disable();
+        _availableTargets.Clear();
+        _availableTargets.Add(_primarySelection);
+        _objectsToDisperse.Remove(_primarySelection);
+    }
+        
+    PopulateTargetChoices(_availableTargets);
+    PopulateOrderList(_objectsToDisperse);
+    
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::ValidateWindow() {
+    if ((ChoiceDisperseFrom->GetStringSelection() == "" || !CheckBoxUsePrimarySel->IsChecked()) && _selectedDirection == DisperseDirection::NONE) {
+        ButtonOK->Disable();
+    } else {
+        ButtonOK->Enable();
+    }
+
+    int numSelected = DisperseOrderList->GetSelectedItemCount();
+    if (numSelected > 0 && numSelected < DisperseOrderList->GetItemCount()) {
+        ButtonOrderUp->Enable(true);
+        ButtonOrderDown->Enable(true);
+    } else {
+        ButtonOrderUp->Enable(false);
+        ButtonOrderDown->Enable(false);
+    }
+}
+
+void DisperseOptionsDialog::PopulateOrderList(wxArrayString objectList) {
+    DisperseOrderList->Freeze();
+    DisperseOrderList->ClearAll();
+    DisperseOrderList->AppendColumn("Objects");
+
+    for (const auto& it : objectList) {
+        DisperseOrderList->InsertItem(DisperseOrderList->GetItemCount(), it);
+    }
+
+    int w,h;
+    DisperseOrderList->GetSize(&w, &h);
+    DisperseOrderList->SetColumnWidth(0, wxLIST_AUTOSIZE);
+    if (DisperseOrderList->GetColumnWidth(0) < w)
+    {
+        DisperseOrderList->SetColumnWidth(0, w);
+    }
+
+    DisperseOrderList->Thaw();
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::RemoveItemFromOrderList(wxString objectName) {
+    int removeIdx = -1;
+    for (size_t i = 0; i < DisperseOrderList->GetItemCount(); i++) {
+        if (objectName == DisperseOrderList->GetItemText(i)) {
+            removeIdx = i;
+            break;
+        }
+    }
+
+    if (removeIdx > -1) {
+        DisperseOrderList->Freeze();
+        DisperseOrderList->DeleteItem(removeIdx);
+        DisperseOrderList->Thaw();
+        DisperseOrderList->Refresh();
+    }
+}
+
+void DisperseOptionsDialog::PopulateTargetChoices(wxArrayString availableTargets) {
+    ChoiceDisperseFrom->Freeze();
+    ChoiceDisperseFrom->Clear();
+    ChoiceDisperseFrom->Append(availableTargets);
+    ChoiceDisperseFrom->Thaw();
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::FillDirectionCbList() {
+    // repetitive but do it once then we can iterate over all the checkboxes
+    _directionCbList.push_back(DirectionFviewLeft);
+    _directionCbList.push_back(DirectionFviewRight);
+    _directionCbList.push_back(DirectionUp);
+    _directionCbList.push_back(DirectionUpLeft);
+    _directionCbList.push_back(DirectionUpRight);
+    _directionCbList.push_back(DirectionDown);
+    _directionCbList.push_back(DirectionDownLeft);
+    _directionCbList.push_back(DirectionDownRight);
+    _directionCbList.push_back(DirectionBack);
+    _directionCbList.push_back(DirectionBackLeft);
+    _directionCbList.push_back(DirectionBackRight);
+    _directionCbList.push_back(DirectionFront);
+    _directionCbList.push_back(DirectionFrontLeft);
+    _directionCbList.push_back(DirectionFrontRight);
+    _directionCbList.push_back(DirectionTviewLeft);
+    _directionCbList.push_back(DirectionTviewRight);
+}
+
+wxString DisperseOptionsDialog::GetTarget() {
+    return ChoiceDisperseFrom->GetStringSelection();
+}
+
+DisperseDirection DisperseOptionsDialog::GetDirection() {
+    return _selectedDirection;
+}
+
+float DisperseOptionsDialog::GetOffset() {
+    return SpinCtrlOffset->GetValue();
+}
+
+wxArrayString DisperseOptionsDialog::GetDisperseOrder() {
+    wxArrayString modelOrder;
+
+    for (int i = 0; i < DisperseOrderList->GetItemCount(); i++) {
+        modelOrder.push_back(DisperseOrderList->GetItemText(i));
+    }
+
+    return modelOrder;
+}
+
+DisperseOptionsDialog::DisperseOptions DisperseOptionsDialog::GetDisperseOptions() {
+    DisperseOptions options;
+
+    options.fromWhat = GetTarget();
+    options.direction = GetDirection();
+    options.offset = GetOffset();
+    options.order = GetDisperseOrder();
+
+    return options;
+}
+
+DisperseDirection DisperseOptionsDialog::GetDirectionByControlId(long ctrlId) {
+
+    if (ctrlId == ID_CB_FVIEW_UP) {
+        return DisperseDirection::UP;
+    } else if (ctrlId == ID_CB_FVIEW_DOWN) {
+        return DisperseDirection::DOWN;
+    } else if (ctrlId == ID_CB_FVIEW_LEFT || ctrlId == ID_CB_TVIEW_LEFT) {
+        return DisperseDirection::LEFT;
+    } else if (ctrlId == ID_CB_FVIEW_UP_LEFT) {
+        return DisperseDirection::UPLEFT;
+    } else if (ctrlId == ID_CB_FVIEW_DOWN_LEFT) {
+        return DisperseDirection::DOWNLEFT;
+    } else if (ctrlId == ID_CB_FVIEW_RIGHT || ctrlId == ID_CB_TVIEW_RIGHT) {
+        return DisperseDirection::RIGHT;
+    } else if (ctrlId == ID_CB_FVIEW_UP_RIGHT) {
+        return DisperseDirection::UPRIGHT;
+    } else if (ctrlId == ID_CB_FVIEW_DOWN_RIGHT) {
+        return DisperseDirection::DOWNRIGHT;
+    } else if (ctrlId == ID_CB_TVIEW_FRONT) {
+        return DisperseDirection::FRONT;
+    } else if (ctrlId == ID_CB_TVIEW_BACK) {
+        return DisperseDirection::BACK;
+    } else if (ctrlId == ID_CB_TVIEW_FRONT_LEFT) {
+        return DisperseDirection::FRONTLEFT;
+    } else if (ctrlId == ID_CB_TVIEW_FRONT_RIGHT) {
+        return DisperseDirection::FRONTRIGHT;
+    } else if (ctrlId == ID_CB_TVIEW_BACK_LEFT) {
+        return DisperseDirection::BACKLEFT;
+    } else if (ctrlId == ID_CB_TVIEW_BACK_RIGHT) {
+        return DisperseDirection::BACKRIGHT;
+    } else {
+        return DisperseDirection::NONE;
+    }
+}
+
+// move selected items up/down by 1 in order
+void DisperseOptionsDialog::StepSelectedItems(bool up) {
+    DisperseOrderList->Freeze();
+
+    if (up) {
+        for (int i = 0; i < DisperseOrderList->GetItemCount(); ++i) {
+            if (DisperseOrderList->IsSelected(i) && i != 0) {
+                wxString modelName = DisperseOrderList->GetItemText(i);
+                DisperseOrderList->DeleteItem(i);
+                int newIdx = DisperseOrderList->InsertItem(i - 1, modelName);
+                DisperseOrderList->Select(newIdx);
+            }
+        }
+    } else {
+        int numItems = DisperseOrderList->GetItemCount();
+        for (int i = numItems - 1; i >= 0; i--) {
+            if (DisperseOrderList->IsSelected(i) && i != numItems - 1) {
+                wxString modelName = DisperseOrderList->GetItemText(i);
+                DisperseOrderList->DeleteItem(i);
+                int newIdx = DisperseOrderList->InsertItem(i + 1, modelName);
+                DisperseOrderList->Select(newIdx);
+            }
+        }
+    }
+
+    DisperseOrderList->Thaw();
+    DisperseOrderList->Refresh();
+}
+
+// move selected items to index of whereTo
+void DisperseOptionsDialog::MoveSelectedItems(int whereTo) {
+    if (whereTo < 0) { return; }
+
+    DisperseOrderList->Freeze();
+    wxArrayString draggedModels;
+    int selected = DisperseOrderList->GetFirstSelected();
+
+    while (selected != -1) {
+        draggedModels.Add(DisperseOrderList->GetItemText(selected));
+        DisperseOrderList->DeleteItem(selected);
+        selected = DisperseOrderList->GetNextSelected(selected - 1);
+    }
+
+    if (whereTo > DisperseOrderList->GetItemCount()) {
+        whereTo = DisperseOrderList->GetItemCount();
+    }
+
+    for (const auto& it : draggedModels) {
+        DisperseOrderList->InsertItem(whereTo, it);
+        DisperseOrderList->Select(whereTo);
+        whereTo++;
+    }
+
+    DisperseOrderList->Thaw();
+    DisperseOrderList->Refresh();
+}
+
+void DisperseOptionsDialog::OnDisperseOrderListBeginDrag(wxListEvent& event) {
+    if (DisperseOrderList->GetSelectedItemCount() == 0) return;
+
+    wxString drag = "Object";
+    wxTextDataObject my_data(drag);
+    wxDropSource dragSource(this);
+    dragSource.SetData(my_data);
+    dragSource.DoDragDrop(wxDrag_DefaultMove);
+    SetCursor(wxCURSOR_HAND);
+}
+
+void DisperseOptionsDialog::OnDrop(wxCommandEvent& event) {
+    wxArrayString parms = wxSplit(event.GetString(), ',');
+    int x = event.GetExtraLong() >> 16;
+    int y = event.GetExtraLong() & 0xFFFF;
+
+    switch(event.GetInt()) {
+        case 0: {
+            // Model dropped, reorder
+            int flags = wxLIST_HITTEST_ONITEM;
+            long index = DisperseOrderList->HitTest(wxPoint(x, y), flags, nullptr);
+            MoveSelectedItems(index);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+wxDragResult DisperseOptionsDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord y, wxDragResult def)
+{
+    static int MINSCROLLDELAY = 10;
+    static int STARTSCROLLDELAY = 300;
+    static int scrollDelay = STARTSCROLLDELAY;
+    static wxLongLong lastTime = wxGetUTCTimeMillis();
+
+    if (wxGetUTCTimeMillis() - lastTime < scrollDelay)
+    {
+        // too soon to scroll again
+    }
+    else
+    {
+        if (_type == "Object" && _list->GetItemCount() > 0)
+        {
+            int flags = wxLIST_HITTEST_ONITEM;
+            int lastItem = _list->HitTest(wxPoint(x, y), flags, nullptr);
+
+            for (int i = 0; i < _list->GetItemCount(); ++i)
+            {
+                if (i == lastItem)
+                {
+                    _list->SetItemState(i, wxLIST_STATE_DROPHILITED, wxLIST_STATE_DROPHILITED);
+                }
+                else
+                {
+                    _list->SetItemState(i, 0, wxLIST_STATE_DROPHILITED);
+                }
+            }
+
+            wxRect rect;
+            _list->GetItemRect(0, rect);
+            int itemSize = rect.GetHeight();
+
+            if (y < 2 * itemSize)
+            {
+                // scroll up
+                if (_list->GetTopItem() > 0)
+                {
+                    lastTime = wxGetUTCTimeMillis();
+                    _list->EnsureVisible(_list->GetTopItem()-1);
+                    scrollDelay = scrollDelay / 2;
+                    if (scrollDelay < MINSCROLLDELAY) scrollDelay = MINSCROLLDELAY;
+                }
+            }
+            else if (y > _list->GetRect().GetHeight() - itemSize)
+            {
+                // scroll down
+                if (lastItem >= 0 && lastItem < _list->GetItemCount())
+                {
+                    _list->EnsureVisible(lastItem+1);
+                    lastTime = wxGetUTCTimeMillis();
+                    scrollDelay = scrollDelay / 2;
+                    if (scrollDelay < MINSCROLLDELAY) scrollDelay = MINSCROLLDELAY;
+                }
+            }
+            else
+            {
+                scrollDelay = STARTSCROLLDELAY;
+            }
+        }
+    }
+
+    return wxDragMove;
+}
+
+bool DisperseOptionsDialogTextDropTarget::OnDropText(wxCoord x, wxCoord y, const wxString& data)
+{
+    if (data == "") return false;
+
+    long mousePos = x;
+    mousePos = mousePos << 16;
+    mousePos += y;
+    wxCommandEvent event(EVT_SMDROP);
+    event.SetString(data); // this is the dropped string
+    event.SetExtraLong(mousePos); // this is the mouse position packed into a long
+
+    wxArrayString parms = wxSplit(data, ',');
+
+    if (parms[0] == "Model")
+    {
+        if (_type == "Model")
+        {
+            event.SetInt(0);
+            wxPostEvent(_owner, event);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void DisperseOptionsDialog::OnButtonOrderUpClick(wxCommandEvent& event) {
+    if (DisperseOrderList->GetSelectedItemCount() == 0) return;
+
+    StepSelectedItems(true);
+}
+
+void DisperseOptionsDialog::OnButtonOrderDownClick(wxCommandEvent& event) {
+    if (DisperseOrderList->GetSelectedItemCount() == 0) return;
+
+    StepSelectedItems(false);
+}
+
+void DisperseOptionsDialog::OnResize(wxSizeEvent& event)
+{
+    wxDialog::OnSize(event);
+    DisperseOrderList->Refresh();
+}
+
+void DisperseOptionsDialog::OnChoiceTargetSelect(wxCommandEvent& event) {
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::OnCheckBoxUsePrimarySelClick(wxCommandEvent& event) {
+    DisperseOrderList->Freeze();
+    if (CheckBoxUsePrimarySel->IsChecked()) {
+        ChoiceDisperseFrom->Clear();
+        ChoiceDisperseFrom->Append(_primarySelection);
+        RemoveItemFromOrderList(_primarySelection);
+    } else {
+        ChoiceDisperseFrom->Clear();
+        ChoiceDisperseFrom->Append(_availableTargets);
+        DisperseOrderList->InsertItem(DisperseOrderList->GetItemCount(), _primarySelection);
+    }
+
+    DisperseOrderList->Thaw();
+    DisperseOrderList->Refresh();
+
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::OnDirectionClick(wxCommandEvent& event) {
+    if (event.IsChecked()) {
+        _selectedDirection = GetDirectionByControlId(event.GetId());
+
+        for (const auto& cb : _directionCbList) {
+            if (event.GetId() != cb->GetId()) {
+                cb->SetValue(false);
+            }
+        }
+    } else {
+        _selectedDirection = DisperseDirection::NONE;
+    }
+
+    ValidateWindow();
+}
+
+
+void DisperseOptionsDialog::OnInit(wxInitDialogEvent& event) {}
+
+void DisperseOptionsDialog::OnDisperseOrderListItemSelect(wxListEvent& event) {
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::OnDisperseOrderListItemDeselect(wxListEvent& event) {
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::OnDisperseOrderListItemActivated(wxListEvent& event) {
+    ValidateWindow();
+}
+
+void DisperseOptionsDialog::OnButtonCancelClick(wxCommandEvent& event) {
+    EndDialog(wxID_CANCEL);
+}
+
+void DisperseOptionsDialog::OnButtonOKClick(wxCommandEvent& event) {
+    EndDialog(wxID_OK);
+}
+
+DisperseOptionsDialog::~DisperseOptionsDialog() {
+    //(*Destroy(DisperseOptionsDialog)
+    //*)
+}

--- a/xLights/DisperseOptionsDialog.h
+++ b/xLights/DisperseOptionsDialog.h
@@ -1,0 +1,197 @@
+#pragma once
+
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/smeighan/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/smeighan/xLights/blob/master/License.txt
+ **************************************************************/
+
+//(*Headers(DisperseOptionsDialog)
+#include <wx/bmpbuttn.h>
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/choice.h>
+#include <wx/dialog.h>
+#include <wx/gbsizer.h>
+#include <wx/listctrl.h>
+#include <wx/notebook.h>
+#include <wx/panel.h>
+#include <wx/sizer.h>
+#include <wx/spinctrl.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+//*)
+
+#include <wx/dnd.h>
+
+enum DisperseDirection {
+    NONE,
+    UP, DOWN, LEFT, RIGHT,
+    UPLEFT, UPRIGHT, DOWNLEFT, DOWNRIGHT,
+    BACK, BACKLEFT, BACKRIGHT,
+    FRONT, FRONTLEFT, FRONTRIGHT
+};
+
+class DisperseOptionsDialogTextDropTarget : public wxTextDropTarget
+{
+public:
+    DisperseOptionsDialogTextDropTarget(wxWindow *owner, wxListCtrl* list, wxString type) { _owner = owner; _list = list; _type = type; };
+
+    virtual bool OnDropText(wxCoord x, wxCoord y, const wxString& data) override;
+    virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override;
+
+    wxWindow *_owner;
+    wxListCtrl* _list;
+    wxString _type;
+};
+
+class DisperseOptionsDialog: public wxDialog
+{
+    public:
+    
+        struct DisperseOptions {
+            wxString fromWhat;
+            DisperseDirection direction;
+            float offset;
+            std::vector<wxString> order;
+        };
+    
+        struct SetupData {
+            wxString primarySelection;
+            wxArrayString availableTargets;
+            wxArrayString objectsToDisperse;
+            bool primaryLocked = false;
+            bool is3d = true;
+            bool forModels = true;
+        };
+        
+        DisperseOptionsDialog(wxWindow* parent, wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize);
+        virtual ~DisperseOptionsDialog();
+    
+        void Setup(SetupData data);
+        DisperseOptions GetDisperseOptions();
+    
+        //(*Declarations(DisperseOptionsDialog)
+        wxBitmapButton* ButtonOrderDown;
+        wxBitmapButton* ButtonOrderUp;
+        wxButton* ButtonCancel;
+        wxButton* ButtonOK;
+        wxCheckBox* CheckBoxUsePrimarySel;
+        wxCheckBox* DirectionBack;
+        wxCheckBox* DirectionBackLeft;
+        wxCheckBox* DirectionBackRight;
+        wxCheckBox* DirectionDown;
+        wxCheckBox* DirectionDownLeft;
+        wxCheckBox* DirectionDownRight;
+        wxCheckBox* DirectionFront;
+        wxCheckBox* DirectionFrontLeft;
+        wxCheckBox* DirectionFrontRight;
+        wxCheckBox* DirectionFviewLeft;
+        wxCheckBox* DirectionFviewRight;
+        wxCheckBox* DirectionTviewLeft;
+        wxCheckBox* DirectionTviewRight;
+        wxCheckBox* DirectionUp;
+        wxCheckBox* DirectionUpLeft;
+        wxCheckBox* DirectionUpRight;
+        wxChoice* ChoiceDisperseFrom;
+        wxFlexGridSizer* DisperseOrderSizer;
+        wxGridBagSizer* GridBagSizerFrontView;
+        wxListView* DisperseOrderList;
+        wxNotebook* DirectionNotebook;
+        wxPanel* DirectionPanelFrontView;
+        wxPanel* DirectionPanelTopView;
+        wxSpinCtrlDouble* SpinCtrlOffset;
+        wxStaticText* DisperseOrderLabel;
+        wxStaticText* StaticText2;
+        wxStaticText* StaticText4;
+        wxTextCtrl* DirectionFrontLabel;
+        wxTextCtrl* DirectionTopLabel;
+        //*)
+
+    protected:
+
+        //(*Identifiers(DisperseOptionsDialog)
+        static const long ID_STATICTEXT4;
+        static const long ID_CHOICE_DISPERSE_FROM;
+        static const long ID_CHECKBOX_USE_PRIMARY;
+        static const long ID_STATICTEXT2;
+        static const long ID_SPINCTRL_OFFSET;
+        static const long ID_CB_FVIEW_UP_LEFT;
+        static const long ID_CB_FVIEW_LEFT;
+        static const long ID_CB_FVIEW_DOWN_LEFT;
+        static const long ID_CB_FVIEW_DOWN;
+        static const long ID_CB_FVIEW_UP;
+        static const long ID_CB_FVIEW_RIGHT;
+        static const long ID_CB_FVIEW_DOWN_RIGHT;
+        static const long ID_TEXTCTRL1;
+        static const long ID_CB_FVIEW_UP_RIGHT;
+        static const long ID_PANEL1;
+        static const long ID_CB_TVIEW_BACK_LEFT;
+        static const long ID_CB_TVIEW_LEFT;
+        static const long ID_CB_TVIEW_FRONT_LEFT;
+        static const long ID_CB_TVIEW_FRONT;
+        static const long ID_CB_TVIEW_FRONT_RIGHT;
+        static const long ID_CB_TVIEW_RIGHT;
+        static const long ID_CB_TVIEW_BACK;
+        static const long ID_CB_TVIEW_BACK_RIGHT;
+        static const long ID_TEXTCTRL2;
+        static const long ID_PANEL2;
+        static const long ID_NOTEBOOK1;
+        static const long ID_STATICTEXT3;
+        static const long ID_DISPERSE_ORDER_LIST;
+        static const long ID_BUTTON_ORDER_UP;
+        static const long ID_BUTTON_ORDER_DOWN;
+        static const long ID_BUTTON_CANCEL;
+        static const long ID_BUTTON_OK;
+        //*)
+    
+        wxString GetTarget();
+        DisperseDirection GetDirection();
+        float GetOffset();
+        wxArrayString GetDisperseOrder();
+        void ValidateWindow();
+        void PopulateOrderList(wxArrayString objectList);
+        void RemoveItemFromOrderList(wxString objectName);
+        void PopulateTargetChoices(wxArrayString targetList);
+        void StepSelectedItems(bool up);
+        void MoveSelectedItems(int whereTo);
+        DisperseDirection GetDirectionByControlId(long ctrlId);
+    
+    private:
+
+        //(*Handlers(DisperseOptionsDialog)
+        void OnOrderListBeginDrag(wxListEvent& event);
+        void OnOrderListSelect(wxListEvent& event);
+        void OnButtonOrderUpClick(wxCommandEvent& event);
+        void OnButtonOrderDownClick(wxCommandEvent& event);
+        void OnResize(wxSizeEvent& event);
+        void OnChoiceTargetSelect(wxCommandEvent& event);
+        void OnCheckBoxUsePrimarySelClick(wxCommandEvent& event);
+        void OnInit(wxInitDialogEvent& event);
+        void OnDisperseOrderListBeginDrag(wxListEvent& event);
+        void OnDisperseOrderListItemSelect(wxListEvent& event);
+        void OnDisperseOrderListItemDeselect(wxListEvent& event);
+        void OnDisperseOrderListItemActivated(wxListEvent& event);
+        void OnButtonCancelClick(wxCommandEvent& event);
+        void OnButtonOKClick(wxCommandEvent& event);
+        void OnDirectionClick(wxCommandEvent& event);
+        void OnSpinCtrlOffsetChange(wxSpinDoubleEvent& event);
+        //*)
+    
+        bool _is3d;
+        
+        wxString _primarySelection;
+        wxArrayString _availableTargets;
+        wxArrayString _objectsToDisperse;
+        DisperseDirection _selectedDirection = DisperseDirection::NONE;
+        std::vector<wxCheckBox*> _directionCbList;
+    
+        void FillDirectionCbList();
+        void OnDrop(wxCommandEvent& event);
+    
+        DECLARE_EVENT_TABLE()
+};

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5198,6 +5198,7 @@ void LayoutPanel::PreviewModelDisperseByDirection(DisperseDirection direction) {
 void LayoutPanel::PreviewModelDisperse(Model* fromModel, std::list<Model*> disperseModels, DisperseDirection direction, float offset) {
     if (fromModel == nullptr) { return; };
     
+    CreateUndoPoint("All", fromModel->name);
     std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
     Model* currFromModel = fromModel;
         
@@ -7978,6 +7979,10 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
         AddAlignOptionsToMenu(mnuAlign);
         mnuAlign->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
 
+        wxMenu* mnuDisperse = new wxMenu();
+        AddDisperseOptionsToMenu(mnuDisperse);
+        mnuDisperse->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
+        
         wxMenu* mnuDistribute = new wxMenu();
         AddDistributeOptionsToMenu(mnuDistribute);
         mnuDistribute->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);
@@ -7988,6 +7993,7 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
 
         mnuContext.Append(ID_PREVIEW_BULKEDIT, "Bulk Edit", mnuBulkEdit, "");
         mnuContext.Append(ID_PREVIEW_ALIGN, "Align", mnuAlign, "");
+        mnuContext.Append(ID_PREVIEW_DISPERSE, "Disperse", mnuDisperse, "");
         mnuContext.Append(ID_PREVIEW_DISTRIBUTE, "Distribute", mnuDistribute, "");
         mnuContext.Append(ID_PREVIEW_RESIZE, "Resize", mnuResize, "");
 

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -158,6 +158,22 @@ const long LayoutPanel::ID_PREVIEW_ALIGN_BACK = wxNewId();
 const long LayoutPanel::ID_PREVIEW_DISTRIBUTE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_H_DISTRIBUTE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_V_DISTRIBUTE = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_SELECT_OPTIONS = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_LEFT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_RIGHT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_UP = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_DOWN = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_UP_LEFT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_UP_RIGHT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_DOWN_LEFT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_DOWN_RIGHT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_BACK = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_BACK_LEFT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_BACK_RIGHT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_FRONT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_FRONT_LEFT = wxNewId();
+const long LayoutPanel::ID_PREVIEW_DISPERSE_FRONT_RIGHT = wxNewId();
 const long LayoutPanel::ID_MNU_DELETE_MODEL = wxNewId();
 const long LayoutPanel::ID_MNU_DELETE_MODEL_GROUP = wxNewId();
 const long LayoutPanel::ID_MNU_DELETE_EMPTY_MODEL_GROUPS = wxNewId();
@@ -4054,6 +4070,9 @@ void LayoutPanel::AddSingleModelOptionsToBaseMenu(wxMenu &menu) {
         if (is_3d && selectedObjectCnt == 1) {
             menu.Append(ID_PREVIEW_ALIGN_GROUND, "Align With Ground");
         }
+        if (selectedObjectCnt == 1) {
+            menu.Append(ID_PREVIEW_DISPERSE_SELECT_OPTIONS, "Disperse");
+        }
     }
     if (editing_models && (selectedBaseObject != nullptr))
     {
@@ -4144,6 +4163,27 @@ void LayoutPanel::AddResizeOptionsToMenu(wxMenu* mnuResize) {
     mnuResize->Append(ID_PREVIEW_RESIZE_SAMESIZE, "Match Size");
 }
 
+void LayoutPanel::AddDisperseOptionsToMenu(wxMenu* mnuDisperse) {
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_SELECT_OPTIONS, "Select Options");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_LEFT, "Left");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_RIGHT, "Right");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_UP, "Up");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_UP_LEFT, "Up + Left");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_UP_RIGHT, "Up + Right");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_DOWN, "Down");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_DOWN_LEFT, "Down + Left");
+    mnuDisperse->Append(ID_PREVIEW_DISPERSE_DOWN_RIGHT, "Down + Right");
+    
+    if (is_3d) {
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_FRONT, "Front");
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_FRONT_LEFT, "Front + Left");
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_FRONT_RIGHT, "Front + Right");
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_BACK, "Back");
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_BACK_LEFT, "Back + Left");
+        mnuDisperse->Append(ID_PREVIEW_DISPERSE_BACK_RIGHT, "Back + Right");
+    }
+}
+
 void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
 {
     modelPreview->SetFocus();
@@ -4163,6 +4203,10 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
         AddAlignOptionsToMenu(mnuAlign);
         mnuAlign->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
 
+        wxMenu* mnuDisperse = new wxMenu();
+        AddDisperseOptionsToMenu(mnuDisperse);
+        mnuDisperse->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
+        
         wxMenu* mnuDistribute = new wxMenu();
         AddDistributeOptionsToMenu(mnuDistribute);
         mnuDistribute->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
@@ -4173,6 +4217,7 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
 
         mnu.Append(ID_PREVIEW_BULKEDIT, "Bulk Edit", mnuBulkEdit, "");
         mnu.Append(ID_PREVIEW_ALIGN, "Align", mnuAlign, "");
+        mnu.Append(ID_PREVIEW_DISPERSE, "Disperse", mnuDisperse, "");
         mnu.Append(ID_PREVIEW_DISTRIBUTE, "Distribute", mnuDistribute, "");
         mnu.Append(ID_PREVIEW_RESIZE, "Resize", mnuResize, "");
 
@@ -4370,6 +4415,112 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent &event)
             PreviewModelAlignVCenter();
         } else {
             objects_panel->PreviewObjectAlignVCenter();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_SELECT_OPTIONS)
+    {
+        if (editing_models ) {
+            PreviewModelDisperseWithOptions();
+        } else {
+            objects_panel->PreviewObjectDisperseWithOptions();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::LEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::LEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::RIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::RIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UP);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UP);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UPLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UPLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UPRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UPRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWN);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWN);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWNLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWNLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWNRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWNRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACK);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACK);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACKLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACKLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACKRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACKRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONTLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONTLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONTRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONTRIGHT);
         }
     }
     else if (event.GetId() == ID_PREVIEW_H_DISTRIBUTE)
@@ -4974,6 +5125,207 @@ void LayoutPanel::PreviewModelVDistribute()
 
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute");
     
+    ReselectTreeModels(selectedModelPaths);
+}
+
+// disperse by selected dialog options
+void LayoutPanel::PreviewModelDisperseWithOptions() {
+        
+    int selectedindex = GetSelectedModelIndex();
+    if (selectedindex < 0) { return; };
+    
+    DisperseOptionsDialog::SetupData dlgData;
+    dlgData.is3d = is_3d;
+    dlgData.forModels = true;
+    
+    Model* primarySelection = modelPreview->GetModels()[selectedindex];
+    dlgData.primarySelection = primarySelection->GetName();
+    dlgData.primaryLocked = primarySelection->GetModelScreenLocation().IsLocked();
+    
+    dlgData.objectsToDisperse.Add(primarySelection->GetName());
+    
+    for (const auto& m : modelPreview->GetModels()) {
+        if (m->GetName() != primarySelection->GetName() && m->GetDisplayAs() != "ModelGroup") {
+            if (m->GroupSelected) {
+                dlgData.objectsToDisperse.push_back(m->GetName());
+            } else {
+                dlgData.availableTargets.push_back(m->GetName());
+            }
+        }
+    }
+    
+    DisperseOptionsDialog dlg(this);
+    dlg.Setup(dlgData);
+    
+    if (dlg.ShowModal() == wxID_OK) {
+        DisperseOptionsDialog::DisperseOptions disperseInfo = dlg.GetDisperseOptions();
+        
+        Model* fromModel = xlights->GetModel(disperseInfo.fromWhat);
+        
+        if (fromModel != nullptr) {
+            std::list<Model*> toDisperse;
+            for (const auto& mName : disperseInfo.order) {
+                Model* m = xlights->GetModel(mName);
+                if (m != nullptr) {
+                    toDisperse.push_back(m);
+                }
+            }
+            
+            PreviewModelDisperse(fromModel, toDisperse, disperseInfo.direction, disperseInfo.offset);
+        }
+    }
+}
+
+// disperse by menu direction from primary selection with default offset, order not guaranteed
+void LayoutPanel::PreviewModelDisperseByDirection(DisperseDirection direction) {
+    int selectedindex = GetSelectedModelIndex();
+    if (selectedindex < 0) { return; };
+        
+    Model* primarySelection = modelPreview->GetModels()[selectedindex];
+        
+    std::list<Model*> disperseModels;
+    
+    for (const auto& m : GetSelectedModelsForEdit()) {
+        if (m->GetName() != primarySelection->GetName()) {
+            disperseModels.push_back(m);
+        }
+    }
+    
+    PreviewModelDisperse(primarySelection, disperseModels, direction);
+}
+
+// do the actual dispersement
+void LayoutPanel::PreviewModelDisperse(Model* fromModel, std::list<Model*> disperseModels, DisperseDirection direction, float offset) {
+    if (fromModel == nullptr) { return; };
+    
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+    Model* currFromModel = fromModel;
+        
+    for (const auto& mToDisperse : disperseModels) {
+
+        if (mToDisperse != nullptr) {
+            float left = currFromModel->GetLeft();
+            float right = currFromModel->GetRight();
+            float top = currFromModel->GetTop();
+            float bottom = currFromModel->GetBottom();
+            float hCenter = currFromModel->GetHcenterPos();
+            float vCenter = currFromModel->GetVcenterPos();
+            float back = 0.0f;
+            float front = 0.0f;
+            float depth = 0.0f;
+            float diagOffset = (offset / 2 * std::sqrt(2));
+            
+            // handle 3d positioning and z-axis centering
+            if (is_3d) {
+                front = currFromModel->GetFront();
+                back = currFromModel->GetBack();
+                depth = currFromModel->GetDepth();
+                
+                // center on z-axis, default to front if target and/or model to distribute is not boxed
+                float zCenter = front;
+                if (dynamic_cast<ModelWithScreenLocation<BoxedScreenLocation>*>(currFromModel)) {
+                    zCenter = fromModel->GetDcenterPos();
+                }
+                
+                if (dynamic_cast<ModelWithScreenLocation<BoxedScreenLocation>*>(mToDisperse)) {
+                    mToDisperse->SetDcenterPos(zCenter);
+                } else {
+                    mToDisperse->SetFront(zCenter);
+                }
+            }
+            
+            // center on x/y axis
+            mToDisperse->SetHcenterPos(hCenter);
+            mToDisperse->SetVcenterPos(vCenter);
+
+            // distribute model in selected direction
+            switch (direction) {
+                case DisperseDirection::LEFT: {
+                    mToDisperse->SetRight(left - offset);
+                    break;
+                }
+                case DisperseDirection::RIGHT: {
+                    mToDisperse->SetLeft(right + offset);
+                    break;
+                }
+                case DisperseDirection::UP: {
+                    mToDisperse->SetBottom(top + offset);
+                    break;
+                }
+                case DisperseDirection::DOWN: {
+                    mToDisperse->SetTop(bottom - offset);
+                    break;
+                }
+                case DisperseDirection::UPLEFT: {
+                    mToDisperse->SetBottom(top + diagOffset);
+                    mToDisperse->SetRight(left - diagOffset);
+                    break;
+                }
+                case DisperseDirection::UPRIGHT: {
+                    mToDisperse->SetBottom(top + diagOffset);
+                    mToDisperse->SetLeft(right + diagOffset);
+                    break;
+                }
+                case DisperseDirection::DOWNLEFT: {
+                    mToDisperse->SetTop(bottom - diagOffset);
+                    mToDisperse->SetRight(left - diagOffset);
+                    break;
+                }
+                case DisperseDirection::DOWNRIGHT: {
+                    mToDisperse->SetTop(bottom - diagOffset);
+                    mToDisperse->SetLeft(right + diagOffset);
+                    break;
+                }
+                case DisperseDirection::BACK: {
+                    if (!is_3d) { break; };
+                    
+                    mToDisperse->SetFront(back + (depth / 2) - offset);
+                    break;
+                }
+                case DisperseDirection::BACKLEFT: {
+                    if (!is_3d) { break; };
+
+                    mToDisperse->SetFront(back + (depth / 2) - diagOffset);
+                    mToDisperse->SetRight(left - diagOffset);
+                    break;
+                }
+                case DisperseDirection::BACKRIGHT: {
+                    if (!is_3d) { break; };
+
+                    mToDisperse->SetFront(back + (depth / 2) - diagOffset);
+                    mToDisperse->SetLeft(right + diagOffset);
+                    break;
+                }
+                case DisperseDirection::FRONT: {
+                    if (!is_3d) { break; };
+                    
+                    mToDisperse->SetBack(front - (depth / 2) + offset);
+                    break;
+                }
+                case DisperseDirection::FRONTLEFT: {
+                    if (!is_3d) { break; };
+
+                    mToDisperse->SetBack(front - (depth / 2) + diagOffset);
+                    mToDisperse->SetRight(left + diagOffset);
+                    break;
+                }
+                case DisperseDirection::FRONTRIGHT: {
+                    if (!is_3d) { break; };
+
+                    mToDisperse->SetBack(front - (depth / 2) + diagOffset);
+                    mToDisperse->SetLeft(right + diagOffset);
+                    break;
+                }
+                default: {
+                    break;
+                }
+            }
+
+            currFromModel = mToDisperse;
+        }
+    }
+    
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewDisperseObjects");
     ReselectTreeModels(selectedModelPaths);
 }
 
@@ -6732,6 +7084,112 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event)
             PreviewModelAlignVCenter();
         } else {
             objects_panel->PreviewObjectAlignVCenter();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_SELECT_OPTIONS)
+    {
+        if (editing_models ) {
+            PreviewModelDisperseWithOptions();
+        } else {
+            objects_panel->PreviewObjectDisperseWithOptions();
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::LEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::LEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::RIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::RIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UP);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UP);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UPLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UPLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_UP_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::UPRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::UPRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWN);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWN);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWNLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWNLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_DOWN_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::DOWNRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::DOWNRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACK);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACK);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACKLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACKLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_BACK_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::BACKRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::BACKRIGHT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT_LEFT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONTLEFT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONTLEFT);
+        }
+    }
+    else if (event.GetId() == ID_PREVIEW_DISPERSE_FRONT_RIGHT) {
+        if (editing_models ) {
+            PreviewModelDisperseByDirection(DisperseDirection::FRONTRIGHT);
+        } else {
+            objects_panel->PreviewObjectDisperseByDirection(DisperseDirection::FRONTRIGHT);
         }
     }
     else if (event.GetId() == ID_PREVIEW_H_DISTRIBUTE)

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -31,6 +31,7 @@ class wxStaticText;
 #include <glm/glm.hpp>
 
 #include "ControllerConnectionDialog.h"
+#include "DisperseOptionsDialog.h"
 
 #include <vector>
 #include <list>
@@ -175,6 +176,22 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_DISTRIBUTE;
         static const long ID_PREVIEW_H_DISTRIBUTE;
         static const long ID_PREVIEW_V_DISTRIBUTE;
+        static const long ID_PREVIEW_DISPERSE;
+        static const long ID_PREVIEW_DISPERSE_SELECT_OPTIONS;
+        static const long ID_PREVIEW_DISPERSE_LEFT;
+        static const long ID_PREVIEW_DISPERSE_RIGHT;
+        static const long ID_PREVIEW_DISPERSE_UP;
+        static const long ID_PREVIEW_DISPERSE_DOWN;
+        static const long ID_PREVIEW_DISPERSE_UP_LEFT;
+        static const long ID_PREVIEW_DISPERSE_UP_RIGHT;
+        static const long ID_PREVIEW_DISPERSE_DOWN_LEFT;
+        static const long ID_PREVIEW_DISPERSE_DOWN_RIGHT;
+        static const long ID_PREVIEW_DISPERSE_BACK;
+        static const long ID_PREVIEW_DISPERSE_BACK_LEFT;
+        static const long ID_PREVIEW_DISPERSE_BACK_RIGHT;
+        static const long ID_PREVIEW_DISPERSE_FRONT;
+        static const long ID_PREVIEW_DISPERSE_FRONT_LEFT;
+        static const long ID_PREVIEW_DISPERSE_FRONT_RIGHT;
         static const long ID_PREVIEW_RESIZE;
         static const long ID_PREVIEW_RESIZE_SAMEWIDTH;
         static const long ID_PREVIEW_RESIZE_SAMEHEIGHT;
@@ -320,6 +337,7 @@ class LayoutPanel: public wxPanel
         void AddAlignOptionsToMenu(wxMenu* mnuAlign);
         void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);
         void AddResizeOptionsToMenu(wxMenu* mnuResize);
+        void AddDisperseOptionsToMenu(wxMenu* mnuDisperse);
         Model* SelectSingleModel(int x,int y);
         bool SelectMultipleModels(int x,int y);
         void SelectAllInBoundingRect(bool models_and_objects);
@@ -363,6 +381,9 @@ class LayoutPanel: public wxPanel
         void PreviewModelAlignVCenter();
         void PreviewModelHDistribute();
         void PreviewModelVDistribute();
+        void PreviewModelDisperseWithOptions();
+        void PreviewModelDisperseByDirection(DisperseDirection direction);
+        void PreviewModelDisperse(Model* fromModel, std::list<Model*> disperseModels, DisperseDirection direction, float offset = 20.0f);
         void PreviewModelResize(bool sameWidth, bool sameHeight);
         Model *CreateNewModel(const std::string &type) const;
 

--- a/xLights/ViewObjectPanel.h
+++ b/xLights/ViewObjectPanel.h
@@ -17,6 +17,8 @@
 
 #include <wx/treelist.h>
 
+#include "DisperseOptionsDialog.h"
+
 class ViewObjectManager;
 class LayoutPanel;
 class LayoutGroup;
@@ -49,6 +51,9 @@ public:
     void PreviewObjectAlignVCenter();
     void PreviewObjectHDistribute();
     void PreviewObjectVDistribute();
+    void PreviewObjectDisperseWithOptions();
+    void PreviewObjectDisperseByDirection(DisperseDirection direction);
+    void PreviewObjectDisperse(ViewObject* fromViewObject, std::list<ViewObject*> disperseObjects, DisperseDirection direction, float offset = 20.0f);
 	void DeleteSelectedObject();
 	bool ObjectListHasFocus() { return TreeListViewObjects->HasFocus() || TreeListViewObjects->GetView()->HasFocus(); };
 

--- a/xLights/wxsmith/DisperseOptionsDialog.wxs
+++ b/xLights/wxsmith/DisperseOptionsDialog.wxs
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wxsmith>
+	<object class="wxDialog" name="DisperseOptionsDialog">
+		<title>Disperse from a Target Model</title>
+		<id_arg>0</id_arg>
+		<style>wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
+		<handler function="OnInit" entry="EVT_INIT_DIALOG" />
+		<handler function="OnResize" entry="EVT_SIZE" />
+		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+			<cols>1</cols>
+			<rows>2</rows>
+			<growablecols>0</growablecols>
+			<growablerows>0</growablerows>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
+					<cols>2</cols>
+					<rows>1</rows>
+					<growablecols>1</growablecols>
+					<growablerows>0</growablerows>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer5" member="no">
+							<cols>1</cols>
+							<rows>2</rows>
+							<object class="sizeritem">
+								<object class="wxFlexGridSizer" variable="FlexGridSizer4" member="no">
+									<cols>2</cols>
+									<rows>3</rows>
+									<object class="sizeritem">
+										<object class="wxStaticText" name="ID_STATICTEXT4" variable="StaticText4" member="yes">
+											<label>Disperse From</label>
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxChoice" name="ID_CHOICE_DISPERSE_FROM" variable="ChoiceDisperseFrom" member="yes">
+											<tooltip>Select the Model to disperse from.</tooltip>
+											<minsize>-1,-1d</minsize>
+											<handler function="OnChoiceTargetSelect" entry="EVT_CHOICE" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="spacer">
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxCheckBox" name="ID_CHECKBOX_USE_PRIMARY" variable="CheckBoxUsePrimarySel" member="yes">
+											<label>Disperse from Primary Selection</label>
+											<minsize>-1,-1</minsize>
+											<handler function="OnCheckBoxUsePrimarySelClick" entry="EVT_CHECKBOX" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxStaticText" name="ID_STATICTEXT2" variable="StaticText2" member="yes">
+											<label>Offset</label>
+										</object>
+										<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxSpinCtrlDouble" name="ID_SPINCTRL_OFFSET" variable="SpinCtrlOffset" member="yes">
+											<value>20</value>
+											<max>500.000000</max>
+											<tooltip>Offset/Spacing between dispursed items.</tooltip>
+											<style>wxALIGN_RIGHT</style>
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxNotebook" name="ID_NOTEBOOK1" variable="DirectionNotebook" member="yes">
+									<focused>1</focused>
+									<tooltip>Select the direction in which to disperse from the Target.</tooltip>
+									<object class="notebookpage">
+										<object class="wxPanel" name="ID_PANEL1" variable="DirectionPanelFrontView" member="yes">
+											<object class="wxGridBagSizer" variable="GridBagSizerFrontView" member="yes">
+												<hgap>1d</hgap>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_UP_LEFT" variable="DirectionUpLeft" member="yes">
+														<label>Up + Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_LEFT" variable="DirectionFviewLeft" member="yes">
+														<label>Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>3</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_DOWN_LEFT" variable="DirectionDownLeft" member="yes">
+														<label>Down + Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_DOWN" variable="DirectionDown" member="yes">
+														<label>Down</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>2</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_UP" variable="DirectionUp" member="yes">
+														<label>Up</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>2</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_RIGHT" variable="DirectionFviewRight" member="yes">
+														<label>Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>3</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_DOWN_RIGHT" variable="DirectionDownRight" member="yes">
+														<label>Down + Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="DirectionFrontLabel" member="yes">
+														<value>Direction to Dispurse</value>
+														<size>153,22</size>
+														<style>wxTE_READONLY|wxTE_CENTRE|wxBORDER_RAISED</style>
+													</object>
+													<col>2</col>
+													<row>3</row>
+													<flag>wxALL|wxEXPAND</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_FVIEW_UP_RIGHT" variable="DirectionUpRight" member="yes">
+														<label>Up + Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+											</object>
+										</object>
+										<label>Front View</label>
+									</object>
+									<object class="notebookpage">
+										<object class="wxPanel" name="ID_PANEL2" variable="DirectionPanelTopView" member="yes">
+											<object class="wxGridBagSizer" variable="GridBagSizerTopView" member="no">
+												<hgap>4</hgap>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_BACK_LEFT" variable="DirectionBackLeft" member="yes">
+														<label>Back + Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_LEFT" variable="DirectionTviewLeft" member="yes">
+														<label>Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>3</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_FRONT_LEFT" variable="DirectionFrontLeft" member="yes">
+														<label>Front + Left</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>0</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_FRONT" variable="DirectionFront" member="yes">
+														<label>Front</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>2</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_FRONT_RIGHT" variable="DirectionFrontRight" member="yes">
+														<label>Front + Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>6</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_RIGHT" variable="DirectionTviewRight" member="yes">
+														<label>Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>3</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_BACK" variable="DirectionBack" member="yes">
+														<label>Back</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>2</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxCheckBox" name="ID_CB_TVIEW_BACK_RIGHT" variable="DirectionBackRight" member="yes">
+														<label>Back + Right</label>
+														<handler function="OnDirectionClick" entry="EVT_CHECKBOX" />
+													</object>
+													<col>5</col>
+													<row>0</row>
+													<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+												<object class="sizeritem">
+													<object class="wxTextCtrl" name="ID_TEXTCTRL2" variable="DirectionTopLabel" member="yes">
+														<value>Direction to Dispurse</value>
+														<size>148,22</size>
+														<style>wxTE_READONLY|wxTE_CENTRE|wxBORDER_RAISED</style>
+													</object>
+													<col>2</col>
+													<row>3</row>
+													<flag>wxALL|wxEXPAND</flag>
+													<border>5</border>
+													<option>1</option>
+												</object>
+											</object>
+										</object>
+										<label>Top View</label>
+									</object>
+								</object>
+								<flag>wxALL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer6" member="no">
+							<cols>1</cols>
+							<rows>2</rows>
+							<growablecols>0</growablecols>
+							<growablerows>1</growablerows>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT3" variable="DisperseOrderLabel" member="yes">
+									<label>Model Disperse Order</label>
+								</object>
+								<flag>wxTOP|wxLEFT|wxRIGHT|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxFlexGridSizer" variable="DisperseOrderSizer" member="yes">
+									<cols>2</cols>
+									<rows>1</rows>
+									<growablecols>0</growablecols>
+									<growablerows>0</growablerows>
+									<object class="sizeritem">
+										<object class="wxListView" name="ID_DISPERSE_ORDER_LIST" variable="DisperseOrderList" member="yes">
+											<size>-1,-1d</size>
+											<maxsize>-1,-1</maxsize>
+											<style>wxLC_REPORT|wxLC_NO_HEADER|wxLC_SORT_ASCENDING|wxBORDER_SIMPLE|wxVSCROLL|wxHSCROLL|wxFULL_REPAINT_ON_RESIZE</style>
+											<handler function="OnDisperseOrderListBeginDrag" entry="EVT_LIST_BEGIN_DRAG" />
+											<handler function="OnDisperseOrderListItemSelect" entry="EVT_LIST_ITEM_SELECTED" />
+											<handler function="OnDisperseOrderListItemDeselect" entry="EVT_LIST_ITEM_DESELECTED" />
+											<handler function="OnDisperseOrderListItemActivated" entry="EVT_LIST_ITEM_ACTIVATED" />
+										</object>
+										<flag>wxTOP|wxEXPAND</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxBoxSizer" variable="BoxSizer2" member="no">
+											<orient>wxVERTICAL</orient>
+											<object class="sizeritem">
+												<object class="wxBitmapButton" name="ID_BUTTON_ORDER_UP" variable="ButtonOrderUp" member="yes">
+													<bitmap stock_id="wxART_GO_UP" />
+													<handler function="OnButtonOrderUpClick" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+												<border>5</border>
+												<option>1</option>
+											</object>
+											<object class="sizeritem">
+												<object class="wxBitmapButton" name="ID_BUTTON_ORDER_DOWN" variable="ButtonOrderDown" member="yes">
+													<bitmap stock_id="wxART_GO_DOWN" />
+													<handler function="OnButtonOrderDownClick" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+												<border>5</border>
+												<option>1</option>
+											</object>
+										</object>
+										<flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+								</object>
+								<flag>wxBOTTOM|wxLEFT|wxRIGHT|wxEXPAND</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxBoxSizer" variable="BoxSizer1" member="no">
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON_CANCEL" variable="ButtonCancel" member="yes">
+							<label>Cancel</label>
+							<handler function="OnButtonCancelClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON_OK" variable="ButtonOK" member="yes">
+							<label>OK</label>
+							<handler function="OnButtonOKClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+		</object>
+	</object>
+</wxsmith>

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -489,6 +489,8 @@
 		<Unit filename="DimmingCurve.h" />
 		<Unit filename="DimmingCurvePanel.cpp" />
 		<Unit filename="DimmingCurvePanel.h" />
+		<Unit filename="DisperseOptionsDialog.cpp" />
+		<Unit filename="DisperseOptionsDialog.h" />
 		<Unit filename="DissolveTransitionPattern.cpp" />
 		<Unit filename="DragColoursBitmapButton.cpp" />
 		<Unit filename="DragColoursBitmapButton.h" />
@@ -1268,6 +1270,7 @@
 		<Unit filename="wxsmith/CustomModelDialog.wxs" />
 		<Unit filename="wxsmith/CustomTimingDialog.wxs" />
 		<Unit filename="wxsmith/DMXPanel.wxs" />
+		<Unit filename="wxsmith/DisperseOptionsDialog.wxs" />
 		<Unit filename="wxsmith/EffectAssist.wxs" />
 		<Unit filename="wxsmith/EffectIconPanel.wxs" />
 		<Unit filename="wxsmith/EffectTimingDialog.wxs" />
@@ -1600,6 +1603,7 @@
 					<wxPanel wxs="wxsmith/ColorManagerSettingsPanel.wxs" src="preferences/ColorManagerSettingsPanel.cpp" hdr="preferences/ColorManagerSettingsPanel.h" fwddecl="0" i18n="1" name="ColorManagerSettingsPanel" language="CPP" />
 					<wxDialog wxs="wxsmith/BulkEditColourPickerDialog.wxs" src="BulkEditColourPickerDialog.cpp" hdr="BulkEditColourPickerDialog.h" fwddecl="0" i18n="1" name="BulkEditColourPickerDialog" language="CPP" />
 					<wxDialog wxs="wxsmith/KeyBindingEditDialog.wxs" src="KeyBindingEditDialog.cpp" hdr="KeyBindingEditDialog.h" fwddecl="0" i18n="1" name="KeyBindingEditDialog" language="CPP" />
+					<wxDialog wxs="wxsmith/DisperseOptionsDialog.wxs" src="DisperseOptionsDialog.cpp" hdr="DisperseOptionsDialog.h" fwddecl="0" i18n="1" name="DisperseOptionsDialog" language="CPP" />
 				</resources>
 			</wxsmith>
 		</Extensions>


### PR DESCRIPTION
Add 'Disperse' feature, hope that is the appropriate term, for models and 3d objects to layout panel.  The idea is to take 1 or more selected models and be able to 'disperse' them in any direction with an offset from the starting point of a target model.  Users can use the default disperse by direction options in right click menu which will disperse selected items with a default offset of 20 (tbd if this is appropriate) from the primary selection or use the 'Select Options' menu item which pulls up a dialog where they can rearrange the order to disperse as well as select any target model as the base for disbursement for selected models as well as the offset.  Dialog also prompts on single selection right click >> disperse so a user can select an existing target model to place the newly created/imported model next to in any direction.  For now the 'Select Options' is top on the menu as we don't track selection order (treelist just gives us what is selected in sort order) but if I can figure out a decent way to track selection order so users don't have to manually manipulate order this should probably dropped to the bottom.