### PR TITLE
enh: add "Cut Effects" option to right-click menu for sequence elements

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -7101,6 +7101,26 @@ void EffectsGrid::StretchAllSelectedEffects(int deltaMS, bool offset) const
     }
 }
 
+void EffectsGrid::CutModelEffects(int row_number, bool allLayers)
+{
+    CopyModelEffects(row_number, allLayers);
+
+    mSequenceElements->get_undo_mgr().CreateUndoStep();
+    if (!allLayers) {
+        EffectLayer* effectLayer = mSequenceElements->GetVisibleEffectLayer(row_number);
+        effectLayer->SelectAllEffects();
+        effectLayer->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
+    }
+    else {
+        Element* element = mSequenceElements->GetVisibleRowInformation(row_number)->element;
+        for (int i = 0; i < element->GetEffectLayerCount(); i++) {
+            EffectLayer* effectLayer = mSequenceElements->GetEffectLayer(i);
+            effectLayer->SelectAllEffects();
+            effectLayer->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
+        }
+    }
+}
+
 void EffectsGrid::CopyModelEffects(int row_number, bool allLayers)
 {
     if (!allLayers)

--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -103,6 +103,7 @@ public:
     void SetEffectsDescription();
     void SetEffectsTiming();
     void ProcessDroppedEffect(Effect* effect);
+    void CutModelEffects(int row_number, bool allLayers);
     void CopyModelEffects(int row_number, bool allLayers);
     void PasteModelEffects(int row_number, bool allLayers);
     Effect* GetSelectedEffect() const;

--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -64,6 +64,8 @@ const long RowHeading::ID_ROW_MNU_TOGGLE_NODES = wxNewId();
 const long RowHeading::ID_ROW_MNU_CONVERT_TO_EFFECTS = wxNewId();
 const long RowHeading::ID_ROW_MNU_CREATE_TIMING_FROM_EFFECTS = wxNewId();
 const long RowHeading::ID_ROW_MNU_PROMOTE_EFFECTS = wxNewId();
+const long RowHeading::ID_ROW_MNU_CUT_ROW = wxNewId();
+const long RowHeading::ID_ROW_MNU_CUT_MODEL = wxNewId();
 const long RowHeading::ID_ROW_MNU_COPY_ROW = wxNewId();
 const long RowHeading::ID_ROW_MNU_COPY_MODEL = wxNewId();
 const long RowHeading::ID_ROW_MNU_PASTE_ROW = wxNewId();
@@ -387,6 +389,8 @@ void RowHeading::rightClick( wxMouseEvent& event)
                 modelMenu->Append(ID_ROW_MNU_EXPORT_RENDERED_MODEL_SELECTED_EFFECTS, "Render and Export Selected Model Effects")->Enable(m != nullptr && m->GetDisplayAs() != "ModelGroup" && element->GetSelectedEffectCount() > 0);
                 rowMenu->Append(ID_ROW_MNU_SELECT_ROW_EFFECTS, "Select Effects");
                 modelMenu->Append(ID_ROW_MNU_SELECT_MODEL_EFFECTS, "Select Effects");
+                rowMenu->Append(ID_ROW_MNU_CUT_ROW, "Cut Effects");
+                modelMenu->Append(ID_ROW_MNU_CUT_MODEL, "Cut Effects");
                 rowMenu->Append(ID_ROW_MNU_COPY_ROW, "Copy Effects");
                 modelMenu->Append(ID_ROW_MNU_COPY_MODEL, "Copy Effects");
                 wxMenuItem* menu_paste = rowMenu->Append(ID_ROW_MNU_PASTE_ROW, "Paste Effects");
@@ -879,6 +883,19 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
         wxCommandEvent playEvent(EVT_PLAY_MODEL);
         playEvent.SetString(element->GetModelName());
         wxPostEvent(GetParent(), playEvent);
+    }
+    else if (id == ID_ROW_MNU_CUT_ROW) {
+        wxCommandEvent cutRowEvent(EVT_CUT_MODEL_EFFECTS);
+        cutRowEvent.SetInt(mSelectedRow);
+        wxPostEvent(GetParent(), cutRowEvent);
+        mCanPaste = true;
+    }
+    else if (id == ID_ROW_MNU_CUT_MODEL) {
+        wxCommandEvent cutRowEvent(EVT_CUT_MODEL_EFFECTS);
+        cutRowEvent.SetInt(mSelectedRow);
+        cutRowEvent.SetString("All");
+        wxPostEvent(GetParent(), cutRowEvent);
+        mCanPaste = true;
     }
     else if (id == ID_ROW_MNU_COPY_ROW) {
         wxCommandEvent copyRowEvent(EVT_COPY_MODEL_EFFECTS);

--- a/xLights/sequencer/RowHeading.h
+++ b/xLights/sequencer/RowHeading.h
@@ -98,6 +98,8 @@ private:
     static const long ID_ROW_MNU_CONVERT_TO_EFFECTS;
     static const long ID_ROW_MNU_CREATE_TIMING_FROM_EFFECTS;
     static const long ID_ROW_MNU_PROMOTE_EFFECTS;
+    static const long ID_ROW_MNU_CUT_ROW;
+    static const long ID_ROW_MNU_CUT_MODEL;
     static const long ID_ROW_MNU_COPY_ROW;
     static const long ID_ROW_MNU_COPY_MODEL;
     static const long ID_ROW_MNU_PASTE_ROW;

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -1362,6 +1362,12 @@ void xLightsFrame::PlayModel(wxCommandEvent& event)
     }
 }
 
