### PR TITLE
adjust/scale size of preset preview with dialog

### DIFF
--- a/xLights/EffectTreeDialog.h
+++ b/xLights/EffectTreeDialog.h
@@ -109,7 +109,8 @@ class EffectTreeDialog : public wxDialog
         void AddEffect(wxXmlNode* ele, wxTreeItemId curGroupID);
         void AddGroup(wxXmlNode* ele, wxTreeItemId curGroupID);
         void EffectsFileDirty();
-
+        int GetOptimalPreviewSize();
+    
         wxTreeItemId findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool &startfound);
 
         void SearchForText();

--- a/xLights/TabConvert.cpp
+++ b/xLights/TabConvert.cpp
@@ -1149,7 +1149,7 @@ void xLightsFrame::CreatePresetIcons()
     }
 }
 
-#define PRESET_ICON_SIZE 32
+#define PRESET_ICON_SIZE 64
 void xLightsFrame::WriteGIFForPreset(const std::string& preset)
 {
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));

--- a/xLights/wxsmith/EffectTreeDialog.wxs
+++ b/xLights/wxsmith/EffectTreeDialog.wxs
@@ -2,8 +2,6 @@
 <wxsmith>
 	<object class="wxDialog" name="EffectTreeDialog">
 		<title>Effect Presets</title>
-		<size>700,500</size>
-		<minsize>300,450</minsize>
 		<id_arg>0</id_arg>
 		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
@@ -37,109 +35,117 @@
 						<option>1</option>
 					</object>
 					<object class="sizeritem">
-						<object class="wxBoxSizer" variable="BoxSizer1" member="no">
-							<orient>wxVERTICAL</orient>
+						<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
+							<cols>1</cols>
+							<rows>2</rows>
+							<growablecols>0</growablecols>
+							<growablerows>0</growablerows>
 							<object class="sizeritem">
-								<object class="wxStaticBitmap" name="ID_STATICBITMAP_GIF" variable="StaticBitmapGif" member="yes">
-									<size>64,64</size>
-									<minsize>64,64</minsize>
-								</object>
+								<object class="wxStaticBitmap" name="ID_STATICBITMAP_GIF" variable="StaticBitmapGif" member="yes" />
 								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
 								<border>5</border>
 								<option>1</option>
 							</object>
 							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON6" variable="btApply" member="yes">
-									<label>&amp;Apply Preset</label>
-									<tooltip>Apply the selected effect Preset.</tooltip>
-									<handler function="OnbtApplyClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON1" variable="btNewPreset" member="yes">
-									<label>&amp;New Preset</label>
-									<tooltip>Create New Effect Preset from current settings.</tooltip>
-									<handler function="OnbtNewPresetClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON2" variable="btUpdate" member="yes">
-									<label>&amp;Update Preset</label>
-									<tooltip>Update the selected effect preset to reflect current effect settings.</tooltip>
-									<handler function="OnbtUpdateClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON7" variable="btAddGroup" member="yes">
-									<label>Add &amp;Group</label>
-									<tooltip>Add effect preset group.</tooltip>
-									<handler function="OnbtAddGroupClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON3" variable="btRename" member="yes">
-									<label>&amp;Rename</label>
-									<tooltip>Rename currently selected effect preset.</tooltip>
-									<handler function="OnbtRenameClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON4" variable="btDelete" member="yes">
-									<label>&amp;Delete</label>
-									<tooltip>Delete curently selected effect preset.</tooltip>
-									<handler function="OnbtDeleteClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON5" variable="btExport" member="yes">
-									<label>Export</label>
-									<handler function="OnbtExportClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxButton" name="ID_BUTTON8" variable="btImport" member="yes">
-									<label>&amp;Import</label>
-									<tooltip>Import presets from another file.</tooltip>
-									<handler function="OnbtImportClick" entry="EVT_BUTTON" />
-								</object>
-								<flag>wxALL|wxEXPAND</flag>
-								<border>5</border>
-							</object>
-							<object class="sizeritem">
-								<object class="wxBoxSizer" variable="BoxSizer2" member="no">
+								<object class="wxBoxSizer" variable="BoxSizer1" member="no">
+									<orient>wxVERTICAL</orient>
 									<object class="sizeritem">
