### PR TITLE
fix: use full LOR brightness encoding range in LOROutput

### DIFF
--- a/xLights/outputs/LOROutput.cpp
+++ b/xLights/outputs/LOROutput.cpp
@@ -43,19 +43,13 @@ bool LOROutput::Open() {
 
     _ok = SerialOutput::Open();
 
-    for (size_t i = 0; i <= 255; i++) {
-        int temp = (int)(100.0*(double)i / (double)255 + 0.5);
-        switch (temp) {
-        case 0:
-            _data[i] = 0xF0;
-            break;
-        case 100:
-            _data[i] = 0x01;
-            break;
-        default:
-            _data[i] = 228 - temp * 2;
-            break;
-        }
+    for (size_t i = 0; i < LOR_PACKET_LEN; i++) {
+        // encode brightness value according to LOR protocol
+        // see: https://github.com/Cryptkeeper/lightorama-protocol/blob/master/PROTOCOL.md#brightness
+        // 100% brightness  = 0x01
+        // 0% brightness    = 0xF0
+        // brightness range = 0xEF
+        _data[i] = (i / 255.0F) * -0xEF + 0xF0;
     }
 
     // initialise to a known state of all off


### PR DESCRIPTION
The encoding routine in `LOROutput.cpp` currently produces a non-linear range. This results in the "brightness" output on LOR hardware producing unexpected "jumps" when fading near its 0%/100% extremes or in unexpected brightness output levels when working with slightly below min/max brightness values.

I've updated the routing to produce a linear brightness range. LOR's protocol defines a linear brightness range of 0% (0xF0) to 100% (0x01), resulting an (inverted) range of -0xEF. Therefore any normalized value `i` [0,1] can be encoded as `i * -0xEF + 0xF0` and utilize the full brightness range.

<details>
    <summary>Brightness encoding table</summary>

| Input (0,255) | Existing Output | Updated Output | Abs. Diff |
| - | - | - | - |
| 0 | 0xf0 (240) | 0xf0 (240) | 0 |
| 1 | 0xf0 (240) | 0xef (239) | 1 |
| 2 | 0xe2 (226) | 0xee (238) | -12 |
| 3 | 0xe2 (226) | 0xed (237) | -11 |
| 4 | 0xe0 (224) | 0xec (236) | -12 |
| 5 | 0xe0 (224) | 0xeb (235) | -11 |
| 6 | 0xe0 (224) | 0xea (234) | -10 |
| 7 | 0xde (222) | 0xe9 (233) | -11 |
| 8 | 0xde (222) | 0xe8 (232) | -10 |
| 9 | 0xdc (220) | 0xe7 (231) | -11 |
| 10 | 0xdc (220) | 0xe6 (230) | -10 |
| 11 | 0xdc (220) | 0xe5 (229) | -9 |
| 12 | 0xda (218) | 0xe4 (228) | -10 |
| 13 | 0xda (218) | 0xe3 (227) | -9 |
| 14 | 0xda (218) | 0xe2 (226) | -8 |
| 15 | 0xd8 (216) | 0xe1 (225) | -9 |
| 16 | 0xd8 (216) | 0xe1 (225) | -9 |
| 17 | 0xd6 (214) | 0xe0 (224) | -10 |
| 18 | 0xd6 (214) | 0xdf (223) | -9 |
| 19 | 0xd6 (214) | 0xde (222) | -8 |
| 20 | 0xd4 (212) | 0xdd (221) | -9 |
| 21 | 0xd4 (212) | 0xdc (220) | -8 |
| 22 | 0xd2 (210) | 0xdb (219) | -9 |
| 23 | 0xd2 (210) | 0xda (218) | -8 |
| 24 | 0xd2 (210) | 0xd9 (217) | -7 |
| 25 | 0xd0 (208) | 0xd8 (216) | -8 |
| 26 | 0xd0 (208) | 0xd7 (215) | -7 |
| 27 | 0xce (206) | 0xd6 (214) | -8 |
| 28 | 0xce (206) | 0xd5 (213) | -7 |
| 29 | 0xce (206) | 0xd4 (212) | -6 |
| 30 | 0xcc (204) | 0xd3 (211) | -7 |
| 31 | 0xcc (204) | 0xd2 (210) | -6 |
| 32 | 0xca (202) | 0xd2 (210) | -8 |
| 33 | 0xca (202) | 0xd1 (209) | -7 |
| 34 | 0xca (202) | 0xd0 (208) | -6 |
| 35 | 0xc8 (200) | 0xcf (207) | -7 |
| 36 | 0xc8 (200) | 0xce (206) | -6 |
| 37 | 0xc6 (198) | 0xcd (205) | -7 |
| 38 | 0xc6 (198) | 0xcc (204) | -6 |
| 39 | 0xc6 (198) | 0xcb (203) | -5 |
| 40 | 0xc4 (196) | 0xca (202) | -6 |
| 41 | 0xc4 (196) | 0xc9 (201) | -5 |
| 42 | 0xc4 (196) | 0xc8 (200) | -4 |
| 43 | 0xc2 (194) | 0xc7 (199) | -5 |
| 44 | 0xc2 (194) | 0xc6 (198) | -4 |
| 45 | 0xc0 (192) | 0xc5 (197) | -5 |
| 46 | 0xc0 (192) | 0xc4 (196) | -4 |
| 47 | 0xc0 (192) | 0xc3 (195) | -3 |
| 48 | 0xbe (190) | 0xc3 (195) | -5 |
| 49 | 0xbe (190) | 0xc2 (194) | -4 |
| 50 | 0xbc (188) | 0xc1 (193) | -5 |
| 51 | 0xbc (188) | 0xc0 (192) | -4 |
| 52 | 0xbc (188) | 0xbf (191) | -3 |
| 53 | 0xba (186) | 0xbe (190) | -4 |
| 54 | 0xba (186) | 0xbd (189) | -3 |
| 55 | 0xb8 (184) | 0xbc (188) | -4 |
| 56 | 0xb8 (184) | 0xbb (187) | -3 |
| 57 | 0xb8 (184) | 0xba (186) | -2 |
| 58 | 0xb6 (182) | 0xb9 (185) | -3 |
| 59 | 0xb6 (182) | 0xb8 (184) | -2 |
| 60 | 0xb4 (180) | 0xb7 (183) | -3 |
| 61 | 0xb4 (180) | 0xb6 (182) | -2 |
| 62 | 0xb4 (180) | 0xb5 (181) | -1 |
| 63 | 0xb2 (178) | 0xb4 (180) | -2 |
| 64 | 0xb2 (178) | 0xb4 (180) | -2 |
| 65 | 0xb2 (178) | 0xb3 (179) | -1 |
| 66 | 0xb0 (176) | 0xb2 (178) | -2 |
| 67 | 0xb0 (176) | 0xb1 (177) | -1 |
| 68 | 0xae (174) | 0xb0 (176) | -2 |
| 69 | 0xae (174) | 0xaf (175) | -1 |
| 70 | 0xae (174) | 0xae (174) | 0 |
| 71 | 0xac (172) | 0xad (173) | -1 |
| 72 | 0xac (172) | 0xac (172) | 0 |
| 73 | 0xaa (170) | 0xab (171) | -1 |
| 74 | 0xaa (170) | 0xaa (170) | 0 |
| 75 | 0xaa (170) | 0xa9 (169) | 1 |
| 76 | 0xa8 (168) | 0xa8 (168) | 0 |
| 77 | 0xa8 (168) | 0xa7 (167) | 1 |
| 78 | 0xa6 (166) | 0xa6 (166) | 0 |
| 79 | 0xa6 (166) | 0xa5 (165) | 1 |
| 80 | 0xa6 (166) | 0xa5 (165) | 1 |
| 81 | 0xa4 (164) | 0xa4 (164) | 0 |
| 82 | 0xa4 (164) | 0xa3 (163) | 1 |
| 83 | 0xa2 (162) | 0xa2 (162) | 0 |
| 84 | 0xa2 (162) | 0xa1 (161) | 1 |
| 85 | 0xa2 (162) | 0xa0 (160) | 2 |
| 86 | 0xa0 (160) | 0x9f (159) | 1 |
| 87 | 0xa0 (160) | 0x9e (158) | 2 |
| 88 | 0x9e (158) | 0x9d (157) | 1 |
| 89 | 0x9e (158) | 0x9c (156) | 2 |
| 90 | 0x9e (158) | 0x9b (155) | 3 |
| 91 | 0x9c (156) | 0x9a (154) | 2 |
| 92 | 0x9c (156) | 0x99 (153) | 3 |
| 93 | 0x9c (156) | 0x98 (152) | 4 |
| 94 | 0x9a (154) | 0x97 (151) | 3 |
| 95 | 0x9a (154) | 0x96 (150) | 4 |
| 96 | 0x98 (152) | 0x96 (150) | 2 |
| 97 | 0x98 (152) | 0x95 (149) | 3 |
| 98 | 0x98 (152) | 0x94 (148) | 4 |
| 99 | 0x96 (150) | 0x93 (147) | 3 |
| 100 | 0x96 (150) | 0x92 (146) | 4 |
| 101 | 0x94 (148) | 0x91 (145) | 3 |
| 102 | 0x94 (148) | 0x90 (144) | 4 |
| 103 | 0x94 (148) | 0x8f (143) | 5 |
| 104 | 0x92 (146) | 0x8e (142) | 4 |
| 105 | 0x92 (146) | 0x8d (141) | 5 |
| 106 | 0x90 (144) | 0x8c (140) | 4 |
| 107 | 0x90 (144) | 0x8b (139) | 5 |
| 108 | 0x90 (144) | 0x8a (138) | 6 |
| 109 | 0x8e (142) | 0x89 (137) | 5 |
| 110 | 0x8e (142) | 0x88 (136) | 6 |
| 111 | 0x8c (140) | 0x87 (135) | 5 |
| 112 | 0x8c (140) | 0x87 (135) | 5 |
| 113 | 0x8c (140) | 0x86 (134) | 6 |
| 114 | 0x8a (138) | 0x85 (133) | 5 |
| 115 | 0x8a (138) | 0x84 (132) | 6 |
| 116 | 0x8a (138) | 0x83 (131) | 7 |
| 117 | 0x88 (136) | 0x82 (130) | 6 |
| 118 | 0x88 (136) | 0x81 (129) | 7 |
| 119 | 0x86 (134) | 0x80 (128) | 6 |
| 120 | 0x86 (134) | 0x7f (127) | 7 |
| 121 | 0x86 (134) | 0x7e (126) | 8 |
| 122 | 0x84 (132) | 0x7d (125) | 7 |
| 123 | 0x84 (132) | 0x7c (124) | 8 |
| 124 | 0x82 (130) | 0x7b (123) | 7 |
| 125 | 0x82 (130) | 0x7a (122) | 8 |
| 126 | 0x82 (130) | 0x79 (121) | 9 |
| 127 | 0x80 (128) | 0x78 (120) | 8 |
| 128 | 0x80 (128) | 0x78 (120) | 8 |
| 129 | 0x7e (126) | 0x77 (119) | 7 |
| 130 | 0x7e (126) | 0x76 (118) | 8 |
| 131 | 0x7e (126) | 0x75 (117) | 9 |
| 132 | 0x7c (124) | 0x74 (116) | 8 |
| 133 | 0x7c (124) | 0x73 (115) | 9 |
| 134 | 0x7a (122) | 0x72 (114) | 8 |
| 135 | 0x7a (122) | 0x71 (113) | 9 |
| 136 | 0x7a (122) | 0x70 (112) | 10 |
| 137 | 0x78 (120) | 0x6f (111) | 9 |
| 138 | 0x78 (120) | 0x6e (110) | 10 |
| 139 | 0x76 (118) | 0x6d (109) | 9 |
| 140 | 0x76 (118) | 0x6c (108) | 10 |
| 141 | 0x76 (118) | 0x6b (107) | 11 |
| 142 | 0x74 (116) | 0x6a (106) | 10 |
| 143 | 0x74 (116) | 0x69 (105) | 11 |
| 144 | 0x74 (116) | 0x69 (105) | 11 |
| 145 | 0x72 (114) | 0x68 (104) | 10 |
| 146 | 0x72 (114) | 0x67 (103) | 11 |
| 147 | 0x70 (112) | 0x66 (102) | 10 |
| 148 | 0x70 (112) | 0x65 (101) | 11 |
| 149 | 0x70 (112) | 0x64 (100) | 12 |
| 150 | 0x6e (110) | 0x63 (99) | 11 |
| 151 | 0x6e (110) | 0x62 (98) | 12 |
| 152 | 0x6c (108) | 0x61 (97) | 11 |
| 153 | 0x6c (108) | 0x60 (96) | 12 |
| 154 | 0x6c (108) | 0x5f (95) | 13 |
| 155 | 0x6a (106) | 0x5e (94) | 12 |
| 156 | 0x6a (106) | 0x5d (93) | 13 |
| 157 | 0x68 (104) | 0x5c (92) | 12 |
| 158 | 0x68 (104) | 0x5b (91) | 13 |
| 159 | 0x68 (104) | 0x5a (90) | 14 |
| 160 | 0x66 (102) | 0x5a (90) | 12 |
| 161 | 0x66 (102) | 0x59 (89) | 13 |
| 162 | 0x64 (100) | 0x58 (88) | 12 |
| 163 | 0x64 (100) | 0x57 (87) | 13 |
| 164 | 0x64 (100) | 0x56 (86) | 14 |
| 165 | 0x62 (98) | 0x55 (85) | 13 |
| 166 | 0x62 (98) | 0x54 (84) | 14 |
| 167 | 0x62 (98) | 0x53 (83) | 15 |
| 168 | 0x60 (96) | 0x52 (82) | 14 |
| 169 | 0x60 (96) | 0x51 (81) | 15 |
| 170 | 0x5e (94) | 0x50 (80) | 14 |
| 171 | 0x5e (94) | 0x4f (79) | 15 |
| 172 | 0x5e (94) | 0x4e (78) | 16 |
| 173 | 0x5c (92) | 0x4d (77) | 15 |
| 174 | 0x5c (92) | 0x4c (76) | 16 |
| 175 | 0x5a (90) | 0x4b (75) | 15 |
| 176 | 0x5a (90) | 0x4b (75) | 15 |
| 177 | 0x5a (90) | 0x4a (74) | 16 |
| 178 | 0x58 (88) | 0x49 (73) | 15 |
| 179 | 0x58 (88) | 0x48 (72) | 16 |
| 180 | 0x56 (86) | 0x47 (71) | 15 |
| 181 | 0x56 (86) | 0x46 (70) | 16 |
| 182 | 0x56 (86) | 0x45 (69) | 17 |
| 183 | 0x54 (84) | 0x44 (68) | 16 |
| 184 | 0x54 (84) | 0x43 (67) | 17 |
| 185 | 0x52 (82) | 0x42 (66) | 16 |
| 186 | 0x52 (82) | 0x41 (65) | 17 |
| 187 | 0x52 (82) | 0x40 (64) | 18 |
| 188 | 0x50 (80) | 0x3f (63) | 17 |
| 189 | 0x50 (80) | 0x3e (62) | 18 |
| 190 | 0x4e (78) | 0x3d (61) | 17 |
| 191 | 0x4e (78) | 0x3c (60) | 18 |
| 192 | 0x4e (78) | 0x3c (60) | 18 |
| 193 | 0x4c (76) | 0x3b (59) | 17 |
| 194 | 0x4c (76) | 0x3a (58) | 18 |
| 195 | 0x4c (76) | 0x39 (57) | 19 |
| 196 | 0x4a (74) | 0x38 (56) | 18 |
| 197 | 0x4a (74) | 0x37 (55) | 19 |
| 198 | 0x48 (72) | 0x36 (54) | 18 |
| 199 | 0x48 (72) | 0x35 (53) | 19 |
| 200 | 0x48 (72) | 0x34 (52) | 20 |
| 201 | 0x46 (70) | 0x33 (51) | 19 |
| 202 | 0x46 (70) | 0x32 (50) | 20 |
| 203 | 0x44 (68) | 0x31 (49) | 19 |
| 204 | 0x44 (68) | 0x30 (48) | 20 |
| 205 | 0x44 (68) | 0x2f (47) | 21 |
| 206 | 0x42 (66) | 0x2e (46) | 20 |
| 207 | 0x42 (66) | 0x2d (45) | 21 |
| 208 | 0x40 (64) | 0x2d (45) | 19 |
| 209 | 0x40 (64) | 0x2c (44) | 20 |
| 210 | 0x40 (64) | 0x2b (43) | 21 |
| 211 | 0x3e (62) | 0x2a (42) | 20 |
| 212 | 0x3e (62) | 0x29 (41) | 21 |
| 213 | 0x3c (60) | 0x28 (40) | 20 |
| 214 | 0x3c (60) | 0x27 (39) | 21 |
| 215 | 0x3c (60) | 0x26 (38) | 22 |
| 216 | 0x3a (58) | 0x25 (37) | 21 |
| 217 | 0x3a (58) | 0x24 (36) | 22 |
| 218 | 0x3a (58) | 0x23 (35) | 23 |
| 219 | 0x38 (56) | 0x22 (34) | 22 |
| 220 | 0x38 (56) | 0x21 (33) | 23 |
| 221 | 0x36 (54) | 0x20 (32) | 22 |
| 222 | 0x36 (54) | 0x1f (31) | 23 |
| 223 | 0x36 (54) | 0x1e (30) | 24 |
| 224 | 0x34 (52) | 0x1e (30) | 22 |
| 225 | 0x34 (52) | 0x1d (29) | 23 |
| 226 | 0x32 (50) | 0x1c (28) | 22 |
| 227 | 0x32 (50) | 0x1b (27) | 23 |
| 228 | 0x32 (50) | 0x1a (26) | 24 |
| 229 | 0x30 (48) | 0x19 (25) | 23 |
| 230 | 0x30 (48) | 0x18 (24) | 24 |
| 231 | 0x2e (46) | 0x17 (23) | 23 |
| 232 | 0x2e (46) | 0x16 (22) | 24 |
| 233 | 0x2e (46) | 0x15 (21) | 25 |
| 234 | 0x2c (44) | 0x14 (20) | 24 |
| 235 | 0x2c (44) | 0x13 (19) | 25 |
| 236 | 0x2a (42) | 0x12 (18) | 24 |
| 237 | 0x2a (42) | 0x11 (17) | 25 |
| 238 | 0x2a (42) | 0x10 (16) | 26 |
| 239 | 0x28 (40) | 0x0f (15) | 25 |
| 240 | 0x28 (40) | 0x0f (15) | 25 |
| 241 | 0x26 (38) | 0x0e (14) | 24 |
| 242 | 0x26 (38) | 0x0d (13) | 25 |
| 243 | 0x26 (38) | 0x0c (12) | 26 |
| 244 | 0x24 (36) | 0x0b (11) | 25 |
| 245 | 0x24 (36) | 0x0a (10) | 26 |
| 246 | 0x24 (36) | 0x09 (9) | 27 |
| 247 | 0x22 (34) | 0x08 (8) | 26 |
| 248 | 0x22 (34) | 0x07 (7) | 27 |
| 249 | 0x20 (32) | 0x06 (6) | 26 |
| 250 | 0x20 (32) | 0x05 (5) | 27 |
| 251 | 0x20 (32) | 0x04 (4) | 28 |
| 252 | 0x1e (30) | 0x03 (3) | 27 |
| 253 | 0x1e (30) | 0x02 (2) | 28 |
| 254 | 0x01 (1) | 0x01 (1) | 0 |
| 255 | 0x01 (1) | 0x01 (1) | 0 |

</details>