### PR TITLE
Update ShaderEffect.cpp

### DIFF
--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -1278,6 +1278,13 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
                 (double)(inputs[i].HasMember("MAX") ? wxAtof(SafeFloat(inputs[i]["MAX"].AsString())) : 1.0),
                 (double)(inputs[i].HasMember("DEFAULT") ? wxAtof(SafeFloat(inputs[i]["DEFAULT"].AsString())) : 0.0)
             ));
+
+						// check whether the shader has an input for zoom
+						_tmpStr = inputs[i]["NAME"].AsString();
+						for (int j = 0; j < _tmpStr.length(); j++) {
+							_tmpStr[j] = tolower(_tmpStr[j]);
+						}
+						if (_tmpStr.find("zoom") > (_tmpStr.length() - 4)) _hasZoom = true;
         }
         else if (type == "long")
         {
@@ -1364,7 +1371,8 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
                 maxPt,
                 defPt
             ));
-        }
+ 		     _hasPoint2D = true ;
+				}
         else if (type == "image")
         {
             // ignore these as we will use the existing buffer content
@@ -1565,7 +1573,7 @@ ShaderConfig::ShaderConfig(const wxString& filename, const wxString& code, const
     _hasRendersize = Contains(shaderCode, "RENDERSIZE");
     _hasTime = Contains(shaderCode, "TIME");
     _hasCoord = Contains(shaderCode, "xl_FragCoord");
-
+		
     _code = "#version 330\n\n";
     size_t idx = shaderCode.find("#extension");
     if (idx != std::string::npos) {


### PR DESCRIPTION
A better solution, no duplication of offset control functionality, and zoom is accounted for separately.  Shaders implementing offset, but not zoom will have this added.  Caveat: the detection looks for ‘zoom ‘ in the name of the input.  If it’s called something else, the control functionality will be duplicated.  We may wish to add ‘scale,’ to the detector.