### PR TITLE
DDP Added to Current WLED Firmware

### DIFF
--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -16,6 +16,7 @@
 			<SerialProtocols/>
 			<InputProtocols>
 				<Protocol>e131</Protocol>
+				<Protocol>ddp</Protocol>
 			</InputProtocols>
 		</Variant>	
 	</Controller>


### PR DESCRIPTION
Not sure how to account for this but the current master branch does have DDP support.  It was added in https://github.com/Aircoookie/WLED/commit/ee8596d175e7b2e4617572eab5eca401f1bbd73b

I'm guessing another variant will need to be created but starting the conversation.