### PR TITLE
controllers:  Add support for BBB16v2

### DIFF
--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -294,7 +294,7 @@
             <fppSerialPort1>ttyS1</fppSerialPort1>
             <fppSerialPort2>ttyS2</fppSerialPort2>
         </Variant>
-        <Variant Name="w/Expansion" ID="BBB16v2" Base="FPP:FPPStringCapeTTYs">
+        <Variant Name="w/Expansion" ID="BBB16v2-EXP" Base="FPP:FPPStringCapeTTYs">
             <MaxPixelPort>36</MaxPixelPort>
             <MaxSerialPort>2</MaxSerialPort>
             <fpp>1</fpp>

--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -285,7 +285,24 @@
             <fppSerialPort2>ttyS2</fppSerialPort2>
         </Variant>
     </Controller>
-    <Controller Name="BBB16-Flex">
+    <Controller Name="BBB16v2">
+        <Variant Name="No Expansion" ID="BBB16v2" Base="FPP:FPPStringCapeTTYs">
+            <MaxPixelPort>20</MaxPixelPort>
+            <MaxSerialPort>2</MaxSerialPort>
+            <fpp>1</fpp>
+            <fpp1>21,-1</fpp1>
+            <fppSerialPort1>ttyS1</fppSerialPort1>
+            <fppSerialPort2>ttyS2</fppSerialPort2>
+        </Variant>
+        <Variant Name="w/Expansion" ID="BBB16v2" Base="FPP:FPPStringCapeTTYs">
+            <MaxPixelPort>36</MaxPixelPort>
+            <MaxSerialPort>2</MaxSerialPort>
+            <fpp>1</fpp>
+            <fpp1>21,16</fpp1>
+            <fppSerialPort1>ttyS1</fppSerialPort1>
+            <fppSerialPort2>ttyS2</fppSerialPort2>
+        </Variant>
+    </Controller>    <Controller Name="BBB16-Flex">
         <Variant Name="" ID="BBB16-Flex" Base="FPP:FPPStringCapeTTYs">
             <MaxPixelPort>48</MaxPixelPort>
             <MaxSerialPort>2</MaxSerialPort>

--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -302,7 +302,8 @@
             <fppSerialPort1>ttyS1</fppSerialPort1>
             <fppSerialPort2>ttyS2</fppSerialPort2>
         </Variant>
-    </Controller>    <Controller Name="BBB16-Flex">
+    </Controller>
+    <Controller Name="BBB16-Flex">
         <Variant Name="" ID="BBB16-Flex" Base="FPP:FPPStringCapeTTYs">
             <MaxPixelPort>48</MaxPixelPort>
             <MaxSerialPort>2</MaxSerialPort>


### PR DESCRIPTION
Scott Hanson's BBB16v2 has an extra 4 ports available using the diff port.
Ports 17 to 20 do not appear in the xLights visualizer so it is
not possible to assign a model to those ports.

This commit adds a controller definition
that includes the additional ports available
using the diff port.