### PR TITLE
change 'Add Group' to 'Add Empty Group' to alleviate user confusion

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -7556,7 +7556,7 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
         mnuContext.AppendSeparator();
     }
 
-    mnuContext.Append(ID_MNU_ADD_MODEL_GROUP, "Add Group");
+    mnuContext.Append(ID_MNU_ADD_MODEL_GROUP, "Add Empty Group");
     if ((selectedTreeModels.size() + selectedTreeSubModels.size() + selectedTreeGroups.size()) > 0) {
         for (const auto& m : xlights->AllModels) {
             if (m.second->GetDisplayAs() == "ModelGroup") {


### PR DESCRIPTION
I have helped a number of users who seem to think that when they select a bunch of models and want to create a new group from the selections they claim there is an issue and selected models aren't added to the new group.  All have been user error as they all default to selecting the first option which is 'Add Group' instead of 'Create Group from Selections'.  Simple change from 'Add Group' to 'Add Empty Group' in menu label should make this more clear as to the intent of what they are doing and make them read further down in the list of menu options to 'Create Group from Selections'.