### PR TITLE
import-from-xsq-package

### DIFF
--- a/xLights.xcodeproj/project.pbxproj
+++ b/xLights.xcodeproj/project.pbxproj
@@ -539,6 +539,8 @@
 		67FE98551EB8C9BF00C5E804 /* ViewsModelsPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67FE98531EB8C9BF00C5E804 /* ViewsModelsPanel.cpp */; };
 		67FF398F1D57F5C000290DB4 /* MusicXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67FF398E1D57F5C000290DB4 /* MusicXML.cpp */; };
 		67FF39931D57F5D000290DB4 /* NoteImportDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67FF39911D57F5D000290DB4 /* NoteImportDialog.cpp */; };
+		FA9C5DE125D253CC00886D4A /* MediaImportOptionsDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA9C5DDF25D253CC00886D4A /* MediaImportOptionsDialog.cpp */; };
+		FA9D7A7625C7696B00C125D6 /* SequencePackage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA9D7A7425C7696B00C125D6 /* SequencePackage.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1528,6 +1530,10 @@
 		67FF39901D57F5D000290DB4 /* MusicXML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicXML.h; sourceTree = "<group>"; };
 		67FF39911D57F5D000290DB4 /* NoteImportDialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NoteImportDialog.cpp; sourceTree = "<group>"; };
 		67FF39921D57F5D000290DB4 /* NoteImportDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NoteImportDialog.h; sourceTree = "<group>"; };
+		FA9C5DDF25D253CC00886D4A /* MediaImportOptionsDialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaImportOptionsDialog.cpp; sourceTree = "<group>"; };
+		FA9C5DE025D253CC00886D4A /* MediaImportOptionsDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaImportOptionsDialog.h; sourceTree = "<group>"; };
+		FA9D7A7425C7696B00C125D6 /* SequencePackage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequencePackage.cpp; sourceTree = "<group>"; };
+		FA9D7A7525C7696B00C125D6 /* SequencePackage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SequencePackage.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2512,6 +2518,8 @@
 				670827FB2024C2D40002B617 /* MatrixFaceDownloadDialog.cpp */,
 				670827FC2024C2D40002B617 /* MatrixFaceDownloadDialog.h */,
 				67F8A28F24788E92004EC222 /* md5.cpp */,
+				FA9C5DDF25D253CC00886D4A /* MediaImportOptionsDialog.cpp */,
+				FA9C5DE025D253CC00886D4A /* MediaImportOptionsDialog.h */,
 				67DAFDCD1CA1A62B004B3237 /* MIDI */,
 				677196B1223CEFAD0082576E /* ModelChainDialog.cpp */,
 				677196B2223CEFAD0082576E /* ModelChainDialog.h */,
@@ -2575,6 +2583,8 @@
 				672F950D1A7A6619005FF8BF /* SeqSettingsDialog.cpp */,
 				6780AB891A65C3480090B26E /* SequenceData.cpp */,
 				6784F9251A5653670018EC0C /* SequenceElements.cpp */,
+				FA9D7A7425C7696B00C125D6 /* SequencePackage.cpp */,
+				FA9D7A7525C7696B00C125D6 /* SequencePackage.h */,
 				67B5F50D2045B96000F5B99D /* SequenceVideoPanel.cpp */,
 				67B5F50C2045B96000F5B99D /* SequenceVideoPanel.h */,
 				67B5F50A2045B96000F5B99D /* SequenceVideoPreview.cpp */,
@@ -3212,6 +3222,7 @@
 				6716574823CAAA45000B47D3 /* DmxImage.cpp in Sources */,
 				671130B31E4EB18100AF09A7 /* VSAFile.cpp in Sources */,
 				6731448822C6F98F00764C44 /* NoteRangeDialog.cpp in Sources */,
+				FA9D7A7625C7696B00C125D6 /* SequencePackage.cpp in Sources */,
 				67BBFD0F208BD72E00A3D5AE /* LayerSelectDialog.cpp in Sources */,
 				679BD3361C37555C000539FE /* EffectPanelUtils.cpp in Sources */,
 				679BD3351C37555C000539FE /* OnPanel.cpp in Sources */,
@@ -3453,6 +3464,7 @@
 				67E5B5E41EAEDC5800735BF0 /* SubModelGenerateDialog.cpp in Sources */,
 				6706BB0A1E9CFD8E00B44278 /* SequenceViewManager.cpp in Sources */,
 				678A41BE23E6417700E5FB09 /* ControllerSerial.cpp in Sources */,
+				FA9C5DE125D253CC00886D4A /* MediaImportOptionsDialog.cpp in Sources */,
 				67E9B4AC226E510700243B4E /* CharMapDialog.cpp in Sources */,
 				67B2CFE81C3A186A003C17CA /* MeteorsEffect.cpp in Sources */,
 				67B2CFF11C3A186A003C17CA /* FanEffect.cpp in Sources */,

