### PR TITLE
Fix "Default View for New Sequences" preference

### DIFF
--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -652,7 +652,7 @@ void SeqSettingsDialog::WizardPage3()
     Connect(ID_BITMAPBUTTON_quick_start,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SeqSettingsDialog::OnBitmapButton_quick_startClick);
     ModelsChoice->Connect(wxEVT_CHOICE, (wxObjectEventFunction)&SeqSettingsDialog::OnViewSelect, NULL, this);
 
-    StaticText_Info->SetLabelText("This option is used to select which models will populate the grid. \nPress Quick Start to begin sequencing and skip option steps.");
+    StaticText_Info->SetLabelText("This option is used to select which models will populate the master view. \nPress Quick Start to begin sequencing and skip option steps.");
     StaticText_Info->Show();
     Fit();
     Refresh();

--- a/xLights/preferences/SequenceFileSettingsPanel.cpp
+++ b/xLights/preferences/SequenceFileSettingsPanel.cpp
@@ -134,10 +134,9 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	StaticText5 = new wxStaticText(this, ID_STATICTEXT2, _("Default View for New Sequences"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
 	GridBagSizer1->Add(StaticText5, wxGBPosition(2, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	ViewDefaultChoice = new wxChoice(this, ID_CHOICE_VIEW_DEFAULT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_VIEW_DEFAULT"));
+	ViewDefaultChoice->SetToolTip(_("This option is used to select which models will populate the master view when a new sequence is created."));
 	GridBagSizer1->Add(ViewDefaultChoice, wxGBPosition(2, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(GridBagSizer1);
-	GridBagSizer1->Fit(this);
-	GridBagSizer1->SetSizeHints(this);
 
 	Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRenderOnSaveCheckBoxClick);
 	Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnFSEQSaveCheckBoxClick);
@@ -154,6 +153,9 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	Connect(ID_BUTTON_REMOVE_MEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRemoveMediaButtonClick);
 	Connect(ID_CHOICE_VIEW_DEFAULT,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnViewDefaultChoiceSelect);
 	//*)
+
+	GridBagSizer1->Fit(this);
+	GridBagSizer1->SetSizeHints(this);
 }
 
 SequenceFileSettingsPanel::~SequenceFileSettingsPanel()

--- a/xLights/preferences/SequenceFileSettingsPanel.cpp
+++ b/xLights/preferences/SequenceFileSettingsPanel.cpp
@@ -133,8 +133,8 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	GridBagSizer1->Add(StaticBoxSizer1, wxGBPosition(6, 0), wxGBSpan(1, 2), wxALL|wxEXPAND, 2);
 	StaticText5 = new wxStaticText(this, ID_STATICTEXT2, _("Default View for New Sequences"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
 	GridBagSizer1->Add(StaticText5, wxGBPosition(2, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	VeiwDefaultChoice = new wxChoice(this, ID_CHOICE_VIEW_DEFAULT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_VIEW_DEFAULT"));
-	GridBagSizer1->Add(VeiwDefaultChoice, wxGBPosition(2, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+	ViewDefaultChoice = new wxChoice(this, ID_CHOICE_VIEW_DEFAULT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_VIEW_DEFAULT"));
+	GridBagSizer1->Add(ViewDefaultChoice, wxGBPosition(2, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(GridBagSizer1);
 	GridBagSizer1->Fit(this);
 	GridBagSizer1->SetSizeHints(this);
@@ -152,6 +152,7 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	Connect(ID_LISTBOX_MEDIA,wxEVT_COMMAND_LISTBOX_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnMediaDirectoryListSelect);
 	Connect(ID_BUTTON_ADDMEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnAddMediaButtonClick);
 	Connect(ID_BUTTON_REMOVE_MEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRemoveMediaButtonClick);
+	Connect(ID_CHOICE_VIEW_DEFAULT,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnViewDefaultChoiceSelect);
 	//*)
 }
 
@@ -202,7 +203,7 @@ bool SequenceFileSettingsPanel::TransferDataFromWindow() {
     frame->SetFSEQFolder(CheckBox_FSEQ->GetValue(), DirPickerCtrl_FSEQ->GetPath());
     frame->SetRenderCacheFolder(CheckBox_RenderCache->GetValue(), DirPickerCtrl_RenderCache->GetPath());
 
-    frame->SetDefaultSeqView(VeiwDefaultChoice->GetStringSelection());
+    frame->SetDefaultSeqView(ViewDefaultChoice->GetStringSelection());
 
     return true;
 }
@@ -258,12 +259,12 @@ bool SequenceFileSettingsPanel::TransferDataToWindow() {
     CheckBox_RenderCache->SetValue(cb);
     DirPickerCtrl_RenderCache->SetPath(folder);
 
-    VeiwDefaultChoice->Clear();
-    VeiwDefaultChoice->Append(wxString());
-    VeiwDefaultChoice->Append(frame->GetSequenceViews());
-    auto const& view = VeiwDefaultChoice->FindString(frame->GetDefaultSeqView());
+    ViewDefaultChoice->Clear();
+    ViewDefaultChoice->Append(wxString());
+    ViewDefaultChoice->Append(frame->GetSequenceViews());
+    auto const& view = ViewDefaultChoice->FindString(frame->GetDefaultSeqView());
     if (wxNOT_FOUND != view) {
-        VeiwDefaultChoice->SetSelection(view);
+        ViewDefaultChoice->SetSelection(view);
     }
 
     ValidateWindow();
@@ -416,7 +417,7 @@ void SequenceFileSettingsPanel::OnModelBlendDefaultChoiceSelect(wxCommandEvent& 
     }
 }
 
-void SequenceFileSettingsPanel::OnVeiwDefaultChoiceSelect(wxCommandEvent& event)
+void SequenceFileSettingsPanel::OnViewDefaultChoiceSelect(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/xLights/preferences/SequenceFileSettingsPanel.h
+++ b/xLights/preferences/SequenceFileSettingsPanel.h
@@ -46,7 +46,7 @@ class SequenceFileSettingsPanel: public wxPanel
 		wxChoice* FSEQVersionChoice;
 		wxChoice* ModelBlendDefaultChoice;
 		wxChoice* RenderCacheChoice;
-		wxChoice* VeiwDefaultChoice;
+		wxChoice* ViewDefaultChoice;
 		wxDirPickerCtrl* DirPickerCtrl_FSEQ;
 		wxDirPickerCtrl* DirPickerCtrl_RenderCache;
 		wxListBox* MediaDirectoryList;
@@ -98,7 +98,7 @@ class SequenceFileSettingsPanel: public wxPanel
 		void OnRemoveMediaButtonClick(wxCommandEvent& event);
 		void OnMediaDirectoryListSelect(wxCommandEvent& event);
 		void OnModelBlendDefaultChoiceSelect(wxCommandEvent& event);
-		void OnVeiwDefaultChoiceSelect(wxCommandEvent& event);
+		void OnViewDefaultChoiceSelect(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/SequenceFileSettingsPanel.wxs
+++ b/xLights/wxsmith/SequenceFileSettingsPanel.wxs
@@ -260,7 +260,7 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
-				<object class="wxChoice" name="ID_CHOICE_VIEW_DEFAULT" variable="VeiwDefaultChoice" member="yes" />
+				<object class="wxChoice" name="ID_CHOICE_VIEW_DEFAULT" variable="ViewDefaultChoice" member="yes" />
 				<col>1</col>
 				<row>2</row>
 				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>

--- a/xLights/wxsmith/SequenceFileSettingsPanel.wxs
+++ b/xLights/wxsmith/SequenceFileSettingsPanel.wxs
@@ -260,7 +260,10 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
-				<object class="wxChoice" name="ID_CHOICE_VIEW_DEFAULT" variable="ViewDefaultChoice" member="yes" />
+				<object class="wxChoice" name="ID_CHOICE_VIEW_DEFAULT" variable="ViewDefaultChoice" member="yes">
+					<tooltip>This option is used to select which models will populate the master view when a new sequence is created.</tooltip>
+					<handler function="OnViewDefaultChoiceSelect" entry="EVT_CHOICE" />
+				</object>
 				<col>1</col>
 				<row>2</row>
 				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>


### PR DESCRIPTION
The preference "Default View for New Sequences" does work.
This commit connects the OnViewDefaultChoiceSelect event.

Also fixes a minor spelling error and updates the dialog info to explain
how the master view is created.

Fixes issue #2884