+void xLightsFrame::CutModelEffects(wxCommandEvent& event)
+{
+    mainSequencer->PanelEffectGrid->CutModelEffects(event.GetInt(), event.GetString() == "All");
+    UnselectEffect();
+}
+
 void xLightsFrame::CopyModelEffects(wxCommandEvent& event)
 {
     mainSequencer->PanelEffectGrid->CopyModelEffects(event.GetInt(), event.GetString() == "All");

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -360,6 +360,7 @@ wxDEFINE_EVENT(EVT_PERSPECTIVES_CHANGED, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SAVE_PERSPECTIVES, wxCommandEvent);
 wxDEFINE_EVENT(EVT_EXPORT_MODEL, wxCommandEvent);
 wxDEFINE_EVENT(EVT_PLAY_MODEL, wxCommandEvent);
+wxDEFINE_EVENT(EVT_CUT_MODEL_EFFECTS, wxCommandEvent);
 wxDEFINE_EVENT(EVT_COPY_MODEL_EFFECTS, wxCommandEvent);
 wxDEFINE_EVENT(EVT_PASTE_MODEL_EFFECTS, wxCommandEvent);
 wxDEFINE_EVENT(EVT_MODEL_SELECTED, wxCommandEvent);
@@ -412,6 +413,7 @@ BEGIN_EVENT_TABLE(xLightsFrame,wxFrame)
     EVT_COMMAND(wxID_ANY, EVT_PERSPECTIVES_CHANGED, xLightsFrame::PerspectivesChanged)
     EVT_COMMAND(wxID_ANY, EVT_EXPORT_MODEL, xLightsFrame::ExportModel)
     EVT_COMMAND(wxID_ANY, EVT_PLAY_MODEL, xLightsFrame::PlayModel)
+    EVT_COMMAND(wxID_ANY, EVT_CUT_MODEL_EFFECTS, xLightsFrame::CutModelEffects)
     EVT_COMMAND(wxID_ANY, EVT_COPY_MODEL_EFFECTS, xLightsFrame::CopyModelEffects)
     EVT_COMMAND(wxID_ANY, EVT_PASTE_MODEL_EFFECTS, xLightsFrame::PasteModelEffects)
     EVT_COMMAND(wxID_ANY, EVT_MODEL_SELECTED, xLightsFrame::ModelSelected)

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -152,6 +152,7 @@ wxDECLARE_EVENT(EVT_SAVE_PERSPECTIVES, wxCommandEvent);
 wxDECLARE_EVENT(EVT_PERSPECTIVES_CHANGED, wxCommandEvent);
 wxDECLARE_EVENT(EVT_EXPORT_MODEL, wxCommandEvent);
 wxDECLARE_EVENT(EVT_PLAY_MODEL, wxCommandEvent);
+wxDECLARE_EVENT(EVT_CUT_MODEL_EFFECTS, wxCommandEvent);
 wxDECLARE_EVENT(EVT_COPY_MODEL_EFFECTS, wxCommandEvent);
 wxDECLARE_EVENT(EVT_PASTE_MODEL_EFFECTS, wxCommandEvent);
 wxDECLARE_EVENT(EVT_MODEL_SELECTED, wxCommandEvent);
@@ -1505,6 +1506,7 @@ private:
     void TurnOnOutputToLights(wxCommandEvent& event);
     void PlayJukeboxItem(wxCommandEvent& event);
     void PlayModel(wxCommandEvent& event);
+    void CutModelEffects(wxCommandEvent& event);
     void CopyModelEffects(wxCommandEvent& event);
     void PasteModelEffects(wxCommandEvent& event);
     void ModelSelected(wxCommandEvent& event);


### PR DESCRIPTION
This PR introduces a "Cut Effects" function (for both the Row and Model right-click menus) as requested in https://github.com/smeighan/xLights/issues/2170. The code re-uses the preexisting `CopyModelEffects` functionality to avoid code duplication, before then creating an undo step and deleting the relevant effects. 

I strayed away from simply posting a `EVT_COPY_MODEL_EFFECTS` event and then duplicating the `ID_ROW_MNU_DELETE_ROW_EFFECTS` handling since the first event will be queued whilst the second would be sync, introducing a race condition and deleting the effects prior to copying.

I have included a call to `UnselectEffect` when cutting to avoid dangling `selectedEffect` pointers if the currently selected effect had been cut. This condition could be gated by a condition to only call `UnselectEffect` if it is within the cut effects, but I'm not sure if it is necessary.

I've successfully tested these changes without experiencing regressions, but given the wealth of various selection and deletion methods within the xLights codebase, additional eyes would be appreciated.