### PR TITLE
Update shaders.xml

### DIFF
--- a/download/shaders.xml
+++ b/download/shaders.xml
@@ -20,10 +20,10 @@
 	</shader>
 	<shader>	
 		<name>Acid Jelly</name>
-		<id>6035b422d4849b0013135cca</id>
-		<link>https://www.interactiveshaderformat.com/sketches/6035b422d4849b0013135cca</link>
-		<download>https://www.interactiveshaderformat.com/sketches/6035b422d4849b0013135cca/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/kbfif8mckfooicfuiqqn</image>
+		<id>607a0571df59c70014cdc666</id>
+		<link>https://www.interactiveshaderformat.com/sketches/607a0571df59c70014cdc666</link>
+		<download>https://www.interactiveshaderformat.com/sketches/607a0571df59c70014cdc666/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/zzpqgpbyilttvvp8jzxk</image>
 		<rating>3</rating>
 	</shader>
 	<shader>
@@ -138,6 +138,14 @@
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/eoqdmccljomjhl03dq7t</image>
 		<rating>2</rating>
 	</shader>
+	<shader>
+		<name>Blue Streaks_xL</name>
+		<id>60690eb1d4849b0013135d93</id>
+		<link>https://www.interactiveshaderformat.com/sketches/60690eb1d4849b0013135d93</link>
+		<download>https://www.interactiveshaderformat.com/sketches/60690eb1d4849b0013135d93/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/vld0iba4fnk275m1vqfi</image>
+		<rating>3</rating>
+	</shader>
 	<shader>	
 		<name>Boxinator</name>
 		<id>5e7a80457c113618206dee27</id>
@@ -163,19 +171,19 @@
 		<rating>4</rating>
 	</shader>
 	<shader>
-		<name>Caterpiller Wurm</name>
-		<id>1789</id>
-		<link>https://www.interactiveshaderformat.com/sketches/1789</link>
-		<download>https://www.interactiveshaderformat.com/sketches/1789/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/ycclnjz8tthav2mexzbf</image>
-		<rating>5</rating>
-	</shader>
-	<shader>
 		<name>Cell Mod</name>
 		<id>5e7a7fcf7c113618206de4c8</id>
 		<link>https://www.interactiveshaderformat.com/sketches/5e7a7fcf7c113618206de4c8</link>
 		<download>https://www.interactiveshaderformat.com/sketches/5e7a7fcf7c113618206de4c8/download</download>
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/nb4dvzssz3zlqnffzqkj</image>
+		<rating>3</rating>
+	</shader>
+	<shader>
+		<name>Christmas Tree_xL</name>
+		<id>60691c3edf59c70014cdc64d</id>
+		<link>https://www.interactiveshaderformat.com/sketches/60691c3edf59c70014cdc64d</link>
+		<download>https://www.interactiveshaderformat.com/sketches/60691c3edf59c70014cdc64d/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/rw8zw6t0iovx0tl9hkfz</image>
 		<rating>3</rating>
 	</shader>
 	<shader>
@@ -307,11 +315,11 @@
 		<rating>4</rating>
 	</shader>
 	<shader>
-		<name>Cyclotron 1</name>
-		<id>974</id>
-		<link>https://www.interactiveshaderformat.com/sketches/974</link>
-		<download>https://www.interactiveshaderformat.com/sketches/974/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/ttxz8hlfoc29eoqb6o59</image>
+		<name>Cyclotron1</name>
+		<id>5e7a7f947c113618206de06f</id>
+		<link>https://editor.isf.video/shaders/5e7a7f947c113618206de06f</link>
+		<download>https://www.interactiveshaderformat.com/sketches/5e7a7f947c113618206de06f/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/obctwogqwkxsbykxkfap</image>
 		<rating>4</rating>
 	</shader>
 	<shader>
@@ -332,10 +340,10 @@
 	</shader>
 	<shader>
 		<name>Electro Bands</name>
-		<id>4918</id>
-		<link>https://www.interactiveshaderformat.com/sketches/4818</link>
-		<download>https://www.interactiveshaderformat.com/sketches/4818/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/cotgql0bcs9fqkjqupzb</image>
+		<id>6074d376df59c70014cdc65b</id>
+		<link>https://editor.isf.video/shaders/6074d376df59c70014cdc65b</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6074d376df59c70014cdc65b/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/kcmorevldopaskrwrvqx</image>
 		<rating>2</rating>
 	</shader>
 	<shader>
@@ -409,8 +417,7 @@
 		<download>https://www.interactiveshaderformat.com/sketches/6076551adf59c70014cdc65e/download</download>
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/tqehsxxowa777c7aqthd</image>
 		<rating>3</rating>
-	</shader>
-	<shader>
+	</shader>	<shader>
 		<name>Fractilian Parabolic Circle Inversion</name>
 		<id>1883</id>
 		<link>https://www.interactiveshaderformat.com/sketches/1883</link>
@@ -588,10 +595,10 @@
 	</shader>
 	<shader>
 		<name>Kaleidolines</name>
