### PR TITLE
Fpp Connect Button Added to Controllers Page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- enh (bill) Add FPP Connect button to Controllers page
    -- enh (bill) Added/change a few tool tips to help new users 
    -- enh (scott) Added the Ability to Import Views from RGBEffects File and Sequence Files
 2021.19 June 16, 2021

--- a/xLights/wxsmith/xLightsframe.wxs
+++ b/xLights/wxsmith/xLightsframe.wxs
@@ -730,6 +730,20 @@
 															<border>3</border>
 															<option>1</option>
 														</object>
+														<object class="spacer">
+															<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+															<border>5</border>
+															<option>1</option>
+														</object>
+														<object class="sizeritem">
+															<object class="wxButton" name="ID_BUTTON12" variable="ButtonFPPConnect" member="yes">
+																<label>FPP Connect</label>
+																<handler function="OnMenuItem_FPP_ConnectSelected" entry="EVT_BUTTON" />
+															</object>
+															<flag>wxALL|wxEXPAND</flag>
+															<border>3</border>
+															<option>1</option>
+														</object>
 													</object>
 													<flag>wxALIGN_TOP|wxALIGN_CENTER_HORIZONTAL</flag>
 													<option>1</option>

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -201,6 +201,7 @@ const long xLightsFrame::ID_BUTTON9 = wxNewId();
 const long xLightsFrame::ID_BUTTON6 = wxNewId();
 const long xLightsFrame::ID_BUTTON10 = wxNewId();
 const long xLightsFrame::ID_BUTTON5 = wxNewId();
+const long xLightsFrame::ID_BUTTON12 = wxNewId();
 const long xLightsFrame::ID_BITMAPBUTTON1 = wxNewId();
 const long xLightsFrame::ID_BITMAPBUTTON2 = wxNewId();
 const long xLightsFrame::ID_PANEL2 = wxNewId();
@@ -677,6 +678,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, wxWindowID id) : _sequenceElements(
     BoxSizer1->Add(ButtonAddControllerNull, 1, wxALL|wxEXPAND, 3);
     ButtonDiscover = new wxButton(PanelSetup, ID_BUTTON5, _("Discover"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON5"));
     BoxSizer1->Add(ButtonDiscover, 1, wxALL|wxEXPAND, 3);
+    BoxSizer1->Add(0,0,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonFPPConnect = new wxButton(PanelSetup, ID_BUTTON12, _("FPP Connect"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON12"));
+    BoxSizer1->Add(ButtonFPPConnect, 1, wxALL|wxEXPAND, 3);
     FlexGridSizerNetworks->Add(BoxSizer1, 1, wxALIGN_TOP|wxALIGN_CENTER_HORIZONTAL, 0);
     FlexGridSizer9 = new wxFlexGridSizer(0, 1, 0, 0);
     BitmapButtonMoveNetworkUp = new wxBitmapButton(PanelSetup, ID_BITMAPBUTTON1, wxArtProvider::GetBitmap(wxART_MAKE_ART_ID_FROM_STR(_T("wxART_GO_UP")),wxART_BUTTON), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_BITMAPBUTTON1"));
@@ -1076,6 +1080,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, wxWindowID id) : _sequenceElements(
     Connect(ID_BUTTON6,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonAddControllerEthernetClick);
     Connect(ID_BUTTON10,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonAddControllerNullClick);
     Connect(ID_BUTTON5,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonDiscoverClick);
+    Connect(ID_BUTTON12,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnMenuItem_FPP_ConnectSelected);
     Connect(ID_BITMAPBUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonNetworkMoveUpClick);
     Connect(ID_BITMAPBUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonNetworkMoveDownClick);
     Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&xLightsFrame::OnButtonVisualiseClick);

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -655,6 +655,7 @@ public:
     static const long ID_BUTTON6;
     static const long ID_BUTTON10;
     static const long ID_BUTTON5;
+    static const long ID_BUTTON12;
     static const long ID_BITMAPBUTTON1;
     static const long ID_BITMAPBUTTON2;
     static const long ID_PANEL2;
@@ -802,6 +803,7 @@ public:
     wxButton* ButtonAddControllerSerial;
     wxButton* ButtonControllerDelete;
     wxButton* ButtonDiscover;
+    wxButton* ButtonFPPConnect;
     wxButton* ButtonOpen;
     wxButton* ButtonSaveSetup;
     wxButton* ButtonUploadInput;


### PR DESCRIPTION
Button to open fpp connect on the controllers tab , one button height spaced below the Discover button.

My original thought was to put it after upload output but it isn't really controller specific like the rest of the functions there are, but goes well with the flow of Upload inputs, Uploads outputs, fpp connect.

