### PR TITLE
3048 - xSchedule - cloning a step makes it loop oddly until restart

### DIFF
--- a/xSchedule/PlayList/PlayListDialog.cpp
+++ b/xSchedule/PlayList/PlayListDialog.cpp
@@ -889,8 +889,7 @@ void PlayListDialog::Clone()
             PlayListStep* step = (PlayListStep*)((MyTreeItemData*)TreeCtrl_PlayList->GetItemData(treeitem))->GetData();
             if (step != nullptr)
             {
-                PlayListStep* pls = new PlayListStep(*step);
-                pls->SetDirty();
+                PlayListStep* pls = step->Clone();
                 _playlist->AddStep(pls, GetPos(treeitem) + 1);
                 PopulateTree(_playlist, step, nullptr);
             }
@@ -906,8 +905,7 @@ void PlayListDialog::Clone()
                     PlayListStep* step = (PlayListStep*)((MyTreeItemData*)TreeCtrl_PlayList->GetItemData(treeitemStep))->GetData();
                     if (step != nullptr)
                     {
-                        PlayListItem* newItem = pli->Copy();
-                        newItem->SetDirty();
+                        PlayListItem* newItem = pli->Clone();
                         step->AddItem(newItem);
                         PopulateTree(_playlist, step, pli);
                     }

--- a/xSchedule/PlayList/PlayListItem.cpp
+++ b/xSchedule/PlayList/PlayListItem.cpp
@@ -119,11 +119,14 @@ std::string PlayListItem::GetNameNoTime() const
     return "<unnamed>";
 }
 
-void PlayListItem::Copy(PlayListItem* to) const
+void PlayListItem::Copy(PlayListItem* to, const bool isClone) const
 {
-    to->_id = _id;
-    to->_lastSavedChangeCount = _lastSavedChangeCount;
-    to->_changeCount = _changeCount;
+    if (!isClone) {
+        // During a clone the following members are not copied because we want the values set in the constructor.
+        to->_id = _id;
+        to->_lastSavedChangeCount = _lastSavedChangeCount;
+        to->_changeCount = _changeCount;
+    }
     to->_delay = _delay;
     to->_frames = _frames;
     to->_msPerFrame = _msPerFrame;
@@ -133,6 +136,11 @@ void PlayListItem::Copy(PlayListItem* to) const
     to->_restOfStep = _restOfStep;
     to->_stepLengthMS = _stepLengthMS;
     to->_type = _type;
+}
+
+PlayListItem* PlayListItem::Clone() const
+{
+    return Copy(true);
 }
 
 bool PlayListItem::IsInSlaveMode() const

--- a/xSchedule/PlayList/PlayListItem.h
+++ b/xSchedule/PlayList/PlayListItem.h
@@ -40,7 +40,7 @@ protected:
     #pragma endregion Member Variables
 
     void Save(wxXmlNode* node);
-    void Copy(PlayListItem* to) const;
+    void Copy(PlayListItem* to, const bool isClone) const;
     bool IsInSlaveMode() const;
     bool IsSuppressAudioOnSlaves() const;
     std::string ReplaceTags(const std::string s) const;
@@ -53,7 +53,8 @@ protected:
     PlayListItem(wxXmlNode* node);
     PlayListItem();
     virtual ~PlayListItem() {};
-    virtual PlayListItem* Copy() const = 0;
+    PlayListItem* Clone() const;
+    virtual PlayListItem* Copy(const bool isClone) const = 0;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemARTNetTrigger.cpp
+++ b/xSchedule/PlayList/PlayListItemARTNetTrigger.cpp
@@ -53,7 +53,7 @@ PlayListItemARTNetTrigger::PlayListItemARTNetTrigger() : PlayListItem()
     _ip = "";
 }
 
-PlayListItem* PlayListItemARTNetTrigger::Copy() const
+PlayListItem* PlayListItemARTNetTrigger::Copy(const bool isClone) const
 {
     PlayListItemARTNetTrigger* res = new PlayListItemARTNetTrigger();
     res->_oem = _oem;
@@ -62,7 +62,7 @@ PlayListItem* PlayListItemARTNetTrigger::Copy() const
     res->_ip = _ip;
     res->_data = _data;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemARTNetTrigger.h
+++ b/xSchedule/PlayList/PlayListItemARTNetTrigger.h
@@ -37,7 +37,7 @@ public:
     PlayListItemARTNetTrigger(wxXmlNode* node);
     PlayListItemARTNetTrigger();
     virtual ~PlayListItemARTNetTrigger() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemAllOff.cpp
+++ b/xSchedule/PlayList/PlayListItemAllOff.cpp
@@ -54,7 +54,7 @@ PlayListItemAllOff::PlayListItemAllOff(OutputManager* outputManager) : PlayListI
     SetName("All Set");
 }
 
