### PR TITLE
Fix #3060 - include middle pixel for Single Strand / From Middle effect with odd number of nodes

### DIFF
--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -408,8 +408,15 @@ void SingleStrandEffect::RenderSingleStrandChase(RenderBuffer &buffer,
     else {
         width = buffer.BufferWi;
     }
+    
+    if (Mirror) {
+        if ((width % 2) == 0) {
+            width /= 2;
+        } else {
+            width = (width + 1) / 2;
+        }
+    }
 
-    if (Mirror) width /= 2;
     if (width == 0) width = 1;
 
     // Make this a variable since it's used regularly


### PR DESCRIPTION
fix for https://github.com/smeighan/xLights/issues/3060

For Single Strand / From/To Middle effects, the middle pixel was never used.