### PR TITLE
Reduce number of shader re-compiles

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2021.26
+   -- bug (kevin) Reduce number of shader recompiles to potentially reduce crashing
    -- enh (dkulp) Add support for "Virtual Matrix" and "LED Panel Matrix" protocols for Models
    -- enh (dkulp) Add Virtual Matrix and LED Panel Matrix ports to Visualizer for controllers that support them
    -- enh (dkulp) Mark the various Pi based hats as being able to support Virtual Matrices

--- a/xLights/DrawGLUtils31.cpp
+++ b/xLights/DrawGLUtils31.cpp
@@ -55,6 +55,7 @@ PFNGLDETACHSHADERPROC glDetachShader;
 PFNGLDELETESHADERPROC glDeleteShader;
 PFNGLLINKPROGRAMPROC glLinkProgram;
 PFNGLDELETEPROGRAMPROC glDeleteProgram;
+PFNGLISPROGRAMPROC glIsProgram;
 PFNGLGETUNIFORMLOCATIONPROC glGetUniformLocation;
 PFNGLUNIFORM1IPROC glUniform1i;
 PFNGLUNIFORM4FPROC glUniform4f;
@@ -116,6 +117,7 @@ bool DrawGLUtils::LoadGLFunctions() {
     glDeleteShader = (PFNGLDELETESHADERPROC)wglGetProcAddress("glDeleteShader");
     glLinkProgram = (PFNGLLINKPROGRAMPROC)wglGetProcAddress("glLinkProgram");
     glDeleteProgram = (PFNGLDELETEPROGRAMPROC)wglGetProcAddress("glDeleteProgram");
+    glIsProgram = (PFNGLISPROGRAMPROC)wglGetProcAddress("glIsProgram");
     glGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)wglGetProcAddress("glGetUniformLocation");
     glUniform1i = (PFNGLUNIFORM1IPROC)wglGetProcAddress("glUniform1i");
     glUniform4f = (PFNGLUNIFORM4FPROC)wglGetProcAddress("glUniform4f");


### PR DESCRIPTION
Shaders seem to be re-compiled quite often... pretty much anytime a shader effect is clicked. Ordinarily this wouldn't be a problem other than slowing things down a bit. But frequent shader re-compilation seems to lead to a crash with some GPUs, so this is an attempt at minimizing the number of re-compiles. There is probably a nicer way to do it with ShaderRenderCache but first I want to see if this actually does reduce the number of crashes.