-PlayListItem* PlayListItemAllOff::Copy() const
+PlayListItem* PlayListItemAllOff::Copy(const bool isClone) const
 {
     PlayListItemAllOff* res = new PlayListItemAllOff(_outputManager);
     res->_duration = _duration;
@@ -64,7 +64,7 @@ PlayListItem* PlayListItemAllOff::Copy() const
     res->_channels = _channels;
     res->_startChannel = _startChannel;
     res->_fadeToZero = _fadeToZero;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemAllOff.h
+++ b/xSchedule/PlayList/PlayListItemAllOff.h
@@ -39,7 +39,7 @@ public:
     PlayListItemAllOff(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemAllOff(OutputManager* outputManager);
     virtual ~PlayListItemAllOff() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
 #pragma endregion Constructors and Destructors
 
 #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemAudio.cpp
+++ b/xSchedule/PlayList/PlayListItemAudio.cpp
@@ -148,10 +148,10 @@ PlayListItemAudio::~PlayListItemAudio()
     }
 }
 
-PlayListItem* PlayListItemAudio::Copy() const
+PlayListItem* PlayListItemAudio::Copy(const bool isClone) const
 {
     PlayListItemAudio* res = new PlayListItemAudio();
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
     res->_fastStartAudio = _fastStartAudio;
     res->_durationMS = _durationMS;
     res->_controlsTimingCache = _controlsTimingCache;

--- a/xSchedule/PlayList/PlayListItemAudio.h
+++ b/xSchedule/PlayList/PlayListItemAudio.h
@@ -44,7 +44,7 @@ public:
     PlayListItemAudio(wxXmlNode* node);
     PlayListItemAudio();
     virtual ~PlayListItemAudio();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemCURL.cpp
+++ b/xSchedule/PlayList/PlayListItemCURL.cpp
@@ -75,7 +75,7 @@ PlayListItemCURL::PlayListItemCURL() : PlayListItem()
     _type = "PLICURL";
 }
 
-PlayListItem* PlayListItemCURL::Copy() const
+PlayListItem* PlayListItemCURL::Copy(const bool isClone) const
 {
     PlayListItemCURL* res = new PlayListItemCURL();
     res->_url = _url;
@@ -83,7 +83,7 @@ PlayListItem* PlayListItemCURL::Copy() const
     res->_body = _body;
     res->_started = false;
     res->_contentType = _contentType;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemCURL.h
+++ b/xSchedule/PlayList/PlayListItemCURL.h
@@ -34,7 +34,7 @@ public:
     PlayListItemCURL(wxXmlNode* node);
     PlayListItemCURL();
     virtual ~PlayListItemCURL() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemColourOrgan.cpp
+++ b/xSchedule/PlayList/PlayListItemColourOrgan.cpp
@@ -78,7 +78,7 @@ PlayListItemColourOrgan::PlayListItemColourOrgan(OutputManager* outputManager) :
     _blendMode = APPLYMETHOD::METHOD_OVERWRITEIFBLACK;
 }
 