-										<object class="wxTextCtrl" name="ID_TEXTCTRL_SEARCH" variable="TextCtrl1" member="yes">
-											<handler function="OnTextCtrl1TextEnter" entry="EVT_TEXT_ENTER" />
+										<object class="wxButton" name="ID_BUTTON6" variable="btApply" member="yes">
+											<label>&amp;Apply Preset</label>
+											<tooltip>Apply the selected effect Preset.</tooltip>
+											<handler function="OnbtApplyClick" entry="EVT_BUTTON" />
 										</object>
-										<flag>wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-										<border>3</border>
-										<option>1</option>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
 									</object>
 									<object class="sizeritem">
-										<object class="wxButton" name="ID_BUTTON_SEARCH" variable="ETButton1" member="yes">
-											<label>Search</label>
-											<style>wxBU_EXACTFIT</style>
-											<handler function="OnETButton1Click" entry="EVT_BUTTON" />
+										<object class="wxButton" name="ID_BUTTON1" variable="btNewPreset" member="yes">
+											<label>&amp;New Preset</label>
+											<tooltip>Create New Effect Preset from current settings.</tooltip>
+											<handler function="OnbtNewPresetClick" entry="EVT_BUTTON" />
 										</object>
-										<flag>wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE</flag>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON2" variable="btUpdate" member="yes">
+											<label>&amp;Update Preset</label>
+											<tooltip>Update the selected effect preset to reflect current effect settings.</tooltip>
+											<handler function="OnbtUpdateClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON7" variable="btAddGroup" member="yes">
+											<label>Add &amp;Group</label>
+											<tooltip>Add effect preset group.</tooltip>
+											<handler function="OnbtAddGroupClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON3" variable="btRename" member="yes">
+											<label>&amp;Rename</label>
+											<tooltip>Rename currently selected effect preset.</tooltip>
+											<handler function="OnbtRenameClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON4" variable="btDelete" member="yes">
+											<label>&amp;Delete</label>
+											<tooltip>Delete curently selected effect preset.</tooltip>
+											<handler function="OnbtDeleteClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON5" variable="btExport" member="yes">
+											<label>Export</label>
+											<handler function="OnbtExportClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BUTTON8" variable="btImport" member="yes">
+											<label>&amp;Import</label>
+											<tooltip>Import presets from another file.</tooltip>
+											<handler function="OnbtImportClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxBoxSizer" variable="BoxSizer2" member="no">
+											<object class="sizeritem">
+												<object class="wxTextCtrl" name="ID_TEXTCTRL_SEARCH" variable="TextCtrl1" member="yes">
+													<handler function="OnTextCtrl1TextEnter" entry="EVT_TEXT_ENTER" />
+												</object>
+												<flag>wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+												<border>3</border>
+												<option>1</option>
+											</object>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_SEARCH" variable="ETButton1" member="yes">
+													<label>Search</label>
+													<style>wxBU_EXACTFIT</style>
+													<handler function="OnETButton1Click" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE</flag>
+											</object>
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
 									</object>
 								</object>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>
+								<option>1</option>
 							</object>
 						</object>
 						<flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
Auto adjust/scale size of Preset Preview as the dialog is resized with a MIN of 64x64 and MAX of 256x256.  I also bumped the actual size of the generated gif to 64x64 or it looked really washed out at sizes > 128x128.  If time to create the file / size of file at 64x64 is a concern here are some numbers I ran on some random presets I had, I also added a loading overlay so the user doesn't think something is stuck while it is generating.  These only need to get generated once so I don't think a few seconds to render is a big deal especially when the quality of the preview is better.  

The dialog size/position is also saved using wxPersistence (ends up in xLights preferences).

The numbers in debug mode....

layers | length (sec) | render (sec) | size (KB)
-- | -- | -- | --
4 | 16 | 4 | 1300
3 | 6.75 | 1.4 | 453
4 | 6 | 0.98 | 187
4 | 12 | 1.9 | 483
3 | 17.6 | 3.7 | 1300
5 | 6.75 | 1.2 | 165
3 | 10 | 2.9 | 772
7 | 20 | 11 | 767
6 | 11.25 | 3.5 | 897
3 | 6.7 | 1.5 | 350
8 | 5 | 0.8 | 161
  |   |   |  
  | AVG | 2.98 | 621