-		<id>60690eb1d4849b0013135d93</id>
-		<link>https://editor.isf.video/shaders/60690eb1d4849b0013135d93</link>
-		<download>https://www.interactiveshaderformat.com/sketches/60690eb1d4849b0013135d93/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/wynclxfonrpjmrhmvsco</image>
+		<id>6075c507d4849b0013135dad</id>
+		<link>https://editor.isf.video/shaders/6075c507d4849b0013135dad</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6075c507d4849b0013135dad/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/g4ph5euqqqxqrfgcxd10</image>
 		<rating>3</rating>
 	</shader>
 	<shader>
@@ -679,7 +686,7 @@
 		<id>5e7a80477c113618206dee5d</id>
 		<link>https://www.interactiveshaderformat.com/sketches/5e7a80477c113618206dee5d</link>
 		<download>https://www.interactiveshaderformat.com/sketches/5e7a80477c113618206dee5d/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/rnubqcijehdsuoomsc9t</image>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/lxt7txknj6f8im7ywox0</image>
 		<rating>3</rating>
 	</shader>
 	<shader>
@@ -771,6 +778,14 @@
 		<rating>3</rating>
 	</shader>
 	<shader>
+		<name>Railroad Tracks_xL</name>
+		<id>606ce068df59c70014cdc64f</id>
+		<link>https://www.interactiveshaderformat.com/sketches/606ce068df59c70014cdc64f</link>
+		<download>https://www.interactiveshaderformat.com/sketches/606ce068df59c70014cdc64f/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/b6hez0dtrtawzjffouhs</image>
+		<rating>3</rating>
+	</shader>
+	<shader>
 		<name>Rainbow Ring Cubic Twist</name>
 		<id>5e7a801c7c113618206deae4</id>
 		<link>https://www.interactiveshaderformat.com/sketches/5e7a801c7c113618206deae4</link>
@@ -850,14 +865,6 @@
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/rya5m4wv2uwwmbwrwyti</image>
 		<rating>3</rating>
 	</shader>
-	<shader>
-		<name>Simply Nebulous</name>
-		<id>5e93bb5a3fd9680017950247</id>
-		<link>https://www.interactiveshaderformat.com/sketches/5e93bb5a3fd9680017950247</link>
-		<download>https://www.interactiveshaderformat.com/sketches/5e93bb5a3fd9680017950247/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/mfygsivjqr9yyn8w5lhl</image>
-		<rating>3</rating>
-	</shader>
 	<shader>	
 		<name>Sleepy Rays</name>
 		<id>5e7a80297c113618206debf2</id>
@@ -865,14 +872,6 @@
 		<download>https://www.interactiveshaderformat.com/sketches/5e7a80297c113618206debf2/download</download>
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/vfjm44qk7llcjnfmepdx</image>
 		<rating>3</rating>
-	</shader>
-	<shader>
-		<name>Soft Patterns</name>
-		<id>1425</id>
-		<link>https://www.interactiveshaderformat.com/sketches/1425</link>
-		<download>https://www.interactiveshaderformat.com/sketches/1425/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/dd1gb5zhf9ykwknf8gph</image>
-		<rating>5</rating>
 	</shader>
 	<shader>	
 		<name>SoftPatterns+</name>
@@ -898,14 +897,6 @@
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/yef3gn5zzmzfhsu4ul42</image>
 		<rating>5</rating>
 	</shader>
-	<shader>	
-		<name>SpaceIsThePlace</name>
-		<id>5f68ab74b1ed0d0014c000a0</id>
-		<link>https://www.interactiveshaderformat.com/sketches/5f68ab74b1ed0d0014c000a0</link>
-		<download>https://www.interactiveshaderformat.com/sketches/5f68ab74b1ed0d0014c000a0/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/ae2y6iqunlb172l50j4o</image>
-		<rating>3</rating>
-	</shader>
 	<shader>
 		<name>Spacels</name>
 		<id>799</id>
@@ -913,6 +904,14 @@
 		<download>https://www.interactiveshaderformat.com/sketches/799/download</download>
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/uf6tsj2c0xnjmkn3sm7n</image>
 		<rating>4</rating>
+	</shader>
+	<shader>
+		<name>Spider Nest_xL</name>
+		<id>6079494fdf59c70014cdc664</id>
+		<link>https://editor.isf.video/shaders/6079494fdf59c70014cdc664</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6079494fdf59c70014cdc664/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/hwu254cm3a3pzrqyvhgl</image>
+		<rating>3</rating>
 	</shader>
 	<shader>
 		<name>Spiral over Beams_xL</name>
@@ -924,10 +923,10 @@
 	</shader>
 	<shader>
 		<name>Spirograph Spectrum</name>
-		<id>3885</id>
-		<link>https://www.interactiveshaderformat.com/sketches/3855</link>
-		<download>https://www.interactiveshaderformat.com/sketches/3855/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/yamrarypzrwl7348vsxx</image>
+		<id>5e7a7fdf7c113618206de60a</id>
+		<link>https://www.interactiveshaderformat.com/sketches/5e7a7fdf7c113618206de60a</link>
+		<download>https://www.interactiveshaderformat.com/sketches/5e7a7fdf7c113618206de60a/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/fgvnyqf30upfplc8bawm</image>
 		<rating>5</rating>
 	</shader>
 	<shader>
