### PR TITLE
Reduce shader effect overhead

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/smeighan/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+   -- bug (kevin) Hopefully reduce some crashing on Windows associated with shader effect
 2021.28 September 7, 2021
    -- enh (keith) Add a check sequence warning about data layers which are uncommonly used
    -- enh (keith) Have face effect use the first assigned face on a model if the effect is calling for a face that is not on the model

--- a/xLights/DrawGLUtils31.cpp
+++ b/xLights/DrawGLUtils31.cpp
@@ -55,6 +55,7 @@ PFNGLDETACHSHADERPROC glDetachShader;
 PFNGLDELETESHADERPROC glDeleteShader;
 PFNGLLINKPROGRAMPROC glLinkProgram;
 PFNGLDELETEPROGRAMPROC glDeleteProgram;
+PFNGLISPROGRAMPROC glIsProgram;
 PFNGLGETUNIFORMLOCATIONPROC glGetUniformLocation;
 PFNGLUNIFORM1IPROC glUniform1i;
 PFNGLUNIFORM4FPROC glUniform4f;
@@ -116,6 +117,7 @@ bool DrawGLUtils::LoadGLFunctions() {
     glDeleteShader = (PFNGLDELETESHADERPROC)wglGetProcAddress("glDeleteShader");
     glLinkProgram = (PFNGLLINKPROGRAMPROC)wglGetProcAddress("glLinkProgram");
     glDeleteProgram = (PFNGLDELETEPROGRAMPROC)wglGetProcAddress("glDeleteProgram");
+    glIsProgram = (PFNGLISPROGRAMPROC)wglGetProcAddress("glIsProgram");
     glGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)wglGetProcAddress("glGetUniformLocation");
     glUniform1i = (PFNGLUNIFORM1IPROC)wglGetProcAddress("glUniform1i");
     glUniform4f = (PFNGLUNIFORM4FPROC)wglGetProcAddress("glUniform4f");

--- a/xLights/effects/ShaderEffect.h
+++ b/xLights/effects/ShaderEffect.h
@@ -219,7 +219,7 @@ protected:
         bool& s_shadersInit,
         unsigned& s_vertexArrayId, unsigned& s_vertexBufferId, unsigned& s_rbId, unsigned& s_fbId,
         unsigned& s_rbTex, int& s_rbWidth, int& s_rbHeight);
-    void recompileFromShaderConfig(ShaderConfig* cfg, unsigned& s_programId);
+    unsigned programIdForShaderCode(ShaderConfig* cfg);
 
     struct VertexTex
     {


### PR DESCRIPTION
I've heard of some crashing when adjusting shader effect parameters or even just clicking on shader effects on a track. I haven't been able to reproduce this but this will hopefully help by cutting down on the number of OpenGL things we do a lot for shader effects. More specifically:
* GL_CONTEXT_POOL is Windows-specific and was added when we were trying to get multi-threaded rendering of shader effects working on Windows. It looks like we have been reverted back to main-thread-only rendering for a long time now, so we don't need to be creating and destroying GL contexts in that case. I left the code for it though, in case we want to revisit multi-threaded rendering on Windows at some point.
* Other than the one-time "make the shader xLights compatible" changes, we don't change fragment-shader code, so we don't need to recompile it for each ShaderRenderCache instance.