### PR TITLE
Fix random number generation issues - First Stage

### DIFF
--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -17,6 +17,11 @@
 #include <wx/mimetype.h>
 #include <wx/display.h>
 
+
+#include <random>
+#include <time.h>
+#include <thread>
+
 #include "UtilFunctions.h"
 #include "xLightsVersion.h"
 
@@ -37,6 +42,12 @@
 #endif
 
 #include <log4cpp/Category.hh>
+
+#if defined (_MSC_VER)  // Visual studio
+#define thread_local __declspec( thread )
+#elif defined (__GCC__) // GCC
+#define thread_local __thread
+#endif
 
 static std::map<std::string, std::string> __resolvedIPMap;
 
@@ -818,6 +829,13 @@ std::string BeforeInt(std::string& s)
     std::string res = s.substr(0, i);
     s = s.substr(i);
     return res;
+}
+
+int intRand(const int& min, const int& max) {
+    static thread_local std::mt19937* generator = nullptr;
+    if (!generator) generator = new std::mt19937(clock() + std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    std::uniform_int_distribution<int> distribution(min, max);
+    return distribution(*generator);
 }
 
 // Extract any leading number ... strip it from the input string

--- a/xLights/UtilFunctions.h
+++ b/xLights/UtilFunctions.h
@@ -78,6 +78,7 @@ inline double rand01()
 
 void SaveWindowPosition(const std::string& tag, wxWindow* window);
 void LoadWindowPosition(const std::string& tag, wxSize& size, wxPoint& position);
+int intRand(const int& min, const int& max);
 void SaveInt(const std::string& tag, int value);
 int LoadInt(const std::string& tag, int defaultValue);
 int NumberAwareStringCompare(const std::string &a, const std::string &b);

--- a/xLights/effects/FacesEffect.cpp
+++ b/xLights/effects/FacesEffect.cpp
@@ -38,7 +38,7 @@ public:
     int nextBlinkTime;
     std::map<std::string, int> nodeNameCache;
 
-    FacesRenderCache() : blinkEndTime(0), nextBlinkTime(0) {
+    FacesRenderCache() : blinkEndTime(0), nextBlinkTime(intRand(0, 5000)) {
     }
     virtual ~FacesRenderCache() {
         for (auto it = _imageCache.begin(); it != _imageCache.end(); ++it)
@@ -590,7 +590,7 @@ void FacesEffect::drawoutline(RenderBuffer &buffer, int Phoneme, bool outline, c
         {
             if ((buffer.curPeriod * buffer.frameTimeInMs) >= cache->nextBlinkTime) {
                 //roughly every 5 seconds we'll blink
-                cache->nextBlinkTime += (4500 + (rand() % 1000));
+                cache->nextBlinkTime += intRand(4500, 5500);
                 cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; //100ms blink
                 eye = "Closed";
             }
@@ -898,7 +898,7 @@ void FacesEffect::RenderFaces(RenderBuffer &buffer,
             if ("Auto" == eyes) {
                 if ((buffer.curPeriod * buffer.frameTimeInMs) >= cache->nextBlinkTime) {
                     //roughly every 5 seconds we'll blink
-                    cache->nextBlinkTime += (4500 + (rand() % 1000));
+                    cache->nextBlinkTime += intRand(4500, 5500);
                     cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; //100ms blink
                     eyes = "Closed";
                 }
@@ -951,7 +951,7 @@ void FacesEffect::RenderFaces(RenderBuffer &buffer,
                 if ((buffer.curPeriod * buffer.frameTimeInMs) >= cache->nextBlinkTime) {
                     if ((startms + 150) >= (buffer.curPeriod * buffer.frameTimeInMs)) {
                         //don't want to blink RIGHT at the start of the rest, delay a little bie
-                        int tmp = (buffer.curPeriod * buffer.frameTimeInMs) + 150 + rand() % 400;
+                        int tmp = (buffer.curPeriod * buffer.frameTimeInMs) + intRand(150, 549);
 
                         //also don't want it right at the end
                         if ((tmp + 130) > endms) {
@@ -963,7 +963,7 @@ void FacesEffect::RenderFaces(RenderBuffer &buffer,
                     }
                     else {
                         //roughly every 5 seconds we'll blink
-                        cache->nextBlinkTime += (4500 + (rand() % 1000));
+                        cache->nextBlinkTime += intRand(4500, 5500);
                         cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; //100ms blink
                         eyes = "Closed";
                     }
@@ -982,7 +982,7 @@ void FacesEffect::RenderFaces(RenderBuffer &buffer,
         if ("Auto" == eyes) {
             if ((buffer.curPeriod * buffer.frameTimeInMs) >= cache->nextBlinkTime) {
                 //roughly every 5 seconds we'll blink
-                cache->nextBlinkTime += (4500 + (rand() % 1000));
+                cache->nextBlinkTime += intRand(4500, 5500);
                 cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; //100ms blink
                 eyes = "Closed";
             }


### PR DESCRIPTION
Originally raised via facebook (https://www.facebook.com/groups/xLights/permalink/3562092260493170), as follows:

> Anyone know how to vary the blink interval on idle faces in xLights? I've now got 4 faces up on the wall, and in idle sequences they all blink at the same time. Frankly, it's creepy :) 
> I guess I could make them each multiple face-effects at staggered intervals, but wondered if there was a "real" way that I can't find...

Keith kindly responded - 

> If you have one face effect on a group this will happen. A face effect on each model should randomly separate them.

Which is what should happen, but there's actually a Windows specific bug that results in the behaviour I was seeing... 

Firstly, all the faces will blink in unison at the start of a sequence like this, as nextBlinkTime is inited to 0 - Easy fix for that one...
```
-    FacesRenderCache() : blinkEndTime(0), nextBlinkTime(0) {
+    FacesRenderCache() : blinkEndTime(0), nextBlinkTime(rand() % 5000) {

```
But that's not the whole story...

I added the following logging to xLights/effects/FacesEffect.cpp, after each time nextBlinkTime is set...

```
-                    cache->nextBlinkTime += (4500 + (rand() % 1000));
+                    int r = rand();
+                    cache->nextBlinkTime += (4500 + (r % 1000));
+                    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+                    logger_base.debug("%d - NextBlinkTime = %d (%d)", __LINE__, cache->nextBlinkTime, r);
```


On a sequence with just 3 faces effects (no other effects on any other props, can supply layout/sequence if anyone's interested), I get the following logging:

```
2020-11-30 03:25:18,441 30472 log_base [DEBUG] 906 - NextBlinkTime = 6169 (19169)
2020-11-30 03:25:19,261 17920 log_base [DEBUG] 906 - NextBlinkTime = 6169 (19169)
2020-11-30 03:25:20,144 32304 log_base [DEBUG] 906 - NextBlinkTime = 6169 (19169)
2020-11-30 03:25:29,967 30472 log_base [DEBUG] 906 - NextBlinkTime = 11393 (15724)
2020-11-30 03:25:31,099 17920 log_base [DEBUG] 906 - NextBlinkTime = 11393 (15724)
2020-11-30 03:25:31,795 32304 log_base [DEBUG] 906 - NextBlinkTime = 11393 (15724)
2020-11-30 03:25:32,668 30472 log_base [DEBUG] 906 - NextBlinkTime = 16371 (11478)
2020-11-30 03:25:33,282 17920 log_base [DEBUG] 906 - NextBlinkTime = 16371 (11478)
2020-11-30 03:25:33,530 17920 log_base [DEBUG] 906 - NextBlinkTime = 21229 (29358)
2020-11-30 03:25:36,039 30472 log_base [DEBUG] 906 - NextBlinkTime = 21229 (29358)
2020-11-30 03:25:37,084 32304 log_base [DEBUG] 906 - NextBlinkTime = 16371 (11478)
2020-11-30 03:25:40,444 17920 log_base [DEBUG] 906 - NextBlinkTime = 26691 (26962)
2020-11-30 03:25:41,077 30472 log_base [DEBUG] 906 - NextBlinkTime = 26691 (26962)
2020-11-30 03:25:41,268 17920 log_base [DEBUG] 906 - NextBlinkTime = 31655 (24464)
2020-11-30 03:25:41,492 30472 log_base [DEBUG] 906 - NextBlinkTime = 31655 (24464)
2020-11-30 03:25:41,662 32304 log_base [DEBUG] 906 - NextBlinkTime = 21229 (29358)
2020-11-30 03:25:41,834 32304 log_base [DEBUG] 906 - NextBlinkTime = 26691 (26962)
2020-11-30 03:25:42,007 32304 log_base [DEBUG] 906 - NextBlinkTime = 31655 (24464)
```

So r is coming back with the same PRNG sequence on each thread - Google + StackOverflow point me to MSDN docs for rand, which says that the PRNG seed is thread-local on Windows, so you'd need a call to srand per thread - This is notably NOT the POSIX behaviour, so it'll work OK on Linux/Mac. Also not 100% sure that the srand call in xLightApp.cpp::main() is being executed on Windows - breakpoints there don't seem to fire. Turns out this doesn't really matter for the purposes of this issue.

References for the above:
https://stackoverflow.com/questions/10159728/does-one-need-to-call-srand-c-function-per-thread-or-per-process-to-seed-the-r
https://docs.microsoft.com/en-us/previous-versions/f0d4wb4t(v=vs.140)?redirectedfrom=MSDN - "The srand function sets the starting point for generating a series of pseudorandom integers **in the current thread**"

Note that when we repeatedly re-render, things get a little better, as different effects get assigned to different render threads where the PRNG is in a less predictable state, and you start to see differences in there. I guess this also depends on the mix of effects you have active and rendering in your sequence.

So - can we just do something like:
```
#if WINDOWS
srand(time(nullptr) + thread_id);
#endif 
```
in the JobPoolWorker::Entry()?

Sadly, no. We shouldn't really be using rand like this anyway - it's not thread safe or re-entrant. This probably matters more for crypto, and less for flashy lights, but we should probably have it right all the same...

I went looking, and nabbed a thread safe implementation from:
https://stackoverflow.com/questions/21237905/how-do-i-generate-thread-safe-uniform-random-numbers

and added it to UtilFunctions.cpp. Modified all faces calls to rand to use this new function.

Rendering again with these changes in place gives us the following:
```
2020-11-30 10:06:10,711 13476 log_base [DEBUG] Rendering 47 models 1200 frames.
2020-11-30 10:06:10,749 33880 log_base [DEBUG] 906 - NextBlinkTime = 5337 (4823)
2020-11-30 10:06:10,750 13476 log_base [DEBUG] Job pool new size 4.
2020-11-30 10:06:10,770 16400 log_base [DEBUG] 906 - NextBlinkTime = 9476 (4961)
2020-11-30 10:06:10,778 35180 log_base [DEBUG] 906 - NextBlinkTime = 8924 (5483)
2020-11-30 10:06:10,790 33880 log_base [DEBUG] 906 - NextBlinkTime = 9950 (4613)
2020-11-30 10:06:10,800 16400 log_base [DEBUG] 906 - NextBlinkTime = 14691 (5215)
2020-11-30 10:06:10,811 35180 log_base [DEBUG] 906 - NextBlinkTime = 14365 (5441)
2020-11-30 10:06:10,823 33880 log_base [DEBUG] 906 - NextBlinkTime = 15361 (5411)
2020-11-30 10:06:10,838 16400 log_base [DEBUG] 906 - NextBlinkTime = 19298 (4607)
2020-11-30 10:06:10,849 35180 log_base [DEBUG] 906 - NextBlinkTime = 18970 (4605)
2020-11-30 10:06:10,854 33880 log_base [DEBUG] 906 - NextBlinkTime = 20720 (5359)
2020-11-30 10:06:10,864 16400 log_base [DEBUG] 906 - NextBlinkTime = 23943 (4645)
2020-11-30 10:06:10,877 35180 log_base [DEBUG] 906 - NextBlinkTime = 24377 (5407)
2020-11-30 10:06:10,888 33880 log_base [DEBUG] 906 - NextBlinkTime = 25364 (4644)
2020-11-30 10:06:10,897 16400 log_base [DEBUG] 906 - NextBlinkTime = 29275 (5332)
2020-11-30 10:06:10,913 33880 log_base [DEBUG] 906 - NextBlinkTime = 30589 (5225)
2020-11-30 10:06:10,920 35180 log_base [DEBUG] 906 - NextBlinkTime = 29838 (5461)
2020-11-30 10:06:10,935 16400 log_base [DEBUG] 906 - NextBlinkTime = 34147 (4872)
2020-11-30 10:06:10,960 35180 log_base [DEBUG] 906 - NextBlinkTime = 35099 (5261)

```
Demonstrably much happier, and less creepy :)

As such - this is a first PR to ensure that I'm not causing other problems, or barking up the wrong tree. Assuming this gets merged, I'll go update other effects with the new function.