### PR TITLE
Set curl postfieldsize when not uploading via chunked transfer encoding.

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -759,6 +759,7 @@ bool FPP::uploadFile(const std::string &filename, const std::string &file) {
     wxFile fileobj(fullFileName);
     if (!usingJqUpload) {
         std::string cl = "Content-Length: " + std::to_string(fileobj.Length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, fileobj.Length());
         chunk = curl_slist_append(chunk, cl.c_str());
     }
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);


### PR DESCRIPTION
Sets POSTFIELDSIZE for libcurl when chunked transfer encoding isn't being used. Fixes corrupt uploads to ESPixelStick from macOS Monterey and possibly newer Linux releases - https://github.com/curl/curl/pull/4138