### PR TITLE
Capability for Open Hardware T24 Boards

### DIFF
--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -191,4 +191,9 @@
             <fppSerialPort2>ttyS2</fppSerialPort2>
         </Variant>
     </Controller>
+    <Controller Name="BBB16">
+        <Variant Name="No Expansion" ID="BBB16" Base="FPP:FPPStringCape">
+            <MaxPixelPort>16</MaxPixelPort>
+            <MaxSerialPort>2</MaxSerialPort>
+        </Variant>
 </Vendor>

--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -196,4 +196,10 @@
             <MaxPixelPort>16</MaxPixelPort>
             <MaxSerialPort>2</MaxSerialPort>
         </Variant>
+        <Variant Name="Multi Expansion" ID="BBB16-MEXP" Base="FPP:FPPStringCape">
+            <MaxPixelPort>32</MaxPixelPort>
+            <MaxSerialPort>2</MaxSerialPort>
+            <fppSerialPort1>ttyS1</fppSerialPort1>
+            <fppSerialPort2>ttyS2</fppSerialPort2>
+        </Variant>
 </Vendor>


### PR DESCRIPTION
Add support to xLights for open source boards. They have EEPROM flashed so are working as expected in FPP and with these changes in my local xLights install.