### PR TITLE
fix mapping when dnd target not part of selections + fix GetNextTreeItem

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -468,6 +468,7 @@ protected:
         void RightClickTimingTracks(wxContextMenuEvent& event);
         void OnPopupTimingTracks(wxCommandEvent& event);
         void OnDrop(wxCommandEvent& event);
+        void HandleDropAvailable(wxDataViewItem dropTarget, std::string availableModelName);
         void SetImportMediaTooltip();
         void LoadAvailableGroups();
     


### PR DESCRIPTION
This fixes an issue introduced with mapping to multiple for dnd.  Prior if the drop target was not part of selections it would still map to the selections and not the drop target.

Also fixes GetNextTreeItem which hasn't worked for a while, the next available was never selected after any form of mapping, double click or dnd.  It seems that spacing in between tree items on all platforms has changed from 1 to 3.  This fix should accommodate any spacing between items when finding the next.