### PR TITLE
Add virtual matrix configuration to Pi Hat.

### DIFF
--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -127,6 +127,7 @@
 			<MaxSerialPort>1</MaxSerialPort>
 			<MaxSerialPortChannels>512</MaxSerialPortChannels>
 			<MaxPixelPortChannels>4200</MaxPixelPortChannels>
+			<SupportsVirtualMatrix/>
 			<SupportsVirtualStrings/>
 			<SupportsAutoLayout/>
             <SupportsPixelPortEndNullPixels/>


### PR DESCRIPTION
This PR enables configuring a Pi Hat controller to also enable a virtual matrix.