### PR TITLE
Added '--no-check-certificate' flag to wget command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ log4cpp: FORCE
 	@printf "Checking log4cpp\n"
 	@if test "`log4cpp-config --version`" != "1.1"; \
 		then if test ! -d log4cpp; \
-			then echo Downloading log4cpp; wget --no-verbose -c https://nchc.dl.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.3.tar.gz; \
+			then echo Downloading log4cpp; wget --no-check-certificate --no-verbose -c https://nchc.dl.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.3.tar.gz; \
 			tar xfz log4cpp-1.1.3.tar.gz ;\
 		fi; \
 		cd log4cpp; \


### PR DESCRIPTION
Certain versions of wget and linux environments require the use of the '--no-check-certificate' flag to allow for log4cpp to be downloaded by the Makefile. If that flag is not present the the standard 'make' command enters an infinite loop of retrying to download and then failing to open the *.tar.gz since it obviously doesn't exist.

Another option is to have a user modify their ~/.wgetrc file to not require '--no-check-certificate' but there seems to be no negative consequence to just adding it in the Makefile as the standard.