### PR TITLE
controller:  add support for default gamma

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -2194,6 +2194,8 @@ bool FPP::UploadPixelOutputs(ModelManager* allmodels,
         defaultBrightness = 100;
     }
 
+    float defaultGamma = controller->GetDefaultGammaUnderFullControl();
+
     wxString pinout = "1.x";
     std::map<std::string, wxJSONValue> origStrings;
     wxString origType = "";
@@ -2294,7 +2296,7 @@ bool FPP::UploadPixelOutputs(ModelManager* allmodels,
                     vs["endNulls"] = 0;
                     vs["zigZag"] = 0; // If we zigzag in xLights, we don't do it in the controller, if we need it in the controller, we don't know about it here
                     vs["brightness"] = defaultBrightness;
-                    vs["gamma"] = wxString("1.0");
+                    vs["gamma"] = wxString::Format("%.1f", defaultGamma);
                 }
                 if (pvs->_reverseSet) {
                     vs["reverse"] = pvs->_reverse == "Reverse" ? 1 : 0;
@@ -2370,7 +2372,7 @@ bool FPP::UploadPixelOutputs(ModelManager* allmodels,
             vs["endNulls"] = 0;
             vs["zigZag"] = 0;
             vs["brightness"] = defaultBrightness;
-            vs["gamma"] = wxString("1.0");
+            vs["gamma"] = wxString::Format("%.1f", defaultGamma);
             stringData["outputs"][x]["virtualStrings"].Append(vs);
         }
         if ((x & 0x3) == 0) {

--- a/xLights/outputs/Controller.cpp
+++ b/xLights/outputs/Controller.cpp
@@ -497,6 +497,12 @@ void Controller::AddProperties(wxPropertyGrid* propertyGrid, ModelManager* model
             p->SetAttribute("Max", 100);
             p->SetEditor("SpinCtrl");
             p->SetHelpString("This option will set the brightness of all ports to this value unless specifically overriden by a model.");
+
+            p = propertyGrid->Append(new wxFloatProperty("Default Port Gamma", "DefaultGammaUnderFullxLightsControl", GetDefaultGammaUnderFullControl()));
+            p->SetAttribute("Min", 0.1F);
+            p->SetAttribute("Max", 5.0F);
+            p->SetEditor("SpinCtrlDouble");
+            p->SetHelpString("This option will set the Gamma of all ports to this value unless specifically overriden by a model.");
         }
     }
 
@@ -632,6 +638,11 @@ bool Controller::HandlePropertyEvent(wxPropertyGridEvent& event, OutputModelMana
     else if (name == "DefaultBrightnessUnderFullxLightsControl") {
         SetDefaultBrightnessUnderFullControl(event.GetValue().GetLong());
         outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "Controller::HandlePropertyEvent::DefaultBrightnessUnderFullxLightsControl");
+        return true;
+    }
+    else if (name == "DefaultGammaUnderFullxLightsControl") {
+        SetDefaultGammaUnderFullControl(event.GetValue().GetDouble());
+        outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "Controller::HandlePropertyEvent::DefaultGammaUnderFullxLightsControl");
         return true;
     }
     else if (name == "Vendor") {

--- a/xLights/outputs/Controller.h
+++ b/xLights/outputs/Controller.h
@@ -55,6 +55,7 @@ protected:
     bool _autoSize = true;                    // controller flexes the number of outputs to meet the needs of xLights
     bool _fullxLightsControl = true;          // when true on upload xLights wipes all other config
     int _defaultBrightnessUnderFullControl = 100; // brightness to use when controllers dont have anything on a port
+    float _defaultGammaUnderFullControl = 1.0F; // Gamma to use when controllers dont have anything on a port
     std::list<Output*> _outputs;               // the outputs on the controller
     ACTIVESTATE _active = ACTIVESTATE::ACTIVE; // output to controller is active
 
@@ -125,6 +126,9 @@ public:
 
     void SetDefaultBrightnessUnderFullControl(int brightness) { if (_defaultBrightnessUnderFullControl != brightness) { _defaultBrightnessUnderFullControl = brightness; _dirty = true; } }
     int GetDefaultBrightnessUnderFullControl() const { return _defaultBrightnessUnderFullControl; }
+
+    void SetDefaultGammaUnderFullControl(float Gamma) { if (_defaultGammaUnderFullControl != Gamma) { _defaultGammaUnderFullControl = Gamma; _dirty = true; } }
+    float GetDefaultGammaUnderFullControl() const { return _defaultGammaUnderFullControl; }
 
     bool IsEnabled() const { return std::any_of(begin(_outputs), end(_outputs), [](Output* o) { return o->IsEnabled(); }); }
     void Enable(bool enable) { for (auto& it : _outputs) { it->Enable(enable); } }


### PR DESCRIPTION
This commit adds a Default Port Gamma setting to the controller
settings dialog of the controller tab.

The setting works similar to the Default Port Brightness.

Address issue #3018 

Note, I do not have a Falcon controller and so I am unable to test the changes against the Falcon controller specific code.  Thus, this commit only supports FPP controllers at the moment.