### PR TITLE
Enable reverse on star transition

### DIFF
--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -485,7 +485,6 @@ namespace
       "Doorway",
       "Blobs",
       "Pinwheel",
-      "Star",
       "Swap"
    };
 


### PR DESCRIPTION
This makes it so star has all the same functionality as the "explode" transitions. The combination of in/out and forward/reverse are different though. I chose to keep it that way in order to not change the existing behavior for the star as an out transition. The differences are summarized here:

explode in forward - shape with effect grows
explode in reverse - black shape shrinks
explode out forward - black shape grows
explode out reverse - colored shape shrinks

star in forward - star with effect grows
star in reverse - black star shrinks
star out forward - star with effect shrinks
star out reverse - black star grows