### PR TITLE
fix memory/loop issue in effect preview generation

### DIFF
--- a/xLights/TabConvert.cpp
+++ b/xLights/TabConvert.cpp
@@ -1203,7 +1203,7 @@ void xLightsFrame::WriteGIFForPreset(const std::string& preset)
                 ModelManager mm(nullptr, this);
                 _presetModel = new MatrixModel(&n, mm, true);
 
-                Element* elem = _presetSequenceElements.AddElement(_presetModel->GetName(), "Model", true, false, false, false);
+                _presetSequenceElements.AddElement(_presetModel->GetName(), "Model", true, false, false, false);
             }
 
             size_t channels = PRESET_ICON_SIZE * PRESET_ICON_SIZE * 3;
@@ -1215,11 +1215,29 @@ void xLightsFrame::WriteGIFForPreset(const std::string& preset)
                 it->DeleteAllEffects();
             }
 
+            // I have seen a few presets where there are negative values for the effects row.
+            // We have to handle these and normalize the row value or we get in an infinite
+            // loop below. To do this we need the lowest row value to adjust below.
+            // example: preset had rows -4,-3,-2,-1,0,1,2,3,4 for the copy data
+            int startRow = 0;
             for (const auto& it : pd.Effects()) {
-                while (it->Row() >= elem->GetEffectLayerCount()) {
+                if (it->Row() < startRow) {
+                    startRow = it->Row();
+                }
+            }
+                        
+            for (const auto& it : pd.Effects()) {
+                // adjust before loop so we don't end up with a (-) row value but still maintaining effect
+                // layer order. If we get to the while loop with a neg int it gets converted to a really
+                // huge number when comparing to size_t returned from GetEffectLayerCount and we run out
+                // of memory really fast.
+                int row = it->Row() - startRow;
+
+                while (row >= elem->GetEffectLayerCount()) {
                     elem->AddEffectLayer();
                 }
-                EffectLayer* el = elem->GetEffectLayer(it->Row());
+                
+                EffectLayer* el = elem->GetEffectLayer(row);
                 el->AddEffect(0, it->EffectName(), it->Settings(), it->Palette(), it->StartTime() - pd.StartTime(), it->EndTime() - pd.StartTime(), false, false, true);
             }
 


### PR DESCRIPTION
This resolves #2496 

I found numerous instances in the preset files from the user who reported the issue where the effect presets had negative values for rows, such as a preset with 8 layers had values of -4,-3,-2,-1,0,1,2,3.  The negative row values where causing a near infinite loop in the loop on WriteGIFForPreset() in TabConvert.cpp which added the layers for the preview.  Negative int was converted to a HUGE number when being compared to size_t returned from GetEffectLayerCount() and memory didn't last long.

Not really sure where the (-) row values came from as I was unable to recreate trying to create a bunch of presets but they do exist and the code in EffectsGrid>>Paste() handles this situation on Applying the effect.  So figured the preview generation should as well as opposed to just ignoring the preview generation.