@@ -972,10 +971,10 @@
 	</shader>
 	<shader>
 		<name>Tapestry Fract</name>
-		<id>384</id>
-		<link>https://www.interactiveshaderformat.com/sketches/348</link>
-		<download>https://www.interactiveshaderformat.com/sketches/348/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/dvjtkzij0hxnbnnhbz0l</image>
+		<id>5e7a7faf7c113618206de28a</id>
+		<link>https://www.interactiveshaderformat.com/sketches/5e7a7faf7c113618206de28a</link>
+		<download>https://www.interactiveshaderformat.com/sketches/5e7a7faf7c113618206de28a/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/lniuck0vfky9kbalpel3</image>
 		<rating>5</rating>
 	</shader>
 	<shader>
@@ -1012,10 +1011,10 @@
 	</shader>
 	<shader>
 		<name>Triangle Square Twist</name>
-		<id>3763</id>
-		<link>https://www.interactiveshaderformat.com/sketches/3763</link>
-		<download>https://www.interactiveshaderformat.com/sketches/3763/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/t5qc9mhxbj5mju62lnyt</image>
+		<id>6076bfd1df59c70014cdc65f</id>
+		<link>https://www.interactiveshaderformat.com/sketches/6076bfd1df59c70014cdc65f</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6076bfd1df59c70014cdc65f/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/tfu7qgvh18ckk7km2pub</image>
 		<rating>5</rating>
 	</shader>
 	<shader>
@@ -1060,10 +1059,10 @@
 	</shader>
 	<shader>
 		<name>Twisty Coloured Bars</name>
-		<id>3782</id>
-		<link>https://www.interactiveshaderformat.com/sketches/3782</link>
-		<download>https://www.interactiveshaderformat.com/sketches/3782/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_300,w_300/peu7soarmwxipzutduma</image>
+		<id>5e7a80057c113618206de912</id>
+		<link>https://www.interactiveshaderformat.com/sketches/5e7a80057c113618206de912</link>
+		<download>https://www.interactiveshaderformat.com/sketches/5e7a80057c113618206de912/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/peu7soarmwxipzutduma</image>
 		<rating>5</rating>
 	</shader>
 	<shader>
@@ -1084,10 +1083,10 @@
 	</shader>
 	<shader>
 		<name>Ultimate Spiral</name>
-		<id>60691c3edf59c70014cdc64d</id>
-		<link>https://editor.isf.video/shaders/60691c3edf59c70014cdc64d</link>
-		<download>https://www.interactiveshaderformat.com/sketches/60691c3edf59c70014cdc64d/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/dcdrverytyjhv1qg6qdl</image>
+		<id>6075c5b8d4849b0013135dae</id>
+		<link>https://editor.isf.video/shaders/6075c5b8d4849b0013135dae</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6075c5b8d4849b0013135dae/download</download>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/uw5slsjqnh5ebbidi9pn</image>
 		<rating>3</rating>
 	</shader>
 	<shader>
@@ -1175,7 +1174,7 @@
 		<id>604b9a6cd4849b0013135d3f</id>
 		<link>https://editor.isf.video/shaders/604b9a6cd4849b0013135d3f</link>
 		<download>https://www.interactiveshaderformat.com/sketches/604b9a6cd4849b0013135d3f/download</download>
-		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/esrv5qth1pwmkouxye8g</image>
+		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/am7l0pymesh98rotldj2</image>
 		<rating>3</rating>
 	</shader>
 	<shader>


### PR DESCRIPTION
Summary of changes:
Changed - Acid Jelly (updated links to xLights  repository at ISF)
Added   - Blue Streaks_xL
Removed - Caterpiller Wurm (uses ISF features not supported by xLights)
Added   - Christmas Tree_xL
Changed - Cylcotron1 (updated links to a working version)
Changed - Electro Bands (repaired, links updated)
Changed - Kaleidolines (updated links to xLights  repository at ISF)
Changed - MatrixRain (updated image link)
Added   - Radial Replicate_xL (for xLights 2021.12+ only)
Added   - Railroad Tracks_xL (Polar Express anyone?)
Removed - Simply Nebulous (No shader on ISF exists with this name)
Removed - Soft Patterns (identical to "Soft Patterns+" same code, one is copy on ISF)
Removed - SpaceIsThePlace (identical to "SpaceIs")
Added   - Spider Nest_xL (And a Creepy Halloween to you!)
Changed - Spirograph Spectrum  (updated links to an existing version)
Changed - Tapestry Fract (updated links to an existing version)
Changed - Triangle Square Twist (shader modified to compile in xLights; links updated)
Changed - Twisty Coloured Bars (updated links to an existing version)
Changed - Ultimate Spiral (repaired shader; links updated)