### PR TITLE
enh: avoid infinite version update check loops for offline computers

### DIFF
--- a/xLights/UpdaterDialog.h
+++ b/xLights/UpdaterDialog.h
@@ -25,7 +25,6 @@ class UpdaterDialog: public wxDialog
 		virtual ~UpdaterDialog();
 		wxString urlVersion = "";
 		wxString downloadUrl = "";
-		bool force = false;
 
 		//(*Declarations(UpdaterDialog)
 		wxButton* ButtonUpDownload;

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1555,7 +1555,7 @@ private:
     void ValidateWindow();
     void DoDonate();
     void AutoShowHouse();
-    bool CheckForUpdate(bool force);
+    bool CheckForUpdate(int maxRetries, bool canSkipUpdates, bool showMessageBoxes);
     void ShiftEffectsOnLayer(EffectLayer* el, int milliseconds);
     void ShiftSelectedEffectsOnLayer(EffectLayer* el, int milliseconds);
     void InitSequencer();


### PR DESCRIPTION
Once a version check has been explicitly request (using Help->Check for Updates), it will block infinitely in a while loop until an HTTP(S) connection can be established. For offline computers, or those with very unreliable internet, this can mean deadlocking the program for an unknown period of time - likely requiring the process be killed. This PR moves the check to use a max retry counter (1 for the default boot check to retain legacy behavior, and 3 for the explicit request).

Alongside this, a new parameter, showMessageBoxes, has been added to allow explicit update requests to present feedback outside of the debug logger. This ensures that should a failure occur when manually checking for an update, the user will know. Additional debug logging has been added to provide insight into state of the retry behavior.