### PR TITLE
Update ShaderPanel.cpp

### DIFF
--- a/xLights/effects/ShaderPanel.cpp
+++ b/xLights/effects/ShaderPanel.cpp
@@ -270,20 +270,43 @@ bool ShaderPanel::BuildUI(const wxString& filename, SequenceElements* sequenceEl
         }
 
         if (_shaderConfig->HasCoord()) {
+          if (_shaderConfig->HasPoint2D()) {
+             // shader already implements offset controls
+             StaticText_Shader_Offset_X->Hide();
+             StaticText_Shader_Offset_Y->Hide();
+             TextCtrl_Shader_Offset_X->Hide();
+             TextCtrl_Shader_Offset_Y->Hide();
+             Slider_Shader_Offset_X->Hide();
+             Slider_Shader_Offset_Y->Hide();
+             BitmapButton_Shader_Offset_X->Hide();
+             BitmapButton_Shader_Offset_Y->Hide();
+          }
+          else {
             StaticText_Shader_Offset_X->Show();
             StaticText_Shader_Offset_Y->Show();
-            StaticText_Shader_Zoom->Show();
             TextCtrl_Shader_Offset_X->Show();
             TextCtrl_Shader_Offset_Y->Show();
-            TextCtrl_Shader_Zoom->Show();
             Slider_Shader_Offset_X->Show();
             Slider_Shader_Offset_Y->Show();
-            Slider_Shader_Zoom->Show();
             BitmapButton_Shader_Offset_X->Show();
             BitmapButton_Shader_Offset_Y->Show();
+          }
+          if (_shaderConfig->HasZoom()) {
+            // shader already implements a zoom control
+            StaticText_Shader_Zoom->Hide();
+            TextCtrl_Shader_Zoom->Hide();
+            Slider_Shader_Zoom->Hide();
+            BitmapButton_Shader_Zoom->Hide();
+          }
+          else {
+            StaticText_Shader_Zoom->Show();
+            TextCtrl_Shader_Zoom->Show();
+            Slider_Shader_Zoom->Show();
             BitmapButton_Shader_Zoom->Show();
+          }
         }
         else {
+            // No coordinates used in the shader - don't add them
             StaticText_Shader_Offset_X->Hide();
             StaticText_Shader_Offset_Y->Hide();
             StaticText_Shader_Zoom->Hide();


### PR DESCRIPTION
A better solution, no duplication of offset control functionality, and zoom is accounted for separately.  Shaders implementing offset, but not zoom will have this added.  Caveat: the detection looks for ‘zoom ‘ in the name of the input.  If it’s called something else, the control functionality will be duplicated.  We may wish to add ‘scale,’ to the detector.