### PR TITLE
fix duplicate models in group when importing from rgb_effects

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -7315,9 +7315,13 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
             }
 
             if (model->GetDisplayAs() == "ModelGroup") {
-                dynamic_cast<ModelGroup*>(model)->AddModel(wxJoin(models, ','));
+                ModelGroup *group = (ModelGroup*)model;
                 for (const auto& m : models) {
-                    logger_base.debug("    Models model group '%s' added model '%s'.", (const char*)name.c_str(), (const char*)m.c_str());
+                    // only add model to group if it doesn't already exist
+                    if (group->GetModel(m) == nullptr) {
+                        group->AddModel(m);
+                        logger_base.debug("    Models model group '%s' added model '%s'.", (const char*)name.c_str(), (const char*)m.c_str());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix issue when importing from rgb_effects and you select a Group + model(s) that are also part of the selected group then the model gets duplicated in the imported group.