-PlayListItem* PlayListItemColourOrgan::Copy() const
+PlayListItem* PlayListItemColourOrgan::Copy(const bool isClone) const
 {
     PlayListItemColourOrgan* res = new PlayListItemColourOrgan(_outputManager);
     res->_outputManager = _outputManager;
@@ -94,7 +94,7 @@ PlayListItem* PlayListItemColourOrgan::Copy() const
     res->_fadeFrames = _fadeFrames;
     res->_fadePerFrame = _fadePerFrame;
     res->_threshold = _threshold;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemColourOrgan.h
+++ b/xSchedule/PlayList/PlayListItemColourOrgan.h
@@ -46,7 +46,7 @@ public:
     PlayListItemColourOrgan(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemColourOrgan(OutputManager* outputManager);
     virtual ~PlayListItemColourOrgan();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemDelay.cpp
+++ b/xSchedule/PlayList/PlayListItemDelay.cpp
@@ -31,11 +31,11 @@ PlayListItemDelay::PlayListItemDelay() : PlayListItem()
     SetName("Delay");
 }
 
-PlayListItem* PlayListItemDelay::Copy() const
+PlayListItem* PlayListItemDelay::Copy(const bool isClone) const
 {
     PlayListItemDelay* res = new PlayListItemDelay();
     res->_duration = _duration;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemDelay.h
+++ b/xSchedule/PlayList/PlayListItemDelay.h
@@ -29,7 +29,7 @@ public:
     PlayListItemDelay(wxXmlNode* node);
     PlayListItemDelay();
     virtual ~PlayListItemDelay() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemDim.cpp
+++ b/xSchedule/PlayList/PlayListItemDim.cpp
@@ -50,7 +50,7 @@ PlayListItemDim::PlayListItemDim(OutputManager* outputManager) : PlayListItem()
     _dim = 100;
 }
 
-PlayListItem* PlayListItemDim::Copy() const
+PlayListItem* PlayListItemDim::Copy(const bool isClone) const
 {
     PlayListItemDim* res = new PlayListItemDim(_outputManager);
     res->_outputManager = _outputManager;
@@ -58,7 +58,7 @@ PlayListItem* PlayListItemDim::Copy() const
     res->_channels = _channels;
     res->_duration = _duration;
     res->_dim = _dim;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemDim.h
+++ b/xSchedule/PlayList/PlayListItemDim.h
@@ -36,7 +36,7 @@ public:
     PlayListItemDim(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemDim(OutputManager* outputManager);
     virtual ~PlayListItemDim();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemESEQ.cpp
+++ b/xSchedule/PlayList/PlayListItemESEQ.cpp
@@ -48,12 +48,12 @@ size_t PlayListItemESEQ::GetDurationMS(size_t frameMS) const
     return 0;
 }
 
-PlayListItem* PlayListItemESEQ::Copy() const
+PlayListItem* PlayListItemESEQ::Copy(const bool isClone) const
 {
     PlayListItemESEQ* res = new PlayListItemESEQ();
     res->_ESEQFileName = _ESEQFileName;
     res->_applyMethod = _applyMethod;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemESEQ.h
+++ b/xSchedule/PlayList/PlayListItemESEQ.h
@@ -36,7 +36,7 @@ public:
     PlayListItemESEQ(wxXmlNode* node);
     PlayListItemESEQ();
     virtual ~PlayListItemESEQ() { CloseFiles(); };
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemFPPEvent.cpp
+++ b/xSchedule/PlayList/PlayListItemFPPEvent.cpp
@@ -157,7 +157,7 @@ PlayListItemFPPEvent::PlayListItemFPPEvent() : PlayListItem()
     _type = "PLIFPPEVENT";
 }
 
-PlayListItem* PlayListItemFPPEvent::Copy() const
+PlayListItem* PlayListItemFPPEvent::Copy(const bool isClone) const
 {
     PlayListItemFPPEvent* res = new PlayListItemFPPEvent();
     res->_major = _major;
@@ -165,7 +165,7 @@ PlayListItem* PlayListItemFPPEvent::Copy() const
     res->_ip = _ip;
     res->_started = false;
     res->_method = _method;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemFPPEvent.h
+++ b/xSchedule/PlayList/PlayListItemFPPEvent.h
@@ -34,7 +34,7 @@ public:
     PlayListItemFPPEvent(wxXmlNode* node);
     PlayListItemFPPEvent();
     virtual ~PlayListItemFPPEvent() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemFSEQ.cpp
+++ b/xSchedule/PlayList/PlayListItemFSEQ.cpp
@@ -224,10 +224,10 @@ PlayListItemFSEQ::PlayListItemFSEQ(OutputManager* outputManager) : PlayListItem(
     _currentFrame = 0;
 }
 
-PlayListItem* PlayListItemFSEQ::Copy() const
+PlayListItem* PlayListItemFSEQ::Copy(const bool isClone) const
 {
     PlayListItemFSEQ* res = new PlayListItemFSEQ(_outputManager);
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
     res->_outputManager = _outputManager;
     res->_cachedAudioFilename = _cachedAudioFilename;
     res->_fseqFileName = _fseqFileName;

--- a/xSchedule/PlayList/PlayListItemFSEQ.h
+++ b/xSchedule/PlayList/PlayListItemFSEQ.h
@@ -54,7 +54,7 @@ public:
     PlayListItemFSEQ(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemFSEQ(OutputManager* outputManager);
     virtual ~PlayListItemFSEQ();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemFSEQVideo.cpp
+++ b/xSchedule/PlayList/PlayListItemFSEQVideo.cpp
@@ -257,10 +257,10 @@ PlayListItemFSEQVideo::PlayListItemFSEQVideo(OutputManager* outputManager, Sched
     }
 }
 
-PlayListItem* PlayListItemFSEQVideo::Copy() const
+PlayListItem* PlayListItemFSEQVideo::Copy(const bool isClone) const
 {
     PlayListItemFSEQVideo* res = new PlayListItemFSEQVideo(_outputManager, (ScheduleOptions*)nullptr);
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
     res->_cachedAudioFilename = _cachedAudioFilename;
     res->_outputManager = _outputManager;
     res->_topMost = _topMost;

--- a/xSchedule/PlayList/PlayListItemFSEQVideo.h
+++ b/xSchedule/PlayList/PlayListItemFSEQVideo.h
@@ -73,7 +73,7 @@ public:
     PlayListItemFSEQVideo(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemFSEQVideo(OutputManager* outputManager, ScheduleOptions* options);
     virtual ~PlayListItemFSEQVideo();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemFade.cpp
+++ b/xSchedule/PlayList/PlayListItemFade.cpp
@@ -46,7 +46,7 @@ PlayListItemFade::PlayListItemFade(OutputManager* outputManager) : PlayListItem(
     SetName("Fade");
 }
 
-PlayListItem* PlayListItemFade::Copy() const
+PlayListItem* PlayListItemFade::Copy(const bool isClone) const
 {
     PlayListItemFade* res = new PlayListItemFade(_outputManager);
     res->_duration = _duration;
@@ -54,7 +54,7 @@ PlayListItem* PlayListItemFade::Copy() const
     res->_fadeDirection = _fadeDirection;
     res->_channels = _channels;
     res->_startChannel = _startChannel;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemFade.h
+++ b/xSchedule/PlayList/PlayListItemFade.h
@@ -41,7 +41,7 @@ public:
     PlayListItemFade(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemFade(OutputManager* outputManager);
     virtual ~PlayListItemFade() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
 #pragma endregion Constructors and Destructors
 
 #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemFile.cpp
+++ b/xSchedule/PlayList/PlayListItemFile.cpp
@@ -45,14 +45,14 @@ PlayListItemFile::PlayListItemFile() : PlayListItem()
     _fileName = "";
 }
 
-PlayListItem* PlayListItemFile::Copy() const
+PlayListItem* PlayListItemFile::Copy(const bool isClone) const
 {
     PlayListItemFile* res = new PlayListItemFile();
     res->_content = _content;
     res->_append = _append;
     res->_fileName = _fileName;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemFile.h
+++ b/xSchedule/PlayList/PlayListItemFile.h
@@ -34,7 +34,7 @@ public:
     PlayListItemFile(wxXmlNode* node);
     PlayListItemFile();
     virtual ~PlayListItemFile() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion 
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemImage.cpp
+++ b/xSchedule/PlayList/PlayListItemImage.cpp
@@ -75,7 +75,7 @@ PlayListItemImage::PlayListItemImage(ScheduleOptions* options) : PlayListItem()
     }
 }
 
-PlayListItem* PlayListItemImage::Copy() const
+PlayListItem* PlayListItemImage::Copy(const bool isClone) const
 {
     PlayListItemImage* res = new PlayListItemImage((ScheduleOptions*)nullptr);
     res->_ImageFile = _ImageFile;
@@ -84,7 +84,7 @@ PlayListItem* PlayListItemImage::Copy() const
     res->_duration = _duration;
     res->_topMost = _topMost;
     res->_suppressVirtualMatrix = _suppressVirtualMatrix;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemImage.h
+++ b/xSchedule/PlayList/PlayListItemImage.h
@@ -42,7 +42,7 @@ public:
     PlayListItemImage(wxXmlNode* node);
     PlayListItemImage(ScheduleOptions* options);
     virtual ~PlayListItemImage();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemJukebox.cpp
+++ b/xSchedule/PlayList/PlayListItemJukebox.cpp
@@ -45,13 +45,13 @@ PlayListItemJukebox::PlayListItemJukebox() :
     SetEnumState(ENUMJUKEBOX::ENUM_STATE_DONE);
 }
 
-PlayListItem* PlayListItemJukebox::Copy() const
+PlayListItem* PlayListItemJukebox::Copy(const bool isClone) const
 {
     PlayListItemJukebox* res = new PlayListItemJukebox();
     res->_jukeboxButton = _jukeboxButton;
     res->_port = _port;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemJukebox.h
+++ b/xSchedule/PlayList/PlayListItemJukebox.h
@@ -46,7 +46,7 @@ public:
     PlayListItemJukebox(wxXmlNode* node);
     PlayListItemJukebox();
     virtual ~PlayListItemJukebox() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemMIDI.cpp
+++ b/xSchedule/PlayList/PlayListItemMIDI.cpp
@@ -50,7 +50,7 @@ PlayListItemMIDI::PlayListItemMIDI() : PlayListItem()
     _data2 = "0x00";
 }
 
-PlayListItem* PlayListItemMIDI::Copy() const
+PlayListItem* PlayListItemMIDI::Copy(const bool isClone) const
 {
     PlayListItemMIDI* res = new PlayListItemMIDI();
     res->_device = _device;
@@ -59,7 +59,7 @@ PlayListItem* PlayListItemMIDI::Copy() const
     res->_data1 = _data1;
     res->_data2 = _data2;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemMIDI.h
+++ b/xSchedule/PlayList/PlayListItemMIDI.h
@@ -35,7 +35,7 @@ public:
     PlayListItemMIDI(wxXmlNode* node);
     PlayListItemMIDI();
     virtual ~PlayListItemMIDI() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     static std::list<std::string> GetDevices();

--- a/xSchedule/PlayList/PlayListItemMQTT.cpp
+++ b/xSchedule/PlayList/PlayListItemMQTT.cpp
@@ -154,7 +154,7 @@ PlayListItemMQTT::PlayListItemMQTT() : PlayListItem()
     _type = "PLIMQTT";
 }
 
-PlayListItem* PlayListItemMQTT::Copy() const
+PlayListItem* PlayListItemMQTT::Copy(const bool isClone) const
 {
     PlayListItemMQTT* res = new PlayListItemMQTT();
 
@@ -166,7 +166,7 @@ PlayListItem* PlayListItemMQTT::Copy() const
     res->_password = _password;
     res->_clientId = _clientId;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemMQTT.h
+++ b/xSchedule/PlayList/PlayListItemMQTT.h
@@ -41,7 +41,7 @@ public:
     PlayListItemMQTT(wxXmlNode* node);
     PlayListItemMQTT();
     virtual ~PlayListItemMQTT() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
 #pragma endregion Constructors and Destructors
 
 #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemMicrophone.cpp
+++ b/xSchedule/PlayList/PlayListItemMicrophone.cpp
@@ -56,7 +56,7 @@ PlayListItemMicrophone::PlayListItemMicrophone(OutputManager* outputManager) : P
     _blendMode = APPLYMETHOD::METHOD_OVERWRITEIFBLACK;
 }
 
-PlayListItem* PlayListItemMicrophone::Copy() const
+PlayListItem* PlayListItemMicrophone::Copy(const bool isClone) const
 {
     PlayListItemMicrophone* res = new PlayListItemMicrophone(_outputManager);
     res->_outputManager = _outputManager;
@@ -66,7 +66,7 @@ PlayListItem* PlayListItemMicrophone::Copy() const
     res->_colour = _colour;
     res->_mode = _mode;
     res->_blendMode = _blendMode;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemMicrophone.h
+++ b/xSchedule/PlayList/PlayListItemMicrophone.h
@@ -40,7 +40,7 @@ public:
     PlayListItemMicrophone(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemMicrophone(OutputManager* outputManager);
     virtual ~PlayListItemMicrophone();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemOSC.cpp
+++ b/xSchedule/PlayList/PlayListItemOSC.cpp
@@ -59,7 +59,7 @@ PlayListItemOSC::PlayListItemOSC() : PlayListItem()
 	}
 }
 
-PlayListItem* PlayListItemOSC::Copy() const
+PlayListItem* PlayListItemOSC::Copy(const bool isClone) const
 {
     PlayListItemOSC* res = new PlayListItemOSC();
 
@@ -72,7 +72,7 @@ PlayListItem* PlayListItemOSC::Copy() const
 		res->_types[i] = _types[i];
 		res->_values[i] = _values[i];
 	}
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemOSC.h
+++ b/xSchedule/PlayList/PlayListItemOSC.h
@@ -43,7 +43,7 @@ public:
     PlayListItemOSC(wxXmlNode* node);
     PlayListItemOSC();
     virtual ~PlayListItemOSC() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
 #pragma endregion Constructors and Destructors
 
 #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemPlugin.cpp
+++ b/xSchedule/PlayList/PlayListItemPlugin.cpp
@@ -48,14 +48,14 @@ PlayListItemPlugin::PlayListItemPlugin() : PlayListItem()
 	_eventParm = "";
 }
 
-PlayListItem* PlayListItemPlugin::Copy() const
+PlayListItem* PlayListItemPlugin::Copy(const bool isClone) const
 {
     PlayListItemPlugin* res = new PlayListItemPlugin();
     res->_plugin = _plugin;
     res->_action = _action;
 	res->_eventParm = _eventParm;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemPlugin.h
+++ b/xSchedule/PlayList/PlayListItemPlugin.h
@@ -32,7 +32,7 @@ public:
     PlayListItemPlugin(wxXmlNode* node);
     PlayListItemPlugin();
     virtual ~PlayListItemPlugin() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemProjector.cpp
+++ b/xSchedule/PlayList/PlayListItemProjector.cpp
@@ -225,7 +225,7 @@ PlayListItemProjector::PlayListItemProjector() : PlayListItem()
     _socket = nullptr;
 }
 
-PlayListItem* PlayListItemProjector::Copy() const
+PlayListItem* PlayListItemProjector::Copy(const bool isClone) const
 {
     PlayListItemProjector* res = new PlayListItemProjector();
     res->_command = _command;
@@ -241,7 +241,7 @@ PlayListItem* PlayListItemProjector::Copy() const
     res->_charBits = _charBits;
     res->_stopBits = _stopBits;
     res->_parameter = _parameter;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemProjector.h
+++ b/xSchedule/PlayList/PlayListItemProjector.h
@@ -58,7 +58,7 @@ public:
     PlayListItemProjector(wxXmlNode* node);
     PlayListItemProjector();
     virtual ~PlayListItemProjector() { };
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemRDS.cpp
+++ b/xSchedule/PlayList/PlayListItemRDS.cpp
@@ -178,14 +178,14 @@ PlayListItemRDS::PlayListItemRDS() : PlayListItem()
 
 PlayListItemRDS::~PlayListItemRDS() { }
 
-PlayListItem* PlayListItemRDS::Copy() const
+PlayListItem* PlayListItemRDS::Copy(const bool isClone) const
 {
     PlayListItemRDS* res = new PlayListItemRDS();
     res->_started = false;
     res->_stationName = _stationName;
     res->_commPort = _commPort;
     res->_text = _text;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemRDS.h
+++ b/xSchedule/PlayList/PlayListItemRDS.h
@@ -41,7 +41,7 @@ public:
     PlayListItemRDS(wxXmlNode* node);
     PlayListItemRDS();
     virtual ~PlayListItemRDS();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemRunCommand.cpp
+++ b/xSchedule/PlayList/PlayListItemRunCommand.cpp
@@ -46,7 +46,7 @@ PlayListItemRunCommand::PlayListItemRunCommand() : PlayListItem()
     _parm3 = "";
 }
 
-PlayListItem* PlayListItemRunCommand::Copy() const
+PlayListItem* PlayListItemRunCommand::Copy(const bool isClone) const
 {
     PlayListItemRunCommand* res = new PlayListItemRunCommand();
     res->_command = _command;
@@ -54,7 +54,7 @@ PlayListItem* PlayListItemRunCommand::Copy() const
     res->_parm2 = _parm2;
     res->_parm3 = _parm3;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemRunCommand.h
+++ b/xSchedule/PlayList/PlayListItemRunCommand.h
@@ -35,7 +35,7 @@ public:
     PlayListItemRunCommand(wxXmlNode* node);
     PlayListItemRunCommand();
     virtual ~PlayListItemRunCommand() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemRunProcess.cpp
+++ b/xSchedule/PlayList/PlayListItemRunProcess.cpp
@@ -41,13 +41,13 @@ PlayListItemRunProcess::PlayListItemRunProcess() : PlayListItem()
     _waitForCompletion = false;
 }
 
-PlayListItem* PlayListItemRunProcess::Copy() const
+PlayListItem* PlayListItemRunProcess::Copy(const bool isClone) const
 {
     PlayListItemRunProcess* res = new PlayListItemRunProcess();
     res->_command = _command;
     res->_started = false;
     res->_waitForCompletion = _waitForCompletion;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemRunProcess.h
+++ b/xSchedule/PlayList/PlayListItemRunProcess.h
@@ -32,7 +32,7 @@ public:
     PlayListItemRunProcess(wxXmlNode* node);
     PlayListItemRunProcess();
     virtual ~PlayListItemRunProcess() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemScreenMap.cpp
+++ b/xSchedule/PlayList/PlayListItemScreenMap.cpp
@@ -67,7 +67,7 @@ PlayListItemScreenMap::PlayListItemScreenMap() : PlayListItem()
     _quality = "Bilinear";
 }
 
-PlayListItem* PlayListItemScreenMap::Copy() const
+PlayListItem* PlayListItemScreenMap::Copy(const bool isClone) const
 {
     PlayListItemScreenMap* res = new PlayListItemScreenMap();
     res->_matrix = _matrix;
@@ -79,7 +79,7 @@ PlayListItem* PlayListItemScreenMap::Copy() const
     res->_blendMode = _blendMode;
     res->_quality = _quality;
     res->_rescale = _rescale;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemScreenMap.h
+++ b/xSchedule/PlayList/PlayListItemScreenMap.h
@@ -42,7 +42,7 @@ public:
     PlayListItemScreenMap(wxXmlNode* node);
     PlayListItemScreenMap();
     virtual ~PlayListItemScreenMap();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemSerial.cpp
+++ b/xSchedule/PlayList/PlayListItemSerial.cpp
@@ -48,7 +48,7 @@ PlayListItemSerial::PlayListItemSerial() : PlayListItem()
     _data = "";
 }
 
-PlayListItem* PlayListItemSerial::Copy() const
+PlayListItem* PlayListItemSerial::Copy(const bool isClone) const
 {
     PlayListItemSerial* res = new PlayListItemSerial();
     res->_commPort = _commPort;
@@ -56,7 +56,7 @@ PlayListItem* PlayListItemSerial::Copy() const
     res->_speed = _speed;
     res->_data = _data;
     res->_started = false;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemSerial.h
+++ b/xSchedule/PlayList/PlayListItemSerial.h
@@ -36,7 +36,7 @@ public:
     PlayListItemSerial(wxXmlNode* node);
     PlayListItemSerial();
     virtual ~PlayListItemSerial() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemSetColour.cpp
+++ b/xSchedule/PlayList/PlayListItemSetColour.cpp
@@ -54,7 +54,7 @@ PlayListItemSetColour::PlayListItemSetColour(OutputManager* outputManager) : Pla
     SetName("Set Colour");
 }
 
-PlayListItem* PlayListItemSetColour::Copy() const
+PlayListItem* PlayListItemSetColour::Copy(const bool isClone) const
 {
     PlayListItemSetColour* res = new PlayListItemSetColour(_outputManager);
     res->_duration = _duration;
@@ -64,7 +64,7 @@ PlayListItem* PlayListItemSetColour::Copy() const
     res->_nodes = _nodes;
     res->_startChannel = _startChannel;
     res->_fadeToBlack = _fadeToBlack;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemSetColour.h
+++ b/xSchedule/PlayList/PlayListItemSetColour.h
@@ -39,7 +39,7 @@ public:
     PlayListItemSetColour(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemSetColour(OutputManager* outputManager);
     virtual ~PlayListItemSetColour() {};
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
 #pragma endregion Constructors and Destructors
 
 #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemTest.cpp
+++ b/xSchedule/PlayList/PlayListItemTest.cpp
@@ -60,7 +60,7 @@ PlayListItemTest::PlayListItemTest(OutputManager* outputManager) : PlayListItem(
     _value2 = 255;
 }
 
-PlayListItem* PlayListItemTest::Copy() const
+PlayListItem* PlayListItemTest::Copy(const bool isClone) const
 {
     PlayListItemTest* res = new PlayListItemTest(_outputManager);
     res->_outputManager = _outputManager;
@@ -71,7 +71,7 @@ PlayListItem* PlayListItemTest::Copy() const
     res->_mode = _mode;
     res->_value1 = _value1;
     res->_value2 = _value2;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemTest.h
+++ b/xSchedule/PlayList/PlayListItemTest.h
@@ -40,7 +40,7 @@ public:
     PlayListItemTest(OutputManager* outputManager, wxXmlNode* node);
     PlayListItemTest(OutputManager* outputManager);
     virtual ~PlayListItemTest();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemText.cpp
+++ b/xSchedule/PlayList/PlayListItemText.cpp
@@ -128,7 +128,7 @@ PlayListItemText::PlayListItemText() : PlayListItem()
     _parameter1 = "";
 }
 
-PlayListItem* PlayListItemText::Copy() const
+PlayListItem* PlayListItemText::Copy(const bool isClone) const
 {
     PlayListItemText* res = new PlayListItemText();
     res->_matrix = _matrix;
@@ -147,7 +147,7 @@ PlayListItem* PlayListItemText::Copy() const
         _font->GetUnderlined(), _font->GetFaceName(), _font->GetEncoding());
     res->_format = _format;
     res->_text = _text;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemText.h
+++ b/xSchedule/PlayList/PlayListItemText.h
@@ -54,7 +54,7 @@ public:
     PlayListItemText(wxXmlNode* node);
     PlayListItemText();
     virtual ~PlayListItemText();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListItemVideo.cpp
+++ b/xSchedule/PlayList/PlayListItemVideo.cpp
@@ -97,7 +97,7 @@ PlayListItemVideo::PlayListItemVideo(ScheduleOptions* options) : PlayListItem()
     _durationMS = 0;
 }
 
-PlayListItem* PlayListItemVideo::Copy() const
+PlayListItem* PlayListItemVideo::Copy(const bool isClone) const
 {
     PlayListItemVideo* res = new PlayListItemVideo((ScheduleOptions*)nullptr);
     res->_origin = _origin;
@@ -111,7 +111,7 @@ PlayListItem* PlayListItemVideo::Copy() const
     res->_loopVideo = _loopVideo;
     res->_suppressVirtualMatrix = _suppressVirtualMatrix;
     res->_useMediaPlayer = _useMediaPlayer;
-    PlayListItem::Copy(res);
+    PlayListItem::Copy(res, isClone);
 
     return res;
 }

--- a/xSchedule/PlayList/PlayListItemVideo.h
+++ b/xSchedule/PlayList/PlayListItemVideo.h
@@ -53,7 +53,7 @@ public:
     PlayListItemVideo(wxXmlNode* node);
     PlayListItemVideo(ScheduleOptions* options);
     virtual ~PlayListItemVideo();
-    virtual PlayListItem* Copy() const override;
+    virtual PlayListItem* Copy(const bool isClone) const override;
     #pragma endregion Constructors and Destructors
 
     #pragma region Getters and Setters

--- a/xSchedule/PlayList/PlayListStep.cpp
+++ b/xSchedule/PlayList/PlayListStep.cpp
@@ -112,10 +112,33 @@ PlayListStep::PlayListStep(const PlayListStep& step)
         ReentrancyCounter rec(_reentrancyCounter);
         for (auto it = step._items.begin(); it != step._items.end(); ++it)
         {
-            _items.push_back((*it)->Copy());
+            _items.push_back((*it)->Copy(false));
         }
         _items.sort(compare_priority);
     }
+}
+
+PlayListStep* PlayListStep::Clone() const
+{
+    PlayListStep* pls = new PlayListStep();
+    pls->_loops = _loops;
+    pls->_framecount = _framecount;
+    pls->_currentFrame = _currentFrame;
+    pls->_name = _name;
+    pls->_changeCount = _changeCount;
+    pls->_excludeFromRandom = _excludeFromRandom;
+    pls->_everyStep = _everyStep;
+    // Note: We are intentially NOT copying "_lastSavedChangeCount" and "_id" here.
+
+    {
+        ReentrancyCounter rec(_reentrancyCounter);
+        for (auto it = _items.begin(); it != _items.end(); ++it) {
+            pls->_items.push_back((*it)->Clone());
+        }
+        pls->_items.sort(compare_priority);
+    }
+
+    return pls;
 }
 
 void PlayListStep::ClearDirty()

--- a/xSchedule/PlayList/PlayListStep.h
+++ b/xSchedule/PlayList/PlayListStep.h
@@ -55,6 +55,7 @@ public:
     PlayListStep();
     virtual ~PlayListStep();
     PlayListStep(const PlayListStep& step);
+    PlayListStep* Clone() const;
 #pragma endregion Constructors and Destructors
 
     bool operator==(const PlayListStep& rhs) const { return _id == rhs._id; }


### PR DESCRIPTION
This addresses: https://github.com/smeighan/xLights/issues/3048

The issue here was that during a clone process the "_id" member was getting copied when in fact it should have been left alone (set in the constructor to be unique). To fix this I created a new clone/copy method that conditionally copies these fields during copy vs. clone.

While fixing this I debated several approaches and settled on this one. However, I'm not married to it and would be happy to change it. I think its more of a preference/style thing. Feel free to ask for changes.