### PR TITLE
Update ShaderEffect.cpp

### DIFF
--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -1364,6 +1364,7 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
                 maxPt,
                 defPt
             ));
+ 		     _hasPoint2D = true ;
         }
         else if (type == "image")
         {


### PR DESCRIPTION
Uses the presence of 'point2D' in the JSON dict to suppress duplication of sliders on the Shader Effect Panel.  Needs companion change to ShaderEffect.h