### PR TITLE
bunch of fixes/improvements for eff preset dlg

### DIFF
--- a/xLights/wxsmith/EffectTreeDialog.wxs
+++ b/xLights/wxsmith/EffectTreeDialog.wxs
@@ -26,7 +26,6 @@
 							</items_text>
 							<minsize>80,-1d</minsize>
 							<handler function="OnTreeCtrl1BeginDrag" entry="EVT_TREE_BEGIN_DRAG" />
-							<handler function="OnTreeCtrl1EndDrag" entry="EVT_TREE_END_DRAG" />
 							<handler function="OnTreeCtrl1ItemActivated" entry="EVT_TREE_ITEM_ACTIVATED" />
 							<handler function="OnTreeCtrl1SelectionChanged" entry="EVT_TREE_SEL_CHANGED" />
 						</object>


### PR DESCRIPTION
Some fixes and improvements for effect tree dialog with the preset preview changes that are going to surface as issues.

- Fix Existing Names which would not render a preview based on prior loose naming restrictions.
- Don't allow duplicate names for presets or groups which would break / not show preview prior.
- Allow real DnD for rearranging.  Prior dnd didn't allow moving groups and dnd for effects would only append the effect to the end of the existing group, not where it was dropped.
- Don't allow duplicate presets/groups within a group
- Rename existing preset gifs on disk when they are rearranged to avoid having to regenerate the gif after dnd move
- Cleanup dangling gifs on disk which are no longer valid on show for the current preset tree structure
- Expand group when hovering with dnd over a group to allow positioning with drop under a group