### PR TITLE
Add "Swap" transition

### DIFF
--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -202,6 +202,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_In_Transition_Type->Append(_("Blobs"));
 	Choice_In_Transition_Type->Append(_("Pinwheel"));
 	Choice_In_Transition_Type->Append(_("Star"));
+	Choice_In_Transition_Type->Append(_("Swap"));
 	FlexGridSizer10->Add(Choice_In_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText2 = new wxStaticText(Panel1, ID_STATICTEXT_Fadein, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadein"));
 	FlexGridSizer10->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
@@ -254,6 +255,7 @@ TimingPanel::TimingPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	Choice_Out_Transition_Type->Append(_("Blobs"));
 	Choice_Out_Transition_Type->Append(_("Pinwheel"));
 	Choice_Out_Transition_Type->Append(_("Star"));
+	Choice_Out_Transition_Type->Append(_("Swap"));
 	FlexGridSizer12->Add(Choice_Out_Transition_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText4 = new wxStaticText(Panel2, ID_STATICTEXT_Fadeout, _("Time (s)"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Fadeout"));
 	FlexGridSizer12->Add(StaticText4, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -485,7 +485,8 @@ namespace
       "Doorway",
       "Blobs",
       "Pinwheel",
-      "Star"
+      "Star",
+      "Swap"
    };
 
    const std::vector<wxString> transitions_noAdjust =
@@ -497,7 +498,8 @@ namespace
       "Dissolve",
       "Circular Swirl",
       "Zoom",
-      "Doorway"
+      "Doorway",
+      "Swap"
    };
 }
 

--- a/xLights/wxsmith/TimingPanel.wxs
+++ b/xLights/wxsmith/TimingPanel.wxs
@@ -240,6 +240,7 @@
 																			<item>Blobs</item>
 																			<item>Pinwheel</item>
 																			<item>Star</item>
+																			<item>Swap</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />
@@ -366,6 +367,7 @@
 																			<item>Blobs</item>
 																			<item>Pinwheel</item>
 																			<item>Star</item>
+																			<item>Swap</item>
 																		</content>
 																		<selection>0</selection>
 																		<handler function="OnTransitionTypeSelect" entry="EVT_CHOICE" />


### PR DESCRIPTION
This is another variation on some of the transitions added in 2020. Those make sense with a single layer but are really designed to transition between two layers. This one does a perspective swap between from the lower layer to the upper layer as an in transition... and the opposite as an out transition. 

Like many of these "newer" transitions, they make sense only for matrices or possibly some other high-density props. I would use this on my 128 x 96 matrix but at lower resolutions the detail would be lost.