### PR TITLE
avoid redundant model list reloads

### DIFF
--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -485,7 +485,9 @@ bool ModelManager::RecalcStartChannels() const {
 
     ResetModelGroups();
 
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "RecalcStartChannels");
+    // Commenting out as this doesn't need to happen unless we have changes and when we do it is redundant as the only
+    // current caller of this method, xLightsMain>>RecalcStartChannels, already adds RELOAD_MODELLIST work if changes exist
+    //xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "RecalcStartChannels");
 
     long end = sw.Time();
     logger_base.debug("RecalcStartChannels takes %ldms.", end);


### PR DESCRIPTION
In RecalcStartChannels(), RELOAD_MODELLIST work was being added regardless of whether or not there were channel changes to models causing unnecessary/redundant reloading of the model tree list in Layout when app is launched/adding a new group/new submodels/etc.  These reloads become more of a pain as a display grows, especially on macOS/gtk with the treectrl implemenations.