--- a/xLights/MediaImportOptionsDialog.cpp
+++ b/xLights/MediaImportOptionsDialog.cpp
@@ -1,0 +1,230 @@
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/smeighan/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/smeighan/xLights/blob/master/License.txt
+ **************************************************************/
+
+//(*InternalHeaders(MediaImportOptionsDialog)
+#include <wx/intl.h>
+#include <wx/string.h>
+//*)
+
+#include "MediaImportOptionsDialog.h"
+#include "UtilFunctions.h"
+
+//(*IdInit(MediaImportOptionsDialog)
+const long MediaImportOptionsDialog::ID_STATICTEXT1 = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_RESTORE_DEFAULTS = wxNewId();
+const long MediaImportOptionsDialog::ID_TEXTCTRL_FACES_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_FACES_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_TEXTCTRL_GLEDIATORS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_GLEDIATORS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_TEXTCTRL3 = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_IMAGES_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_TEXTCTRL_SHADERS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_SHADERS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_TEXTCTRL_VIDEOS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_VIDEOS_FLD = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_OK = wxNewId();
+const long MediaImportOptionsDialog::ID_BUTTON_CANCEL = wxNewId();
+//*)
+
+BEGIN_EVENT_TABLE(MediaImportOptionsDialog,wxDialog)
+	//(*EventTable(MediaImportOptionsDialog)
+	//*)
+END_EVENT_TABLE()
+
+MediaImportOptionsDialog::MediaImportOptionsDialog(wxWindow* parent, SeqPkgImportOptions* importOptions, wxWindowID id,const wxPoint& pos,const wxSize& size) : _importOptions(importOptions)
+{
+	//(*Initialize(MediaImportOptionsDialog)
+	wxFlexGridSizer* FlexGridSizer1;
+	wxFlexGridSizer* FlexGridSizer2;
+	wxFlexGridSizer* FlexGridSizer3;
+	wxFlexGridSizer* FlexGridSizer4;
+	wxFlexGridSizer* FlexGridSizer5;
+	wxFlexGridSizer* FlexGridSizer6;
+	wxFlexGridSizer* FlexGridSizer7;
+	wxFlexGridSizer* FlexGridSizer8;
+	wxGridBagSizer* SizerQuickActions;
+	wxStaticBoxSizer* SizerFaces;
+	wxStaticBoxSizer* SizerGlediators;
+	wxStaticBoxSizer* SizerImages;
+	wxStaticBoxSizer* SizerShaders;
+	wxStaticBoxSizer* SizerVideos;
+
+	Create(parent, wxID_ANY, _("Media Import Options"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE, _T("wxID_ANY"));
+	FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
+	FlexGridSizer8 = new wxFlexGridSizer(0, 3, 0, 0);
+	StaticText1 = new wxStaticText(this, ID_STATICTEXT1, _("Select the target directories for each media type where available files will be imported into.\n\nNOTE:  Only media files from mapped effects which actually exist in the sequence package \nyou are mapping from will be imported."), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
+	FlexGridSizer8->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(FlexGridSizer8, 1, wxALL|wxEXPAND, 5);
+	SizerQuickActions = new wxGridBagSizer(0, 0);
+	ButtonRestoreDefaults = new wxButton(this, ID_BUTTON_RESTORE_DEFAULTS, _("Restore Defaults"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_RESTORE_DEFAULTS"));
+	SizerQuickActions->Add(ButtonRestoreDefaults, wxGBPosition(0, 0), wxDefaultSpan, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+	SizerQuickActions->Add(0,0,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerQuickActions, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+	SizerFaces = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Faces"));
+	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
+	FacesFolder = new wxTextCtrl(this, ID_TEXTCTRL_FACES_FLD, wxEmptyString, wxDefaultPosition, wxSize(450,-1), wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL_FACES_FLD"));
+	FlexGridSizer2->Add(FacesFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonFacesFolder = new wxButton(this, ID_BUTTON_FACES_FLD, _("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_FACES_FLD"));
+	FlexGridSizer2->Add(ButtonFacesFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerFaces->Add(FlexGridSizer2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerFaces, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerGlediators = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Glediators"));
+	FlexGridSizer3 = new wxFlexGridSizer(0, 3, 0, 0);
+	GlediatorsFolder = new wxTextCtrl(this, ID_TEXTCTRL_GLEDIATORS_FLD, wxEmptyString, wxDefaultPosition, wxSize(450,-1), wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL_GLEDIATORS_FLD"));
+	FlexGridSizer3->Add(GlediatorsFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonGlediatorsFolder = new wxButton(this, ID_BUTTON_GLEDIATORS_FLD, _("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_GLEDIATORS_FLD"));
+	FlexGridSizer3->Add(ButtonGlediatorsFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerGlediators->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerGlediators, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerImages = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Images"));
+	FlexGridSizer4 = new wxFlexGridSizer(0, 3, 0, 0);
+	ImagesFolder = new wxTextCtrl(this, ID_TEXTCTRL3, wxEmptyString, wxDefaultPosition, wxSize(450,-1), wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL3"));
+	FlexGridSizer4->Add(ImagesFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonImagesFolder = new wxButton(this, ID_BUTTON_IMAGES_FLD, _("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_IMAGES_FLD"));
+	FlexGridSizer4->Add(ButtonImagesFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerImages->Add(FlexGridSizer4, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerImages, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerShaders = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Shaders"));
+	FlexGridSizer5 = new wxFlexGridSizer(0, 3, 0, 0);
+	ShadersFolder = new wxTextCtrl(this, ID_TEXTCTRL_SHADERS_FLD, wxEmptyString, wxDefaultPosition, wxSize(450,-1), wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL_SHADERS_FLD"));
+	FlexGridSizer5->Add(ShadersFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonShadersFolder = new wxButton(this, ID_BUTTON_SHADERS_FLD, _("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_SHADERS_FLD"));
+	FlexGridSizer5->Add(ButtonShadersFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerShaders->Add(FlexGridSizer5, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerShaders, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerVideos = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Videos"));
+	FlexGridSizer6 = new wxFlexGridSizer(0, 3, 0, 0);
+	VideosFolder = new wxTextCtrl(this, ID_TEXTCTRL_VIDEOS_FLD, wxEmptyString, wxDefaultPosition, wxSize(450,-1), wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL_VIDEOS_FLD"));
+	FlexGridSizer6->Add(VideosFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonVideosFolder = new wxButton(this, ID_BUTTON_VIDEOS_FLD, _("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_VIDEOS_FLD"));
+	FlexGridSizer6->Add(ButtonVideosFolder, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SizerVideos->Add(FlexGridSizer6, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(SizerVideos, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer7 = new wxFlexGridSizer(0, 2, 0, 0);
+	ButtonOK = new wxButton(this, ID_BUTTON_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_OK"));
+	FlexGridSizer7->Add(ButtonOK, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	ButtonCancel = new wxButton(this, ID_BUTTON_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_CANCEL"));
+	FlexGridSizer7->Add(ButtonCancel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer1->Add(FlexGridSizer7, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	SetSizer(FlexGridSizer1);
+	FlexGridSizer1->Fit(this);
+	FlexGridSizer1->SetSizeHints(this);
+
+	Connect(ID_BUTTON_RESTORE_DEFAULTS,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonRestoreDefaultsClick);
+	Connect(ID_BUTTON_FACES_FLD,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonSelectFolderClick);
+	Connect(ID_BUTTON_GLEDIATORS_FLD,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonSelectFolderClick);
+	Connect(ID_BUTTON_IMAGES_FLD,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonSelectFolderClick);
+	Connect(ID_BUTTON_SHADERS_FLD,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonSelectFolderClick);
+	Connect(ID_BUTTON_VIDEOS_FLD,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonSelectFolderClick);
+	Connect(ID_BUTTON_OK,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonOKClick);
+	Connect(ID_BUTTON_CANCEL,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&MediaImportOptionsDialog::OnButtonCancelClick);
+	Connect(wxID_ANY,wxEVT_INIT_DIALOG,(wxObjectEventFunction)&MediaImportOptionsDialog::OnInit);
+	//*)
+}
+
+MediaImportOptionsDialog::~MediaImportOptionsDialog()
+{
+	//(*Destroy(MediaImportOptionsDialog)
+	//*)
+}
+
+
+void MediaImportOptionsDialog::OnInit(wxInitDialogEvent& event)
+{
+    UpdateOptions();
+}
+
+void MediaImportOptionsDialog::UpdateOptions() {
+
+    FacesFolder->SetLabel(_importOptions->GetDir(MediaTargetDir::FACES_DIR));
+    GlediatorsFolder->SetLabel(_importOptions->GetDir(MediaTargetDir::GLEDIATORS_DIR));
+    ImagesFolder->SetLabel(_importOptions->GetDir(MediaTargetDir::IMAGES_DIR));
+    ShadersFolder->SetLabel(_importOptions->GetDir(MediaTargetDir::SHADERS_DIR));
+    VideosFolder->SetLabel(_importOptions->GetDir(MediaTargetDir::VIDEOS_DIR));
+
+    Layout();
+}
+
+void MediaImportOptionsDialog::GetCurrentLabelAndPath(int btnId, std::string& label, std::string& path) {
+    wxString dlgLabel = "Select Destination for ";
+    wxString fldName;
+
+    if (btnId == ID_BUTTON_FACES_FLD) {
+        fldName = "Faces";
+        path = FacesFolder->GetLabel();
+    } else if (btnId == ID_BUTTON_GLEDIATORS_FLD) {
+        fldName = "Glediators";
+        path = GlediatorsFolder->GetLabel();
+    } else if (btnId == ID_BUTTON_IMAGES_FLD) {
+        fldName = "Images";
+        path = ImagesFolder->GetLabel();
+    } else if (btnId == ID_BUTTON_SHADERS_FLD) {
+        fldName = "Shaders";
+        path = ShadersFolder->GetLabel();
+    } else if (btnId == ID_BUTTON_VIDEOS_FLD) {
+        fldName = "Videos";
+        path = VideosFolder->GetLabel();
+    }
+
+    label = dlgLabel + fldName;
+}
+
+void MediaImportOptionsDialog::UpdateFolderPath(int btnId, std::string& newPath) {
+    if (btnId == ID_BUTTON_FACES_FLD) {
+        FacesFolder->SetLabel(newPath);
+        FacesFolder->SetToolTip(newPath);
+    } else if (btnId == ID_BUTTON_GLEDIATORS_FLD) {
+        GlediatorsFolder->SetLabel(newPath);
+    } else if (btnId == ID_BUTTON_IMAGES_FLD) {
+        ImagesFolder->SetLabel(newPath);
+    } else if (btnId == ID_BUTTON_SHADERS_FLD) {
+        ShadersFolder->SetLabel(newPath);
+    } else if (btnId == ID_BUTTON_VIDEOS_FLD) {
+        VideosFolder->SetLabel(newPath);
+    }
+
+    Layout();
+}
+
+void MediaImportOptionsDialog::OnButtonSelectFolderClick(wxCommandEvent& event)
+{
+    std::string label, path;
+    GetCurrentLabelAndPath(event.GetId(), label, path);
+
+    wxDirDialog dlg(this, label, path, wxDD_DEFAULT_STYLE|wxDD_DIR_MUST_EXIST|wxDD_CHANGE_DIR, wxDefaultPosition, wxDefaultSize, _T("wxDirDialog"));
+    OptimiseDialogPosition(&dlg);
+
+    if (dlg.ShowModal() == wxID_OK) {
+        std::string newPath = dlg.GetPath().ToStdString();
+        UpdateFolderPath(event.GetId(), newPath);
+    }
+}
+
+void MediaImportOptionsDialog::OnButtonOKClick(wxCommandEvent& event)
+{
+    _importOptions->SetDir(MediaTargetDir::FACES_DIR, FacesFolder->GetValue());
+    _importOptions->SetDir(MediaTargetDir::GLEDIATORS_DIR, GlediatorsFolder->GetValue());
+    _importOptions->SetDir(MediaTargetDir::IMAGES_DIR, ImagesFolder->GetValue());
+    _importOptions->SetDir(MediaTargetDir::SHADERS_DIR, ShadersFolder->GetValue());
+    _importOptions->SetDir(MediaTargetDir::VIDEOS_DIR, VideosFolder->GetValue());
+
+    EndDialog(wxID_OK);
+}
+
+void MediaImportOptionsDialog::OnButtonCancelClick(wxCommandEvent& event)
+{
+    EndDialog(wxID_CANCEL);
+}
+
+void MediaImportOptionsDialog::OnButtonRestoreDefaultsClick(wxCommandEvent& event)
+{
+    _importOptions->RestoreDefaults();
+    UpdateOptions();
+}

--- a/xLights/MediaImportOptionsDialog.h
+++ b/xLights/MediaImportOptionsDialog.h
@@ -1,0 +1,85 @@
+#pragma once
+
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/smeighan/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/smeighan/xLights/blob/master/License.txt
+ **************************************************************/
+
+//(*Headers(MediaImportOptionsDialog)
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/gbsizer.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+//*)
+
+#include "SequencePackage.h"
+
+class MediaImportOptionsDialog: public wxDialog
+{
+	public:
+
+		MediaImportOptionsDialog(wxWindow* parent, SeqPkgImportOptions* importOptions, wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize);
+		virtual ~MediaImportOptionsDialog();
+
+		//(*Declarations(MediaImportOptionsDialog)
+		wxButton* ButtonCancel;
+		wxButton* ButtonFacesFolder;
+		wxButton* ButtonGlediatorsFolder;
+		wxButton* ButtonImagesFolder;
+		wxButton* ButtonOK;
+		wxButton* ButtonRestoreDefaults;
+		wxButton* ButtonShadersFolder;
+		wxButton* ButtonVideosFolder;
+		wxStaticText* StaticText1;
+		wxTextCtrl* FacesFolder;
+		wxTextCtrl* GlediatorsFolder;
+		wxTextCtrl* ImagesFolder;
+		wxTextCtrl* ShadersFolder;
+		wxTextCtrl* VideosFolder;
+		//*)
+
+	protected:
+
+		//(*Identifiers(MediaImportOptionsDialog)
+		static const long ID_STATICTEXT1;
+		static const long ID_BUTTON_RESTORE_DEFAULTS;
+		static const long ID_TEXTCTRL_FACES_FLD;
+		static const long ID_BUTTON_FACES_FLD;
+		static const long ID_TEXTCTRL_GLEDIATORS_FLD;
+		static const long ID_BUTTON_GLEDIATORS_FLD;
+		static const long ID_TEXTCTRL3;
+		static const long ID_BUTTON_IMAGES_FLD;
+		static const long ID_TEXTCTRL_SHADERS_FLD;
+		static const long ID_BUTTON_SHADERS_FLD;
+		static const long ID_TEXTCTRL_VIDEOS_FLD;
+		static const long ID_BUTTON_VIDEOS_FLD;
+		static const long ID_BUTTON_OK;
+		static const long ID_BUTTON_CANCEL;
+		//*)
+
+	private:
+
+		//(*Handlers(MediaImportOptionsDialog)
+		void OnInit(wxInitDialogEvent& event);
+		void OnButtonSelectFolderClick(wxCommandEvent& event);
+		void OnButtonOKClick(wxCommandEvent& event);
+		void OnButtonCancelClick(wxCommandEvent& event);
+		void OnButtonRestoreDefaultsClick(wxCommandEvent& event);
+		//*)
+    
+        void UpdateOptions();
+        void GetCurrentLabelAndPath(int btnId, std::string& label, std::string& path);
+        void UpdateFolderPath(int btnId, std::string& newPath);
+        
+        SeqPkgImportOptions* _importOptions;
+        SeqPkgImportOptions _defaultOptions;
+
+		DECLARE_EVENT_TABLE()
+};

--- a/xLights/SequencePackage.cpp
+++ b/xLights/SequencePackage.cpp
@@ -1,0 +1,424 @@
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/smeighan/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/smeighan/xLights/blob/master/License.txt
+ **************************************************************/
+
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+#include <wx/xml/xml.h>
+#include <wx/log.h>
+#include <wx/time.h>
+#include <wx/dir.h>
+#include <wx/progdlg.h>
+
+#include "SequencePackage.h"
+#include "xLightsMain.h"
+
+#include <log4cpp/Category.hh>
+
+static const std::string IMPORTED_MEDIA = "ImportedMedia";
+static const std::string SUBFLD_IMAGES = "Images";
+static const std::string SUBFLD_VIDEOS = "Videos";
+static const std::string SUBFLD_FACES = "DownloadedFaces";
+static const std::string SUBFLD_SHADERS = "Shaders";
+static const std::string SUBFLD_GLEDIATORS = "Glediators";
+static const char PATH_SEP = wxFileName::GetPathSeparator();
+
+SeqPkgImportOptions::SeqPkgImportOptions() {};
+
+SeqPkgImportOptions::~SeqPkgImportOptions() {};
+
+void SeqPkgImportOptions::SetImportActive(bool active) {
+    _importActive = active;
+}
+
+bool SeqPkgImportOptions::IsImportActive() const {
+    return _importActive;
+}
+
+void SeqPkgImportOptions::SetDir(MediaTargetDir dirType, const std::string &dirPath, bool saveAsDefault) {
+    _mediaDirs[dirType] = dirPath;
+    
+    if (saveAsDefault) {
+        _defaultDirs[dirType] = dirPath;
+    }
+}
+
+std::string SeqPkgImportOptions::GetDir(MediaTargetDir dirType) {
+    return _mediaDirs[dirType];
+}
+
+void SeqPkgImportOptions::RestoreDefaults() {
+    _mediaDirs.clear();
+    
+    for (const auto& dir : _defaultDirs) {
+        _mediaDirs[dir.first] = dir.second;
+    }
+}
+
+SequencePackage::SequencePackage(const wxFileName& fileName, xLightsFrame* xlights) {
+    _xlights = xlights;
+
+    if (fileName.GetExt() == "zip") {
+        _xsqOnly = false;
+        _pkgFile = fileName;
+    } else {
+        _xsqOnly = true;
+        _xsqFile = fileName;
+    }
+}
+
+SequencePackage::~SequencePackage() {
+    // cleanup extracted files
+    if (!_xsqOnly && _tempDir.Exists()) {
+        wxDir::Remove(_tempDir.GetFullPath(), wxPATH_RMDIR_RECURSIVE);
+    }
+}
+
+void SequencePackage::InitDefaultImportOptions() {
+    // Set default target media directories based on a few assumptions. User
+    // can still change these in the Mapping Dialog to whatever they would like.
+    
+    std::string showFolder = _xlights->GetShowDirectory();
+
+    // always default faces/shaders to default download folder as they tend to be reused
+    _importOptions.SetDir(MediaTargetDir::FACES_DIR, wxString::Format("%s%c%s", showFolder, PATH_SEP, SUBFLD_FACES), true);
+    _importOptions.SetDir(MediaTargetDir::SHADERS_DIR, wxString::Format("%s%c%s", showFolder, PATH_SEP, SUBFLD_SHADERS), true);
+    
+    
+    wxFileName targetXsq(_xlights->GetSeqXmlFileName());
+    wxString targetDir = targetXsq.GetPath();
+    
+    wxString mediaBaseFolder;
+    
+    if (targetDir.ToStdString() != showFolder) {
+        // target xsq is not at the root of show folder, assume user manages show folder
+        // with a subfolder per sequence as Gil noted
+        mediaBaseFolder = targetDir;
+    } else {
+        // default images/videos/glediators into new ImportedMedia/<NameOfSrcXsq>/<MediaType>
+        mediaBaseFolder = wxString::Format("%s%c%s%c%s", showFolder, PATH_SEP, IMPORTED_MEDIA, PATH_SEP, _xsqName);
+    }
+
+    // set the defaults for media sub folders
+    _importOptions.SetDir(MediaTargetDir::GLEDIATORS_DIR, wxString::Format("%s%c%s", mediaBaseFolder, PATH_SEP, SUBFLD_GLEDIATORS), true);
+    _importOptions.SetDir(MediaTargetDir::IMAGES_DIR, wxString::Format("%s%c%s", mediaBaseFolder, PATH_SEP, SUBFLD_IMAGES), true);
+    _importOptions.SetDir(MediaTargetDir::VIDEOS_DIR, wxString::Format("%s%c%s", mediaBaseFolder, PATH_SEP, SUBFLD_VIDEOS), true);
+}
+
+void SequencePackage::Extract() {
+    static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    if (_xsqOnly) {
+        return;
+    }
+    
+    wxProgressDialog prog("Extract Package", "Extracting Sequence Package...", 100, _xlights, wxPD_APP_MODAL | wxPD_AUTO_HIDE);
+    prog.Show();
+    
+    wxFileInputStream fis(_pkgFile.GetFullPath());
+    
+    if (!fis.IsOk()) {
+        logger_base.error("Could not open the Sequence Package '%s'", _pkgFile.GetFullName().ToStdString().c_str());
+        prog.Update(100);
+        return;
+    }
+
+    _tempDir = wxString::Format("%s%c%s_%lld", wxFileName::GetTempDir(), wxFileName::GetPathSeparator(), _pkgFile.GetName(), wxGetUTCTimeMillis());
+    logger_base.debug("Extracting Sequence Package '%s' to '%s'", _pkgFile.GetFullName().ToStdString().c_str(), _tempDir.GetFullPath().ToStdString().c_str());
+
+    
+    wxZipInputStream zis(fis);
+    std::unique_ptr<wxZipEntry> upZe;
+    
+    // start extracting each entry
+    upZe.reset(zis.GetNextEntry());
+        
+    prog.Update(10);
+    int numEntryProcessed = 0;
+    int progStep = (int)(std::floor(90 / zis.GetTotalEntries()));
+    
+    while (upZe != nullptr) {
+        wxString fnEntry = wxString::Format("%s%c%s", _tempDir.GetFullPath(), wxFileName::GetPathSeparator(), upZe->GetName());
+        wxFileName fnOutput;
+        
+        upZe->IsDir() ? fnOutput.AssignDir(fnEntry) : fnOutput.Assign(fnEntry);
+        
+        // Create output dir in temp if needed
+        if (!wxDirExists(fnOutput.GetPath())) {
+            wxFileName::Mkdir(fnOutput.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+        }
+
+        // handle file output
+        if (!upZe->IsDir()) {
+            
+            if (!zis.CanRead()) {
+                logger_base.error("Could not read file from package '%s'", upZe->GetName().ToStdString().c_str());
+            }
+            
+            wxFileOutputStream fos(fnOutput.GetFullPath());
+
+            if (!fos.IsOk()) {
+                logger_base.error("Could not create sequence file at '%s'", fnOutput.GetFullName().ToStdString().c_str());
+            }
+
+            zis.Read(fos);
+            wxString ext = fnOutput.GetExt();
+            
+            if (ext == "xsq") {
+                _xsqFile = fnOutput;
+                _xsqName = fnOutput.GetName();
+            } else if (ext == "xml") {
+                if (fnOutput.GetName() == "xlights_rgbeffects") {
+                    wxXmlDocument rgbEffects;
+                    if (rgbEffects.Load(fnOutput.GetFullPath())) {
+                        _rgbEffects = rgbEffects;
+                        _pkgRoot = fnOutput.GetPath();
+                    }
+                } else if (fnOutput.GetName() == "xlights_networks") {
+                    _xlNetworks = fnOutput;
+                } else {
+                    wxXmlDocument doc;
+                    if (doc.Load(fnOutput.GetFullPath())) {
+                        if (doc.GetRoot()->GetName() == "xsequence") {
+                            _xsqFile = fnOutput;
+                            _xsqName = fnOutput.GetName();
+                        }
+                    }
+                }
+            } else {
+                // assume other files are media for effects, images/videos/gediators/shaders/faces/etc
+                _media[fnOutput.GetFullName()] = fnOutput;
+            }
+            
+            fos.Close();
+        }
+        
+        numEntryProcessed++;
+        prog.Update(10 + progStep * numEntryProcessed);
+
+        // get next zip entry
+        upZe.reset(zis.GetNextEntry());
+    }
+    
+    // seems silly but if we don't call this twice the dialog sticks around after
+    // this method has completed if the main app is busy, for example opening another
+    // modal dialog like Mapping Dialog
+    prog.Update(100);
+    prog.Update(100);
+    
+    if (!_xsqFile.IsOk() || !_xsqFile.Exists()) {
+        logger_base.error("No sequence file found in package '%s'", _pkgFile.GetFullName().ToStdString().c_str());
+    } else {
+        InitDefaultImportOptions();
+    }
+};
+
+bool SequencePackage::IsValid() const {
+    if (_xsqOnly) {
+        return _xsqFile.IsOk() && _xsqFile.Exists();
+    } else {
+        return  _xsqFile.IsOk() && _xsqFile.Exists() && _rgbEffects.IsOk();
+    }
+}
+
+bool SequencePackage::IsPkg() {
+    return !_xsqOnly;
+}
+
+bool SequencePackage::HasMedia() const {
+    return _media.size() > 0;
+}
+
+bool SequencePackage::HasMissingMedia() const {
+    return _missingMedia.size() > 0;
+}
+
+wxFileName& SequencePackage::GetXsqFile() {
+    return _xsqFile;
+}
+
+wxXmlDocument& SequencePackage::GetRgbEffectsFile() {
+    return _rgbEffects;
+}
+
+bool SequencePackage::ModelsChanged() const {
+    return _modelsChanged;
+}
+
+SeqPkgImportOptions* SequencePackage::GetImportOptions() {
+    if (!_xsqOnly) {
+        return &_importOptions;
+    } else {
+        return nullptr;
+    }
+}
+
+std::list<std::string> SequencePackage::GetMissingMedia() {
+    _missingMedia.unique();
+    return _missingMedia;
+}
+
+std::string SequencePackage::FixAndImportMedia(Effect* mappedEffect, EffectLayer *target) {
+    auto settings = mappedEffect->GetSettings();
+    wxString effName = mappedEffect->GetEffectName();
+    
+    wxString settingEffectFile = wxEmptyString;
+    wxString targetMediaFolder = wxEmptyString;
+    
+    if (effName == "Pictures") {
+        settingEffectFile = "E_FILEPICKER_Pictures_Filename";
+        targetMediaFolder = _importOptions.GetDir(MediaTargetDir::IMAGES_DIR);
+    } else if (effName == "Video") {
+        settingEffectFile = "E_FILEPICKERCTRL_Video_Filename";
+        targetMediaFolder = _importOptions.GetDir(MediaTargetDir::VIDEOS_DIR);
+    } else if (effName == "Shader") {
+        settingEffectFile = "E_0FILEPICKERCTRL_IFS";
+        targetMediaFolder = _importOptions.GetDir(MediaTargetDir::SHADERS_DIR);
+    } else if (effName == "Glediator") {
+        settingEffectFile = "E_FILEPICKERCTRL_Glediator_Filename";
+        targetMediaFolder = _importOptions.GetDir(MediaTargetDir::GLEDIATORS_DIR);
+    } else if (effName == "Faces") {
+        wxString faceName = settings["E_CHOICE_Faces_FaceDefinition"];
+        if (faceName != wxEmptyString) {
+            ImportFaceInfo(mappedEffect, target, faceName);
+        }
+    }
+    
+    if (!settingEffectFile.IsEmpty()) {
+        wxString settingPath = settings.Get(settingEffectFile, "");
+
+        // normalize path so wxFileName can properly parse it, we just need
+        // it to parse properly so we can get to the real filename
+        wxFileName picFilePath;
+        if (settingPath.Contains("\\")) {
+            picFilePath = wxFileName(settingPath, wxPATH_DOS);
+        } else {
+            picFilePath = wxFileName(settingPath);
+        }
+        
+        // import the asset if we have it, otherwise track it as missing
+        wxFileName fileToCopy = _media[picFilePath.GetFullName()];
+        
+        if (fileToCopy.IsOk() && fileToCopy.Exists()) {
+            wxFileName copiedAsset = CopyMediaToTarget(targetMediaFolder, fileToCopy);
+            settings.erase(settingEffectFile);
+            wxString newSetting = copiedAsset.GetFullPath().ToStdString();
+            settings[settingEffectFile] = newSetting;
+        } else {
+            _missingMedia.push_back(picFilePath.GetFullName().ToStdString());
+        }
+    }
+    
+    return settings.AsString();
+}
+
+void SequencePackage::ImportFaceInfo(Effect* mappedEffect, EffectLayer *target, const std::string& faceName) {
+    
+    auto targetModelName = target->GetParentElement()->GetModelName();
+    auto srcModelName = mappedEffect->GetParentEffectLayer()->GetParentElement()->GetModelName();
+    Model* targetModel = _xlights->AllModels[targetModelName];
+    
+    const auto& faceInfo = targetModel->faceInfo.find(faceName);
+    if (faceInfo != targetModel->faceInfo.end()) {
+        // face already defined don't overwrite it
+        return;
+    }
+    
+    wxXmlDocument srcRgbEffects;
+    if (_rgbEffects.IsOk()) {
+        wxXmlNode* modelsNode = nullptr;
+        for (wxXmlNode* node = _rgbEffects.GetRoot()->GetChildren(); node != nullptr; node = node->GetNext()) {
+            if (node->GetName() == "models") {
+                modelsNode = node;
+                break;
+            }
+        }
+
+        if (modelsNode != nullptr) {
+            wxXmlNode* modelNode = nullptr;
+            for (wxXmlNode* model = modelsNode->GetChildren(); model != nullptr; model = model->GetNext()) {
+                if (model->GetAttribute("name") == srcModelName) {
+                    modelNode = model;
+                    break;
+                }
+            }
+
+            if (modelNode != nullptr) {
+                // find faceInfo node
+                for (wxXmlNode* modelChild = modelNode->GetChildren(); modelChild != nullptr; modelChild = modelChild->GetNext()) {
+                    if (modelChild->GetName() == "faceInfo") {
+                        wxString name = modelChild->GetAttribute("Name", "");
+                        wxString type = modelChild->GetAttribute("Type", "");
+                        
+                        // only import if type is matrix
+                        if ((name == faceName || faceName == "Default") && type == "Matrix") {
+                            wxXmlNode* newFaceInfo = new wxXmlNode(wxXML_ELEMENT_NODE, "faceInfo");
+                            
+                            for (wxXmlAttribute* attr = modelChild->GetAttributes(); attr != nullptr; attr = attr->GetNext()) {
+                                wxString attrName = attr->GetName();
+                                wxString attrValue = attr->GetValue();
+                                
+                                // import files
+                                if (attrName.Left(5) == "Mouth" || attrName.Left(4) == "Eyes") {
+                                    if (attrValue != wxEmptyString) {
+                                        // normalize path so wxFileName can properly parse it, we just need
+                                        // it to parse properly so we can get to the real filename
+                                        wxFileName faceFile;
+                                        if (attrValue.Contains("\\")) {
+                                            faceFile = wxFileName(attrValue, wxPATH_DOS);
+                                        } else {
+                                            faceFile = wxFileName(attrValue);
+                                        }
+                                        
+                                        // import the asset if we have it, otherwise track it as missing
+                                        wxFileName fileToCopy = _media[faceFile.GetFullName()];
+                                        
+                                        if (fileToCopy.IsOk() && fileToCopy.Exists()) {
+                                            wxFileName copiedAsset = CopyMediaToTarget(_importOptions.GetDir(MediaTargetDir::FACES_DIR), fileToCopy);
+                                            newFaceInfo->AddAttribute(attrName, copiedAsset.GetFullPath());
+                                        } else {
+                                            _missingMedia.push_back(fileToCopy.GetFullName().ToStdString());
+                                        }
+                                        
+                                    }
+                                } else {
+                                    newFaceInfo->AddAttribute(attrName, attrValue);
+                                }
+                            }
+                            
+                            targetModel->AddFace(newFaceInfo);
+                            targetModel->IncrementChangeCount();
+                            _modelsChanged = true;
+                            
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+wxFileName SequencePackage::CopyMediaToTarget(const std::string& targetFolder, const wxFileName& mediaToCopy) {
+    wxFileName targetFile = wxString::Format("%s%c%s", targetFolder, PATH_SEP, mediaToCopy.GetFullName());
+    
+    // Only import if file doesn't alrady exist in target folder
+    if (!targetFile.Exists()) {
+        // make sure dir exists first
+        if (!wxDirExists(targetFile.GetPath())) {
+            wxFileName::Mkdir(targetFile.GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+        }
+        
+        // now copy the asset
+        wxCopyFile(mediaToCopy.GetFullPath(), targetFile.GetFullPath());
+    }
+    
+    return targetFile;
+}
+

--- a/xLights/SequencePackage.h
+++ b/xLights/SequencePackage.h
@@ -1,0 +1,83 @@
+#pragma once
+
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/smeighan/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/smeighan/xLights/blob/master/License.txt
+ **************************************************************/
+
+#include <wx/filename.h>
+#include <wx/xml/xml.h>
+
+#include <map>
+
+#include "sequencer/Element.h"
+#include "sequencer/Effect.h"
+
+class xLightsFrame;
+
+enum class MediaTargetDir
+{
+    FACES_DIR,
+    GLEDIATORS_DIR,
+    IMAGES_DIR,
+    SHADERS_DIR,
+    VIDEOS_DIR,
+};
+
+
+class SeqPkgImportOptions {
+    public:
+        SeqPkgImportOptions();
+        virtual ~SeqPkgImportOptions();
+        void SetImportActive(bool active);
+        bool IsImportActive() const;
+        void SetDir(MediaTargetDir dirType, const std::string& dirPath, bool saveAsDefault = false);
+        std::string GetDir(MediaTargetDir dirType);
+        void RestoreDefaults();
+    private:
+        bool _importActive = true;
+        std::map<MediaTargetDir, std::string> _mediaDirs;
+        std::map<MediaTargetDir, std::string> _defaultDirs;
+};
+
+class SequencePackage {
+    public:
+        SequencePackage(const wxFileName& zipFile, xLightsFrame* xlights);
+        virtual ~SequencePackage();
+        void Extract();
+        bool IsValid() const;
+        bool IsPkg();
+        bool HasMedia() const;
+        bool HasMissingMedia() const;
+        bool ModelsChanged() const;
+        SeqPkgImportOptions* GetImportOptions();
+        wxFileName& GetXsqFile();
+        wxXmlDocument& GetRgbEffectsFile();
+        wxFileName& GetMedia(const wxString& fileName);
+        void ClearMedia();
+        std::string FixAndImportMedia(Effect* mappedEffect, EffectLayer *target);
+        void ImportFaceInfo(Effect* mappedEffect, EffectLayer *target, const std::string& faceName);
+        wxFileName CopyMediaToTarget(const std::string& targetFolder, const wxFileName& mediaToCopy);
+        std::list<std::string> GetMissingMedia();
+    private:
+        xLightsFrame*   _xlights;
+        bool            _xsqOnly = true;
+        wxFileName      _xsqFile;
+        std::string     _xsqName;
+        wxFileName      _pkgFile;
+        wxFileName      _tempDir;
+        wxXmlDocument   _rgbEffects;
+        wxFileName      _xlNetworks;
+        wxFileName      _pkgRoot;
+        std::list<std::string> _missingMedia;
+        std::map<std::string, wxFileName> _media;
+        bool _modelsChanged = false;
+        SeqPkgImportOptions _importOptions;
+    
+        void InitDefaultImportOptions();
+};

--- a/xLights/wxsmith/MediaImportOptionsDialog.wxs
+++ b/xLights/wxsmith/MediaImportOptionsDialog.wxs
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wxsmith>
+	<object class="wxDialog" name="MediaImportOptionsDialog">
+		<title>Media Import Options</title>
+		<id_arg>0</id_arg>
+		<handler function="OnInit" entry="EVT_INIT_DIALOG" />
+		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+			<cols>1</cols>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer8" member="no">
+					<cols>3</cols>
+					<object class="sizeritem">
+						<object class="wxStaticText" name="ID_STATICTEXT1" variable="StaticText1" member="yes">
+							<label>Select the target directories for each media type where available files will be imported into.&#x0A;&#x0A;NOTE:  Only media files from mapped effects which actually exist in the sequence package &#x0A;you are mapping from will be imported.</label>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxGridBagSizer" variable="SizerQuickActions" member="no">
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON_RESTORE_DEFAULTS" variable="ButtonRestoreDefaults" member="yes">
+							<label>Restore Defaults</label>
+							<handler function="OnButtonRestoreDefaultsClick" entry="EVT_BUTTON" />
+						</object>
+						<col>0</col>
+						<row>0</row>
+						<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="spacer">
+						<col>1</col>
+						<row>0</row>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="SizerFaces" member="no">
+					<label>Faces</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
+							<cols>3</cols>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_FACES_FLD" variable="FacesFolder" member="yes">
+									<size>450,-1</size>
+									<style>wxTE_READONLY</style>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_FACES_FLD" variable="ButtonFacesFolder" member="yes">
+									<label>Select</label>
+									<handler function="OnButtonSelectFolderClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="SizerGlediators" member="no">
+					<label>Glediators</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
+							<cols>3</cols>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_GLEDIATORS_FLD" variable="GlediatorsFolder" member="yes">
+									<size>450,-1</size>
+									<style>wxTE_READONLY</style>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_GLEDIATORS_FLD" variable="ButtonGlediatorsFolder" member="yes">
+									<label>Select</label>
+									<handler function="OnButtonSelectFolderClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="SizerImages" member="no">
+					<label>Images</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer4" member="no">
+							<cols>3</cols>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL3" variable="ImagesFolder" member="yes">
+									<size>450,-1</size>
+									<style>wxTE_READONLY</style>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_IMAGES_FLD" variable="ButtonImagesFolder" member="yes">
+									<label>Select</label>
+									<handler function="OnButtonSelectFolderClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="SizerShaders" member="no">
+					<label>Shaders</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer5" member="no">
+							<cols>3</cols>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_SHADERS_FLD" variable="ShadersFolder" member="yes">
+									<size>450,-1</size>
+									<style>wxTE_READONLY</style>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_SHADERS_FLD" variable="ButtonShadersFolder" member="yes">
+									<label>Select</label>
+									<handler function="OnButtonSelectFolderClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="SizerVideos" member="no">
+					<label>Videos</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer6" member="no">
+							<cols>3</cols>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_VIDEOS_FLD" variable="VideosFolder" member="yes">
+									<size>450,-1</size>
+									<style>wxTE_READONLY</style>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON_VIDEOS_FLD" variable="ButtonVideosFolder" member="yes">
+									<label>Select</label>
+									<handler function="OnButtonSelectFolderClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer7" member="no">
+					<cols>2</cols>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON_OK" variable="ButtonOK" member="yes">
+							<label>OK</label>
+							<handler function="OnButtonOKClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON_CANCEL" variable="ButtonCancel" member="yes">
+							<label>Cancel</label>
+							<handler function="OnButtonCancelClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+		</object>
+	</object>
+</wxsmith>

--- a/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
+++ b/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
@@ -11,12 +11,11 @@
 			<object class="sizeritem">
 				<object class="wxSplitterWindow" name="ID_SPLITTERWINDOW1" variable="SplitterWindow1" member="yes">
 					<orientation>vertical</orientation>
-					<minsize>10,10</minsize>
 					<object class="wxPanel" name="ID_PANEL1" variable="Panel1" member="yes">
 						<object class="wxFlexGridSizer" variable="Sizer1" member="yes">
 							<cols>1</cols>
 							<growablecols>0</growablecols>
-							<growablerows>5</growablerows>
+							<growablerows>6</growablerows>
 							<object class="sizeritem">
 								<object class="wxFlexGridSizer" variable="Sizer_TimeAdjust" member="yes">
 									<cols>2</cols>
@@ -92,6 +91,33 @@
 									<object class="sizeritem">
 										<object class="wxStaticText" name="ID_STATICTEXT_BLEND_TYPE" variable="StaticText_Blend_Type" member="yes">
 											<label>Blend Mode</label>
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>1</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxFlexGridSizer" variable="FlexGridSizerImportMedia" member="yes">
+									<cols>3</cols>
+									<object class="sizeritem">
+										<object class="wxCheckBox" name="ID_CHECKBOX3" variable="CheckBoxImportMedia" member="yes">
+											<label>Import Media</label>
+											<checked>1</checked>
+											<handler function="OnCheckBoxImportMediaClick" entry="EVT_CHECKBOX" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON_IMPORT_OPTIONS" variable="ButtonImportOptions" member="yes">
+											<label>View/Change Options</label>
+											<handler function="OnButtonImportOptionsClick" entry="EVT_BUTTON" />
 										</object>
 										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 										<border>5</border>

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -577,6 +577,8 @@
 		<Unit filename="MSWStackWalk.h" />
 		<Unit filename="MatrixFaceDownloadDialog.cpp" />
 		<Unit filename="MatrixFaceDownloadDialog.h" />
+		<Unit filename="MediaImportOptionsDialog.cpp" />
+		<Unit filename="MediaImportOptionsDialog.h" />
 		<Unit filename="ModelChainDialog.cpp" />
 		<Unit filename="ModelChainDialog.h" />
 		<Unit filename="ModelDimmingCurveDialog.cpp" />
@@ -1329,6 +1331,7 @@
 		<Unit filename="wxsmith/MainSequencer.wxs" />
 		<Unit filename="wxsmith/MarqueePanel.wxs" />
 		<Unit filename="wxsmith/MatrixFaceDownloadDialog.wxs" />
+		<Unit filename="wxsmith/MediaImportOptionsDialog.wxs" />
 		<Unit filename="wxsmith/MeteorsPanel.wxs" />
 		<Unit filename="wxsmith/ModelChainDialog.wxs" />
 		<Unit filename="wxsmith/ModelDimmingCurveDialog.wxs" />
@@ -1623,6 +1626,7 @@
 					<wxDialog wxs="wxsmith/KeyBindingEditDialog.wxs" src="KeyBindingEditDialog.cpp" hdr="KeyBindingEditDialog.h" fwddecl="0" i18n="1" name="KeyBindingEditDialog" language="CPP" />
 					<wxDialog wxs="wxsmith/InAppPurchaseDialog.wxs" src="InAppPurchaseDialog.cpp" hdr="InAppPurchaseDialog.h" fwddecl="0" i18n="1" name="InAppPurchaseDialog" language="CPP" />
 					<wxDialog wxs="wxsmith/AboutDialog.wxs" src="AboutDialog.cpp" hdr="AboutDialog.h" fwddecl="1" i18n="1" name="AboutDialog" language="CPP" />
+					<wxDialog wxs="wxsmith/MediaImportOptionsDialog.wxs" src="MediaImportOptionsDialog.cpp" hdr="MediaImportOptionsDialog.h" fwddecl="0" i18n="1" name="MediaImportOptionsDialog" language="CPP" />
 				</resources>
 			</wxsmith>
 		</Extensions>

--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -34,6 +34,7 @@
 #include <wx/arrstr.h>
 #include <wx/filename.h>
 #include <list>
+#include "SequencePackage.h"
 
 class SequenceElements;
 class xLightsFrame;
@@ -363,18 +364,22 @@ class xLightsImportChannelMapDialog: public wxDialog
         bool InitImport(std::string checkboxText = "");
         void SetModelBlending(bool enabled);
         bool GetImportModelBlending();
+        void SetXsqPkg(SequencePackage* xsqPkg);
         xLightsImportTreeModel *_dataModel;
 
 		//(*Declarations(xLightsImportChannelMapDialog)
+		wxButton* ButtonImportOptions;
 		wxButton* Button_AutoMap;
 		wxButton* Button_Cancel;
 		wxButton* Button_Ok;
+		wxCheckBox* CheckBoxImportMedia;
 		wxCheckBox* CheckBox_EraseExistingEffects;
 		wxCheckBox* CheckBox_Import_Blend_Mode;
 		wxCheckBox* CheckBox_MapCCRStrand;
 		wxCheckListBox* TimingTrackListBox;
 		wxFlexGridSizer* FlexGridSizer11;
 		wxFlexGridSizer* FlexGridSizer1;
+		wxFlexGridSizer* FlexGridSizerImportMedia;
 		wxFlexGridSizer* FlexGridSizer_Blend_Mode;
 		wxFlexGridSizer* OldSizer;
 		wxFlexGridSizer* Sizer1;
@@ -410,6 +415,8 @@ protected:
 		static const long ID_CHECKBOX11;
 		static const long ID_CHECKBOX2;
 		static const long ID_STATICTEXT_BLEND_TYPE;
+		static const long ID_CHECKBOX3;
+		static const long ID_BUTTON_IMPORT_OPTIONS;
 		static const long ID_CHECKLISTBOX1;
 		static const long ID_BUTTON3;
 		static const long ID_BUTTON4;
@@ -441,11 +448,16 @@ protected:
 		void OnCheckBox_MapCCRStrandClick(wxCommandEvent& event);
 		void OnButton_AutoMapClick(wxCommandEvent& event);
 		void OnListCtrl_AvailableItemActivated(wxListEvent& event);
+		void OnButtonImportOptionsClick(wxCommandEvent& event);
+		void OnCheckBoxImportMediaClick(wxCommandEvent& event);
 		//*)
 
         void RightClickTimingTracks(wxContextMenuEvent& event);
         void OnPopupTimingTracks(wxCommandEvent& event);
         void OnDrop(wxCommandEvent& event);
+        void SetImportMediaTooltip();
+    
+        SequencePackage* _xsqPkg = nullptr;
 
 		DECLARE_EVENT_TABLE()
 };

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -79,6 +79,7 @@
 #include "outputs/ZCPP.h"
 #include "OutputModelManager.h"
 #include "models/Model.h"
+#include "SequencePackage.h"
 
 class wxDebugReport;
 
@@ -385,6 +386,8 @@ public:
 	void SetAudioControls();
     void ImportXLights(const wxFileName &filename);
     void ImportXLights(SequenceElements &se, const std::vector<Element *> &elements, const wxFileName &filename,
+        bool modelBlendig = false, bool showModelBlending = false, bool allowAllModels = false, bool clearSrc = false);
+    void ImportXLights(SequenceElements &se, const std::vector<Element *> &elements, SequencePackage &xsqPkg,
         bool modelBlendig = false, bool showModelBlending = false, bool allowAllModels = false, bool clearSrc = false);
     void ImportVix(const wxFileName &filename);
     void ImportHLS(const wxFileName &filename);


### PR DESCRIPTION
Import Effects from a Packaged Sequence.  Assets (images/videos/shaders) for mapped effects which exist in the package will be imported into the user's show directory if they don't already exist under a new subfolder called "ImportedAssets/<name of sequence>".   Also if a Faces Effect of type Matrix is mapped it will create the Face Definition on the target model. 

Existing .xsq/.xml only sequences work as they did before. 