### PR TITLE
Move SketchEffectDialog content into Effect Assist panel

### DIFF
--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -275,6 +275,7 @@
     <ClCompile Include="DissolveTransitionPattern.cpp" />
     <ClCompile Include="DragColoursBitmapButton.cpp" />
     <ClCompile Include="DragValueCurveBitmapButton.cpp" />
+    <ClCompile Include="effects\assist\SketchAssistPanel.cpp" />
     <ClCompile Include="effects\FX.cpp" />
     <ClCompile Include="effects\KaleidoscopeEffect.cpp" />
     <ClCompile Include="effects\KaleidoscopePanel.cpp" />
@@ -284,6 +285,7 @@
     <ClCompile Include="effects\ShaderPanel.cpp" />
     <ClCompile Include="effects\ShapeEffect.cpp" />
     <ClCompile Include="effects\ShapePanel.cpp" />
+    <ClCompile Include="effects\assist\SketchCanvasPanel.cpp" />
     <ClCompile Include="effects\SketchEffect.cpp" />
     <ClCompile Include="effects\SketchEffectDrawing.cpp" />
     <ClCompile Include="effects\SketchPanel.cpp" />
@@ -739,6 +741,7 @@
     <ClInclude Include="DragValueCurveBitmapButton.h" />
     <ClInclude Include="effects\assist\AssistPanel.h" />
     <ClInclude Include="effects\assist\PicturesAssistPanel.h" />
+    <ClInclude Include="effects\assist\SketchAssistPanel.h" />
     <ClInclude Include="effects\assist\xlGridCanvasEmpty.h" />
     <ClInclude Include="effects\assist\xlGridCanvasMorph.h" />
     <ClInclude Include="effects\assist\xlGridCanvasPictures.h" />
@@ -751,6 +754,7 @@
     <ClInclude Include="effects\ShaderPanel.h" />
     <ClInclude Include="effects\ShapeEffect.h" />
     <ClInclude Include="effects\ShapePanel.h" />
+    <ClInclude Include="effects\assist\SketchCanvasPanel.h" />
     <ClInclude Include="effects\SketchEffect.h" />
     <ClInclude Include="effects\SketchEffectDrawing.h" />
     <ClInclude Include="effects\SketchPanel.h" />

--- a/xLights/Xlights.vcxproj.filters
+++ b/xLights/Xlights.vcxproj.filters
@@ -974,6 +974,10 @@
     <ClCompile Include="effects\SketchEffectDrawing.cpp">
       <Filter>Effects</Filter>
     </ClCompile>
+    <ClCompile Include="effects\assist\SketchAssistPanel.cpp" />
+    <ClCompile Include="effects\assist\SketchCanvasPanel.cpp">
+      <Filter>Effects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BatchRenderDialog.h" />
@@ -1952,6 +1956,10 @@
       <Filter>Effects</Filter>
     </ClInclude>
     <ClInclude Include="effects\SketchEffectDrawing.h">
+      <Filter>Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="effects\assist\SketchAssistPanel.h" />
+    <ClInclude Include="effects\assist\SketchCanvasPanel.h">
       <Filter>Effects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xLights/effects/SketchEffect.h
+++ b/xLights/effects/SketchEffect.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "RenderableEffect.h"
-#include "SketchEffectDrawing.h"
 
 class wxImage;
+
+class SketchEffectSketch;
+class SketchPanel;
 
 class SketchEffect : public RenderableEffect
 {
@@ -11,21 +13,34 @@ public:
     SketchEffect( int id );
     virtual ~SketchEffect();
 
-    bool CanBeRandom() override { return false; }
+    bool CanBeRandom() override
+    {
+        return false;
+    }
     void Render( Effect* effect, SettingsMap& settings, RenderBuffer& buffer ) override;
-    bool SupportsLinearColorCurves( const SettingsMap& SettingsMap ) const override { return false; }
+    bool SupportsLinearColorCurves(const SettingsMap& SettingsMap) const override
+    {
+        return false;
+    }
     void SetDefaultParameters() override;
     bool needToAdjustSettings( const std::string& version ) override;
     void adjustSettings( const std::string& version, Effect* effect, bool removeDefaults = true ) override;
     std::list<std::string> CheckEffectSettings( const SettingsMap& settings, AudioManager* media, Model* model, Effect* eff, bool renderCache ) override;
 
+    AssistPanel* GetAssistPanel(wxWindow* parent, xLightsFrame* xl_frame) override;
+    bool HasAssistPanel() override
+    {
+        return true;
+    }
+
 protected:
     void RemoveDefaults( const std::string& version, Effect* effect ) override;
     xlEffectPanel* CreatePanel( wxWindow* parent ) override;
 
-    void renderSketch(wxImage& img, double progress,
-        double drawPercentage, int lineThickness, bool hasMotion, double motionPercentage,
-        const xlColorVector& colors);
+    void renderSketch(const SketchEffectSketch& sketch,
+                      wxImage& img, double progress,
+                      double drawPercentage, int lineThickness, bool hasMotion, double motionPercentage,
+                      const xlColorVector& colors);
 
-    SketchEffectSketch m_sketch;
+    SketchPanel* m_panel = nullptr;
 };

--- a/xLights/effects/SketchPanel.cpp
+++ b/xLights/effects/SketchPanel.cpp
@@ -1,8 +1,8 @@
 #include "SketchPanel.h"
 #include "BulkEditControls.h"
-#include "SketchPathDialog.h"
+//#include "SketchPathDialog.h"
 
-#include <wx/button.h>
+//#include <wx/button.h>
 #include <wx/hyperlink.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -13,12 +13,12 @@ namespace
     const char effectInfoText[] =
         "The sketch effect allows you to trace out a sketch over an image. That sketch "
         "is then drawn over some percentage of the effect. In the remaining percentage, the entire sketch "
-        "is rendered.\n\n"
+        "is rendered. The sketch is defined within the Effect Assist panel.\n\n"
         "Optionally, motion can be enabled, which enables drawing over the full duration of the effect "
         "but renders only a percentage of the effect in order to create simple 'motion graphics' elements. "
         "For more info, see the link below.";
 
-    const char demoVideoURL[] = "https://vimeo.com/694290476";
+    const char demoVideoURL[] = "https://vimeo.com/696352082";
 }
 
 BEGIN_EVENT_TABLE(SketchPanel, wxPanel)
@@ -65,11 +65,12 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
     auto label = new wxStaticText(this, wxID_ANY, "Sketch:");
     TextCtrl_SketchDef = new BulkEditTextCtrl(this, ID_TEXTCTRL_SketchDef, wxEmptyString, wxDefaultPosition, wxDLG_UNIT(this, wxSize(20, -1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_SketchDef"));
     TextCtrl_SketchDef->SetEditable(false);
-    auto defineSketchBtn = new wxButton(this, wxNewId(), "...", wxDefaultPosition, wxDLG_UNIT(this, wxSize(16, -1)));
+    //auto defineSketchBtn = new wxButton(this, wxNewId(), "...", wxDefaultPosition, wxDLG_UNIT(this, wxSize(16, -1)));
 
     sketchDefSizer->Add(label, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
     sketchDefSizer->Add(TextCtrl_SketchDef, 1, wxALL | wxEXPAND, 2);
-    sketchDefSizer->Add(defineSketchBtn, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 2);
+    //sketchDefSizer->Add(defineSketchBtn, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 2);
+    sketchDefSizer->AddStretchSpacer();
 
     // Draw Percentage
     auto label2 = new wxStaticText(this, wxID_ANY, "Draw Percentage:");
@@ -120,7 +121,7 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
 
     SetName("ID_PANEL_SKETCH");
 
-	Connect(defineSketchBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchPanel::OnButton_DefineSketch);
+	//Connect(defineSketchBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchPanel::OnButton_DefineSketch);
 
     Connect(ID_VALUECURVE_Thickness, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchPanel::OnVCButtonClick);
 
@@ -135,13 +136,13 @@ void SketchPanel::ValidateWindow()
 
 }
 
-void SketchPanel::OnButton_DefineSketch(wxCommandEvent& /*event*/)
-{
-    SketchPathDialog dlg(this);
-    dlg.setSketch(TextCtrl_SketchDef->GetValue());
-
-    if ( dlg.ShowModal() == wxID_OK ) {
-        std::string sketchDef(dlg.sketchDefString());
-        TextCtrl_SketchDef->SetValue(sketchDef);
-    }
-}
+//void SketchPanel::OnButton_DefineSketch(wxCommandEvent& /*event*/)
+//{
+//    SketchPathDialog dlg(this);
+//    dlg.setSketch(TextCtrl_SketchDef->GetValue());
+//
+//    if ( dlg.ShowModal() == wxID_OK ) {
+//        std::string sketchDef(dlg.sketchDefString());
+//        TextCtrl_SketchDef->SetValue(sketchDef);
+//    }
+//}

--- a/xLights/effects/assist/AssistPanel.cpp
+++ b/xLights/effects/assist/AssistPanel.cpp
@@ -14,6 +14,7 @@
 //*)
 
 #include "AssistPanel.h"
+#include "SketchAssistPanel.h"
 #include "../../xLightsMain.h"
 #include "../../models/Model.h"
 #include "../../sequencer/Element.h"
@@ -90,11 +91,13 @@ void AssistPanel::SetGridCanvas(xlGridCanvas* canvas)
     FlexGridSizer2->SetSizeHints(ScrolledWindowAssist);
 }
 
-void AssistPanel::AddPanel(wxPanel* panel)
+void AssistPanel::AddPanel(wxPanel* panel, std::optional<int> panelFlags /*=std::nullopt*/)
 {
+    int flags = panelFlags.value_or(wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
+
     mPanel = panel;
     FlexGridSizer2->SetCols(2);
-    FlexGridSizer2->Add(mPanel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+    FlexGridSizer2->Add(mPanel, 1, flags, 2);
     FlexGridSizer2->Fit(ScrolledWindowAssist);
     FlexGridSizer2->SetSizeHints(ScrolledWindowAssist);
     SetHandlers(this);
@@ -189,7 +192,7 @@ void AssistPanel::OnCharHook(wxKeyEvent& event)
 {
     if (mEffect != nullptr)
     {
-        if( mEffect->GetEffectIndex() == EffectManager::eff_PICTURES )
+        if ( mEffect->GetEffectIndex() == EffectManager::eff_PICTURES )
         {
             wxChar uc = event.GetUnicodeKey();
             switch(uc)
@@ -240,6 +243,10 @@ void AssistPanel::OnCharHook(wxKeyEvent& event)
                     event.Skip();
                     break;
             }
+        } else if (mEffect->GetEffectIndex() == EffectManager::eff_SKETCH) {
+            auto sketchAssistPanel = dynamic_cast<SketchAssistPanel *>(mPanel);
+            if (sketchAssistPanel != nullptr)
+                sketchAssistPanel->ForwardKeyEvent(event);
         }
     }
 }

--- a/xLights/effects/assist/AssistPanel.h
+++ b/xLights/effects/assist/AssistPanel.h
@@ -18,6 +18,8 @@
 
 #include "../../xlGridCanvas.h"
 
+#include <optional>
+
 class xLightsFrame;
 class Model;
 
@@ -33,7 +35,7 @@ class AssistPanel: public wxPanel
         void SetGridCanvas(xlGridCanvas* canvas);
         void SetEffectInfo(Effect* effect_, xLightsFrame* xlights_parent);
         void RefreshEffect();
-        void AddPanel(wxPanel* panel);
+        void AddPanel(wxPanel* panel, std::optional<int> panelFlags=std::nullopt);
 
 		//(*Declarations(AssistPanel)
 		wxFlexGridSizer* FlexGridSizer1;

--- a/xLights/effects/assist/SketchAssistPanel.cpp
+++ b/xLights/effects/assist/SketchAssistPanel.cpp
@@ -1,0 +1,282 @@
+#include "SketchAssistPanel.h"
+#include "SketchCanvasPanel.h"
+
+#include <wx/filepicker.h>
+#include <wx/listbox.h>
+#include <wx/menu.h>
+#include <wx/sizer.h>
+#include <wx/slider.h>
+#include <wx/statbox.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+namespace
+{
+    const wxString imgSelect("Select an image file");
+    const wxString imgFilters(" *.jpg; *.gif; *.png; *.bmp; *.jpeg");
+
+    const char HotkeysText[] =
+        "Shift\tToggle segment type (line, one-point curve, two-point curve)\n"
+        "Esc\tEnd current path\n"
+        "Space\tClose current path\n"
+        "Delete\tDelete point/segment\n\n"
+        "Use mouse wheel and middle button to zoom and pan on sketch";
+}
+
+BEGIN_EVENT_TABLE(SketchAssistPanel, wxPanel)
+END_EVENT_TABLE()
+
+long SketchAssistPanel::ID_MENU_Delete = wxNewId();
+
+SketchAssistPanel::SketchAssistPanel(wxWindow* parent, wxWindowID id /*wxID_ANY*/, const wxPoint& pos /*wxDefaultPosition*/, const wxSize& size /*wxDefaultSize*/) :
+    wxPanel(parent, id, pos, size)
+{
+    /*
+ 
+    mainSizer
+     \
+      pathUISizer (canvas, bg-image controls, and path/sketch controls)
+      |\
+      | canvasFrame (m_sketchCanvasPanel)
+      |\
+      | bgSizer (m_filePicker, m_bgAlphaSlider)
+      |
+      |\
+      | pathSketchCtrlsSizer
+      | |\
+      | | pathCtrlsSizer (m_startPathBtn, m_endPathBtn, m_closePathBtn)
+      | |
+      |  \
+      |   sketchCtrlsSizer ("Clear" sketch button)
+      |
+      sketchUISizer (hotkeys text and paths listbox)
+      |\
+      | hotkeysSizer (Canvas hotkeys)
+      |
+      |\
+      | pathsSizer (m_pathsListBox)
+
+    */
+    auto mainSizer = new wxFlexGridSizer(3, 1, 0, 0);
+    mainSizer->AddGrowableCol(0);
+    mainSizer->AddGrowableRow(0);
+
+    auto pathUISizer = new wxFlexGridSizer(3, 1, 5, 0);
+    pathUISizer->AddGrowableRow(0);
+    pathUISizer->AddGrowableCol(0);
+
+    auto bgSizer = new wxFlexGridSizer(1, 3, 0, 0);
+    bgSizer->AddGrowableCol(1);
+
+    auto pathSketchCtrlsSizer = new wxFlexGridSizer(1, 3, 0, 5);
+    auto sketchCtrlsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Sketch");
+
+    auto sketchUISizer = new wxFlexGridSizer(2, 1, 5, 0);
+    sketchUISizer->AddGrowableRow(1);
+    sketchUISizer->AddGrowableCol(0);
+
+    auto hotkeysSizer = new wxStaticBoxSizer(wxVERTICAL, this, "Canvas hotkeys");
+    auto pathsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Paths");
+
+    // canvas
+    auto canvasFrame = new wxStaticBox(this, wxID_ANY, wxEmptyString);
+    auto canvasFrameSizer = new wxFlexGridSizer(1, 1, 0, 0);
+    canvasFrameSizer->AddGrowableRow(0);
+    canvasFrameSizer->AddGrowableCol(0);
+    m_sketchCanvasPanel = new SketchCanvasPanel(this, canvasFrame, wxID_ANY, wxDefaultPosition, wxSize(400, 300));
+    canvasFrameSizer->Add(m_sketchCanvasPanel, 1, wxALL | wxEXPAND);
+    canvasFrame->SetSizer(canvasFrameSizer);
+
+    // background image controls
+    auto bgLabel = new wxStaticText(this, wxID_ANY, "Background:");
+    m_filePicker = new wxFilePickerCtrl(this, wxID_ANY, wxEmptyString, imgSelect, imgFilters, wxDefaultPosition, wxDefaultSize, wxFLP_FILE_MUST_EXIST | wxFLP_OPEN | wxFLP_USE_TEXTCTRL);
+    m_filePicker->GetTextCtrl()->SetEditable(false);
+    m_bgAlphaSlider = new wxSlider(this, wxID_ANY, m_bitmapAlpha, 0x00, 0xff);
+
+    bgSizer->Add(bgLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    bgSizer->Add(m_filePicker, 1, wxALL | wxEXPAND, 2);
+    bgSizer->Add(m_bgAlphaSlider, 1, wxALL | wxEXPAND, 2);
+
+    // path / sketch controls
+    m_startPathBtn = new wxButton(this, wxID_ANY, "Start");
+    m_endPathBtn = new wxButton(this, wxID_ANY, "End");
+    m_closePathBtn = new wxButton(this, wxID_ANY, "Close");
+    auto clearSketchBtn = new wxButton(this, wxID_ANY, "Clear");
+
+    auto pathCtrlsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Path");
+    pathCtrlsSizer->Add(m_startPathBtn, 1, wxALL | wxEXPAND, 3);
+    pathCtrlsSizer->Add(m_endPathBtn, 1, wxALL | wxEXPAND, 3);
+    pathCtrlsSizer->Add(m_closePathBtn, 1, wxALL | wxEXPAND, 3);
+
+    sketchCtrlsSizer->Add(clearSketchBtn, 1, wxALL | wxEXPAND, 3);
+
+    pathSketchCtrlsSizer->AddGrowableCol(2);
+    pathSketchCtrlsSizer->Add(pathCtrlsSizer, 1, wxALL, 2);
+    pathSketchCtrlsSizer->Add(sketchCtrlsSizer, 1, wxALL, 2);
+
+    // Hotkeys text
+    hotkeysSizer->Add(new wxStaticText(hotkeysSizer->GetStaticBox(), wxID_ANY, HotkeysText), 1, wxALL | wxEXPAND, 3);
+
+    // Paths ListBox
+    m_pathsListBox = new wxListBox(this, wxID_ANY);
+    pathsSizer->Add(m_pathsListBox, 1, wxALL | wxEXPAND, 3);
+
+    sketchUISizer->Add(hotkeysSizer, 1, wxALL | wxEXPAND);
+    sketchUISizer->Add(pathsSizer, 1, wxALL | wxEXPAND, 5);
+
+    pathUISizer->Add(canvasFrame, 1, wxALL | wxEXPAND, 5);
+    pathUISizer->Add(bgSizer, 1, wxALL | wxEXPAND);
+    pathUISizer->Add(pathSketchCtrlsSizer, 1, wxALL | wxEXPAND, 5);
+
+    mainSizer->Add(pathUISizer, 1, wxALL | wxEXPAND, 5);
+    mainSizer->Add(sketchUISizer, 1, wxALL | wxEXPAND, 5);
+
+    SetSizer(mainSizer);
+
+    Connect(m_filePicker->GetId(), wxEVT_COMMAND_FILEPICKER_CHANGED, (wxObjectEventFunction)&SketchAssistPanel::OnFilePickerCtrl_FileChanged);
+    Connect(m_bgAlphaSlider->GetId(), wxEVT_COMMAND_SLIDER_UPDATED, (wxObjectEventFunction)&SketchAssistPanel::OnSlider_BgAlphaChanged);
+
+    Connect(m_startPathBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_StartPath);
+    Connect(m_endPathBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_EndPath);
+    Connect(m_closePathBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_ClosePath);
+    Connect(clearSketchBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_ClearSketch);
+
+    m_pathsListBox->Connect(wxEVT_LISTBOX, (wxObjectEventFunction)&SketchAssistPanel::OnListBox_PathSelected, nullptr, this);
+    m_pathsListBox->Connect(wxEVT_CONTEXT_MENU, (wxObjectEventFunction)&SketchAssistPanel::OnListBox_ContextMenu, nullptr, this);
+
+    m_sketchCanvasPanel->UpdatePathState(SketchCanvasPanel::Undefined);
+}
+
+void SketchAssistPanel::SetSketchDef(const std::string& sketchDef)
+{
+    if ( sketchDef != m_sketchDef) {
+        m_sketchDef = sketchDef;
+        m_sketch = SketchEffectSketch::SketchFromString(m_sketchDef);
+        updateUIFromSketch();
+        Refresh();
+    }
+}
+
+void SketchAssistPanel::ForwardKeyEvent(wxKeyEvent& event)
+{
+    if (m_sketchCanvasPanel != nullptr)
+        m_sketchCanvasPanel->OnSketchKeyDown(event);
+}
+
+void SketchAssistPanel::OnFilePickerCtrl_FileChanged(wxCommandEvent& /*event*/)
+{
+    wxImage img(m_filePicker->GetFileName().GetFullPath());
+    if (img.IsOk()) {
+        if (!img.HasAlpha())
+            img.InitAlpha();
+
+        m_bgImage = img;
+        updateBgImage();
+    }
+}
+
+void SketchAssistPanel::OnSlider_BgAlphaChanged(wxCommandEvent& event)
+{
+    m_bitmapAlpha = static_cast<unsigned char>(m_bgAlphaSlider->GetValue());
+    updateBgImage();
+}
+void SketchAssistPanel::OnButton_StartPath(wxCommandEvent& /*event*/)
+{
+    m_sketchCanvasPanel->ResetHandlesState(SketchCanvasPanel::DefineStartPoint);
+
+    m_pathsListBox->DeselectAll();
+}
+
+void SketchAssistPanel::OnButton_EndPath(wxCommandEvent& /*event*/)
+{
+    m_sketchCanvasPanel->UpdatePathState(SketchCanvasPanel::Undefined);
+    sketchUpdatedFromCanvasPanel();
+}
+
+void SketchAssistPanel::OnButton_ClosePath(wxCommandEvent& /*event*/)
+{
+    m_sketchCanvasPanel->ClosePath();
+    m_sketchCanvasPanel->UpdatePathState(SketchCanvasPanel::Undefined);
+    sketchUpdatedFromCanvasPanel();
+}
+
+void SketchAssistPanel::OnButton_ClearSketch(wxCommandEvent& /*event*/)
+{
+    m_sketch = SketchEffectSketch();
+
+    m_pathsListBox->Clear();
+
+    m_sketchCanvasPanel->ResetHandlesState();
+    sketchUpdatedFromCanvasPanel();
+}
+
+void SketchAssistPanel::OnListBox_PathSelected(wxCommandEvent& /*event*/)
+{
+    m_sketchCanvasPanel->UpdateHandlesForPath(m_pathsListBox->GetSelection());
+}
+
+void SketchAssistPanel::OnListBox_ContextMenu(wxContextMenuEvent& event)
+{
+    wxPoint pt(m_pathsListBox->ScreenToClient(event.GetPosition()));
+    m_pathIndexToDelete = m_pathsListBox->HitTest(pt);
+    if (m_pathIndexToDelete < 0)
+        return;
+
+    wxString str;
+    str.sprintf("Delete Path %d", 1 + m_pathIndexToDelete);
+
+    wxMenu mnu;
+    mnu.Append(ID_MENU_Delete, str);
+    mnu.Connect(wxEVT_MENU, (wxObjectEventFunction)&SketchAssistPanel::OnPopupCommand, nullptr, this);
+    PopupMenu(&mnu);
+}
+
+void SketchAssistPanel::OnPopupCommand(wxCommandEvent& event)
+{
+    if (event.GetId() == ID_MENU_Delete && m_pathIndexToDelete < m_sketch.pathCount()) {
+        m_sketch.deletePath(m_pathIndexToDelete);
+
+        m_sketchCanvasPanel->ResetHandlesState();
+
+        populatePathListBoxFromSketch();
+        sketchUpdatedFromCanvasPanel();
+    }
+}
+
+void SketchAssistPanel::updateBgImage()
+{
+    if (!m_bgImage.IsOk())
+        return;
+
+    int w = m_bgImage.GetWidth();
+    int h = m_bgImage.GetHeight();
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x)
+            m_bgImage.SetAlpha(x, y, m_bitmapAlpha);
+
+    m_sketchCanvasPanel->setBackgroundBitmap(std::make_unique<wxBitmap>(m_bgImage));
+}
+
+void SketchAssistPanel::updateUIFromSketch()
+{
+    populatePathListBoxFromSketch();
+}
+
+void SketchAssistPanel::populatePathListBoxFromSketch()
+{
+    m_pathsListBox->Clear();
+
+    int i = 0;
+    for (const auto& path : m_sketch.paths()) {
+        wxString text;
+        text.sprintf("Path %d", i + 1);
+        m_pathsListBox->Insert(text, i++);
+    }
+}
+
+void SketchAssistPanel::sketchUpdatedFromCanvasPanel()
+{
+    m_sketchDef = m_sketch.toString();
+    if (m_sketchUpdateCB != nullptr)
+        m_sketchUpdateCB(m_sketchDef);
+}

--- a/xLights/effects/assist/SketchAssistPanel.h
+++ b/xLights/effects/assist/SketchAssistPanel.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "../SketchEffectDrawing.h"
+
+#include <functional>
+#include <string>
+
+#include <wx/image.h>
+#include <wx/panel.h>
+
+class wxButton;
+class wxFilePickerCtrl;
+class wxKeyEvent;
+class wxListBox;
+class wxSlider;
+
+class SketchCanvasPanel;
+
+class SketchAssistPanel : public wxPanel
+{
+public:
+    // Effect panels are static (a single panel for the lifetime of the app) but
+    // assist panels are not... so it seems like it should be safe for an assist
+    // panel to reference an effect panel via a lambda 'this' capture
+    typedef std::function<void(const std::string&)> SketchUpdateCallback;
+
+    SketchAssistPanel(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+    virtual ~SketchAssistPanel() = default;
+
+    void SetSketchDef(const std::string& sketchDef);
+    void SetSketchUpdateCallback(SketchUpdateCallback cb)
+    {
+        m_sketchUpdateCB = cb;
+    }
+
+    void ForwardKeyEvent(wxKeyEvent& event);
+
+private:
+    DECLARE_EVENT_TABLE()
+
+    void OnFilePickerCtrl_FileChanged(wxCommandEvent& event);
+    void OnSlider_BgAlphaChanged(wxCommandEvent& event);
+
+    void OnButton_StartPath(wxCommandEvent& event);
+    void OnButton_EndPath(wxCommandEvent& event);
+    void OnButton_ClosePath(wxCommandEvent& event);
+    void OnButton_ClearSketch(wxCommandEvent& event);
+
+    void OnListBox_PathSelected(wxCommandEvent& event);
+    void OnListBox_ContextMenu(wxContextMenuEvent& event);
+    void OnPopupCommand(wxCommandEvent& event);
+
+    void updateBgImage();
+    void updateUIFromSketch();
+    void populatePathListBoxFromSketch();
+    void sketchUpdatedFromCanvasPanel();
+
+    std::string m_sketchDef;
+    SketchEffectSketch m_sketch;
+    SketchUpdateCallback m_sketchUpdateCB;
+
+    SketchCanvasPanel* m_sketchCanvasPanel = nullptr;
+    wxFilePickerCtrl* m_filePicker = nullptr;
+    wxSlider* m_bgAlphaSlider = nullptr;
+    wxButton* m_startPathBtn = nullptr;
+    wxButton* m_endPathBtn = nullptr;
+    wxButton* m_closePathBtn = nullptr;
+    wxListBox* m_pathsListBox = nullptr;
+    static long ID_MENU_Delete;
+
+    wxImage m_bgImage;
+    unsigned char m_bitmapAlpha = 0x30;
+    int m_pathIndexToDelete = -1;
+
+    friend class SketchCanvasPanel;
+};

--- a/xLights/effects/assist/SketchCanvasPanel.cpp
+++ b/xLights/effects/assist/SketchCanvasPanel.cpp
@@ -1,0 +1,645 @@
+#include "SketchCanvasPanel.h"
+#include "../assist/SketchAssistPanel.h"
+
+#include <wx/dcbuffer.h>
+#include <wx/filepicker.h>
+#include <wx/graphics.h>
+#include <wx/listbox.h>
+
+namespace
+{
+    const int BorderWidth = 5;
+ 
+    const int MouseWheelLimit = 1440;
+
+    struct LinearInterpolater {
+        double operator()(double t) const
+        {
+            return t;
+        }
+    };
+
+    template<class T>
+    double interpolate(double x, double loIn, double loOut, double hiIn, double hiOut, const T& interpolater)
+    {
+        return (loIn != hiIn)
+                   ? (loOut + (hiOut - loOut) * interpolater((x - loIn) / (hiIn - loIn)))
+                   : ((loOut + hiOut) / 2);
+    }
+}
+
+BEGIN_EVENT_TABLE(SketchCanvasPanel, wxPanel)
+    EVT_PAINT(SketchCanvasPanel::OnSketchPaint)
+    EVT_KEY_DOWN(SketchCanvasPanel::OnSketchKeyDown)
+    EVT_LEFT_DOWN(SketchCanvasPanel::OnSketchLeftDown)
+    EVT_LEFT_UP(SketchCanvasPanel::OnSketchLeftUp)
+    EVT_MOTION(SketchCanvasPanel::OnSketchMouseMove)
+    EVT_ENTER_WINDOW(SketchCanvasPanel::OnSketchEntered)
+    EVT_MOUSEWHEEL(SketchCanvasPanel::OnSketchMouseWheel)
+    EVT_MIDDLE_DOWN(SketchCanvasPanel::OnSketchMidDown)
+END_EVENT_TABLE()
+
+
+SketchCanvasPanel::SketchCanvasPanel(SketchAssistPanel* parentPanel, wxWindow*parent, wxWindowID id /*=wxID_ANY*/, const wxPoint& pos /*= wxDefaultPosition*/, const wxSize& size /*=wxDefaultSize*/) :
+    wxPanel(parent, id, pos, size, wxNO_BORDER | wxWANTS_CHARS),
+    m_parentPanel(parentPanel)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+void SketchCanvasPanel::OnSketchPaint(wxPaintEvent& /*event*/)
+{
+    wxAutoBufferedPaintDC pdc(this);
+    wxSize sz(GetSize());
+    wxRect borderRect(BorderWidth, BorderWidth, sz.GetWidth() - 2 * BorderWidth - 2, sz.GetHeight() - 2 * BorderWidth - 2);
+    wxRect bgRect(wxRect(borderRect).Deflate(1, 1));
+
+    pdc.SetPen(*wxWHITE_PEN);
+    pdc.SetBrush(*wxWHITE_BRUSH);
+    pdc.DrawRectangle(wxPoint(0, 0), sz);
+
+    pdc.SetPen(*wxLIGHT_GREY_PEN);
+    pdc.DrawRectangle(borderRect);
+
+    {
+        std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(pdc));
+        double zoomLevel = 1.;
+        if (m_wheelRotation) {
+            zoomLevel = interpolate(m_wheelRotation, 0, 1., MouseWheelLimit, 8., LinearInterpolater());
+            wxGraphicsMatrix m = gc->CreateMatrix();
+            wxPoint2DDouble pt(NormalizedToUI(m_normalizedZoomPt));
+            m.Translate(-m_canvasTranslation.m_x, -m_canvasTranslation.m_y);
+            m.Translate(pt.m_x, pt.m_y);
+            m.Scale(zoomLevel, zoomLevel);
+            m.Translate(-pt.m_x, -pt.m_y);
+            gc->SetTransform(m);
+
+            m.Get(m_matrixComponents, m_matrixComponents + 1, m_matrixComponents + 2,
+                  m_matrixComponents + 3, m_matrixComponents + 4, m_matrixComponents + 5);
+        }
+
+
+        // First, draw the background
+        if (m_bgBitmap != nullptr)
+            gc->DrawBitmap(*(m_bgBitmap.get()), bgRect.x, bgRect.y, bgRect.width, bgRect.height);
+
+        // Next, draw the unselected path(s)
+        wxGraphicsPen pen = gc->CreatePen(wxGraphicsPenInfo(*wxLIGHT_GREY, 1. / zoomLevel));
+        gc->SetPen(pen);
+
+        long selectedPathIndex = m_parentPanel->m_pathsListBox->GetSelection();
+        long pathIndex = 0;
+        for (const auto& path : m_parentPanel->m_sketch.paths()) {
+            if (pathIndex++ == selectedPathIndex)
+                continue;
+            wxGraphicsPath graphicsPath(gc->CreatePath());
+            const auto& firstSegment(path->segments().front());
+            wxPoint2DDouble startPt(NormalizedToUI(firstSegment->StartPoint()));
+            graphicsPath.MoveToPoint(startPt);
+
+            for (const auto& segment : path->segments()) {
+                std::shared_ptr<SketchQuadraticBezier> quadratic;
+                std::shared_ptr<SketchCubicBezier> cubic;
+
+                if (std::dynamic_pointer_cast<SketchLine>(segment) != nullptr) {
+                    graphicsPath.AddLineToPoint(NormalizedToUI(segment->EndPoint()));
+                } else if ((quadratic = std::dynamic_pointer_cast<SketchQuadraticBezier>(segment)) != nullptr) {
+                    wxPoint2DDouble ctrlPt(NormalizedToUI(quadratic->ControlPoint()));
+                    wxPoint2DDouble endPt(NormalizedToUI(quadratic->EndPoint()));
+                    graphicsPath.AddQuadCurveToPoint(ctrlPt.m_x, ctrlPt.m_y, endPt.m_x, endPt.m_y);
+                } else if ((cubic = std::dynamic_pointer_cast<SketchCubicBezier>(segment)) != nullptr) {
+                    wxPoint2DDouble ctrlPt1(NormalizedToUI(cubic->ControlPoint1()));
+                    wxPoint2DDouble ctrlPt2(NormalizedToUI(cubic->ControlPoint2()));
+                    wxPoint2DDouble endPt(NormalizedToUI(cubic->EndPoint()));
+                    graphicsPath.AddCurveToPoint(ctrlPt1, ctrlPt2, endPt);
+                }
+            }
+            if (path->isClosed())
+                graphicsPath.CloseSubpath();
+
+            gc->DrawPath(graphicsPath);
+        }
+
+        // Next, draw the selected path
+        pen = gc->CreatePen(wxGraphicsPenInfo(*wxBLACK, 1. / zoomLevel));
+        gc->SetPen(pen);
+        std::vector<wxPoint>::size_type n = m_handles.size();
+        wxGraphicsPath path(gc->CreatePath());
+        for (std::vector<wxPoint>::size_type i = 0; i < n; ++i) {
+            wxPoint2DDouble pt(NormalizedToUI(m_handles[i].pt));
+            if (i == 0)
+                path.MoveToPoint(pt);
+            else if (m_handles[i].handlePointType == Point)
+                path.AddLineToPoint(pt);
+            else if (m_handles[i].handlePointType == QuadraticControlPt) {
+                auto endPt = NormalizedToUI(m_handles[i + 1].pt);
+                path.AddQuadCurveToPoint(pt.m_x, pt.m_y, endPt.m_x, endPt.m_y);
+                i += 1;
+            } else if (m_handles[i].handlePointType == CubicControlPt1) {
+                auto cp2 = NormalizedToUI(m_handles[i + 1].pt);
+                auto endPt = NormalizedToUI(m_handles[i + 2].pt);
+                path.AddCurveToPoint(pt, cp2, endPt);
+                i += 2;
+            }
+        }
+
+        if (m_pathClosed && m_handles.size() > 2)
+            path.CloseSubpath();
+        gc->DrawPath(path);
+
+        // Next, if we are in a segment-adding state, draw that potential segment
+        if ((m_pathState == LineToNewPoint || m_pathState == QuadraticCurveToNewPoint || m_pathState == CubicCurveToNewPoint) && !m_handles.empty()) {
+            switch (m_pathState) {
+            case LineToNewPoint:
+                pen = gc->CreatePen(wxGraphicsPenInfo(*wxBLACK, 2. / zoomLevel, wxPENSTYLE_SHORT_DASH));
+                break;
+            case QuadraticCurveToNewPoint:
+                pen = gc->CreatePen(wxGraphicsPenInfo(*wxRED, 2. / zoomLevel, wxPENSTYLE_SHORT_DASH));
+                break;
+            case CubicCurveToNewPoint:
+                pen = gc->CreatePen(wxGraphicsPenInfo(*wxBLUE, 2. / zoomLevel, wxPENSTYLE_SHORT_DASH));
+                break;
+            }
+            gc->SetPen(pen);
+
+            wxAffineMatrix2D m;
+            if (m_wheelRotation) {
+                wxMatrix2D m2d(m_matrixComponents[0], m_matrixComponents[1],
+                               m_matrixComponents[2], m_matrixComponents[3]);
+                wxPoint2DDouble mt(m_matrixComponents[4], m_matrixComponents[5]);
+                m.Set(m2d, mt);
+                m.Invert();
+            }
+
+            auto ptFrom = NormalizedToUI(m_handles.back().pt);
+            auto ptTo(m.TransformPoint(m_mousePos));
+            gc->StrokeLine(ptFrom.m_x, ptFrom.m_y, ptTo.m_x, ptTo.m_y);
+
+            pen = gc->CreatePen(wxGraphicsPenInfo(*wxBLACK, 1. / zoomLevel, wxPENSTYLE_SOLID));
+            gc->SetPen(pen);
+        }
+
+        // Finally, draw the handles
+        for (std::vector<wxPoint>::size_type i = 0; i < n; ++i) {
+            wxPoint2DDouble pt(NormalizedToUI(m_handles[i].pt));
+            if (i == 0 && !m_handles[i].state)
+                gc->SetBrush(*wxGREEN_BRUSH);
+            else if (i == n - 1 && !m_handles[i].state)
+                gc->SetBrush(*wxRED_BRUSH);
+            else
+                gc->SetBrush((m_handles[i].state) ? (*wxYELLOW_BRUSH)
+                                                  : (IsControlPoint(m_handles[i]) ? (*wxBLUE_BRUSH) : (*wxLIGHT_GREY_BRUSH)));
+
+            gc->DrawEllipse(pt.m_x - 4.5 / zoomLevel, pt.m_y - 4.5 / zoomLevel, 9 / zoomLevel, 9 / zoomLevel);
+        }
+    }
+}
+
+void SketchCanvasPanel::OnSketchKeyDown(wxKeyEvent& event)
+{
+    int keycode = event.GetKeyCode();
+    if (keycode == WXK_DELETE && (m_pathState == Undefined || m_pathState == DefineStartPoint)) {
+        int pathIndex = m_parentPanel->m_pathsListBox->GetSelection();
+        std::optional<std::pair<int, int>> toErase;
+        int index = 0;
+        for (auto iter = m_handles.begin(); iter != m_handles.end(); ++iter, ++index) {
+            if (iter->state) {
+                switch (iter->handlePointType) {
+                case Point:
+                    toErase = std::make_pair(index, 1);
+                    break;
+                case QuadraticControlPt:
+                    toErase = std::make_pair(index, 2);
+                    break;
+                case QuadraticCurveEnd:
+                    toErase = std::make_pair(index - 1, 2);
+                    break;
+                case CubicControlPt1:
+                    toErase = std::make_pair(index, 3);
+                    break;
+                case CubicControlPt2:
+                    toErase = std::make_pair(index - 1, 3);
+                    break;
+                case CubicCurveEnd:
+                    toErase = std::make_pair(index - 2, 3);
+                    break;
+                }
+                break;
+            }
+        }
+        if (toErase.has_value()) {
+            auto startIter = m_handles.cbegin();
+            auto endIter = m_handles.cbegin();
+            auto p = toErase.value();
+            std::advance(startIter, p.first);
+            std::advance(endIter, p.second + p.first);
+            m_handles.erase(startIter, endIter);
+            if (m_handles.size() == 1)
+                m_handles.clear();
+
+            if (m_handles.empty()) {
+                SketchEffectSketch& sketch(m_parentPanel->m_sketch);
+                sketch.deletePath(pathIndex);
+                m_parentPanel->sketchUpdatedFromCanvasPanel();
+                m_parentPanel->populatePathListBoxFromSketch();
+            } else
+                UpdatePathFromHandles();
+        }
+
+        Refresh();
+    } else if (keycode == WXK_ESCAPE) {
+        UpdatePathState(Undefined);
+        m_parentPanel->sketchUpdatedFromCanvasPanel();
+    } else if (keycode == WXK_SPACE) {
+        m_pathClosed = true;
+        UpdatePathState(Undefined);
+        m_parentPanel->sketchUpdatedFromCanvasPanel();
+    } else if (keycode == WXK_SHIFT) {
+        switch (m_pathState) {
+        case LineToNewPoint:
+            m_pathState = QuadraticCurveToNewPoint;
+            break;
+        case QuadraticCurveToNewPoint:
+            m_pathState = CubicCurveToNewPoint;
+            break;
+        case CubicCurveToNewPoint:
+            m_pathState = LineToNewPoint;
+            break;
+        }
+        Refresh();
+    }
+}
+
+void SketchCanvasPanel::OnSketchLeftDown(wxMouseEvent& event)
+{
+    wxAffineMatrix2D m;
+    if (m_wheelRotation) {
+        wxMatrix2D m2d(m_matrixComponents[0], m_matrixComponents[1],
+                       m_matrixComponents[2], m_matrixComponents[3]);
+        wxPoint2DDouble mt(m_matrixComponents[4], m_matrixComponents[5]);
+        m.Set(m2d, mt);
+        m.Invert();
+    }
+    wxPoint2DDouble ptUI(m.TransformPoint(event.GetPosition()));
+    wxPoint2DDouble pt(UItoNormalized(ptUI));
+
+    // Defining-new-segment stuff
+    if (m_pathState == DefineStartPoint) {
+        m_handles.push_back(pt);
+        UpdatePathState(LineToNewPoint);
+        return;
+    } else if (m_pathState == LineToNewPoint) {
+        m_handles.push_back(pt);
+        Refresh();
+        return;
+    } else if (m_pathState == QuadraticCurveToNewPoint) {
+        wxPoint2DDouble startPt = m_handles.back().pt;
+        wxPoint2DDouble endPt = pt;
+        wxPoint2DDouble cp = 0.5 * startPt + 0.5 * endPt;
+
+        m_handles.push_back(HandlePoint(cp, QuadraticControlPt));
+        m_handles.push_back(HandlePoint(endPt, QuadraticCurveEnd));
+        Refresh();
+        return;
+    } else if (m_pathState == CubicCurveToNewPoint) {
+        wxPoint2DDouble startPt = m_handles.back().pt;
+        wxPoint2DDouble endPt = pt;
+        wxPoint2DDouble cp1 = 0.75 * startPt + 0.25 * endPt;
+        wxPoint2DDouble cp2 = 0.25 * startPt + 0.75 * endPt;
+
+        m_handles.push_back(HandlePoint(cp1, CubicControlPt1));
+        m_handles.push_back(HandlePoint(cp2, CubicControlPt2));
+        m_handles.push_back(HandlePoint(endPt, CubicCurveEnd));
+        Refresh();
+        return;
+    }
+
+    // Updating 'grabbed' handle
+    for (std::vector<HandlePoint>::size_type i = 0; i < m_handles.size(); ++i) {
+        if (m_handles[i].state) {
+            m_grabbedHandleIndex = i;
+            break;
+        }
+    }
+}
+
+void SketchCanvasPanel::OnSketchLeftUp(wxMouseEvent& /*event*/)
+{
+    if (m_grabbedHandleIndex != -1) {
+        UpdatePathFromHandles(m_grabbedHandleIndex);
+        // temp for debugging handles-path synchronization
+        // UpdateHandlesForPath(m_pathsListView->GetFirstSelected());
+    }
+
+    m_grabbedHandleIndex = -1;
+}
+
+void SketchCanvasPanel::OnSketchMouseMove(wxMouseEvent& event)
+{
+    // handling drag of canvas as a special case for now...
+    if (event.ButtonIsDown(wxMOUSE_BTN_MIDDLE)) {
+        m_canvasTranslation += m_mousePos - event.GetPosition();
+        m_mousePos = event.GetPosition();
+        Refresh();
+        return;
+    }
+
+    m_mousePos = event.GetPosition();
+
+    if (m_pathState == LineToNewPoint || m_pathState == QuadraticCurveToNewPoint || m_pathState == CubicCurveToNewPoint) {
+        Refresh();
+        return;
+    }
+
+    wxAffineMatrix2D m;
+    if (m_wheelRotation) {
+        wxMatrix2D m2d(m_matrixComponents[0], m_matrixComponents[1],
+                       m_matrixComponents[2], m_matrixComponents[3]);
+        wxPoint2DDouble mt(m_matrixComponents[4], m_matrixComponents[5]);
+        m.Set(m2d, mt);
+    }
+
+    if (m_grabbedHandleIndex != -1) {
+        m.Invert();
+        m_handles[m_grabbedHandleIndex].pt = UItoNormalized(m.TransformPoint(m_mousePos));
+        Refresh();
+    } else {
+        bool somethingChanged = false;
+        for (auto& handle : m_handles) {
+            wxPoint2DDouble handlePos(NormalizedToUI(handle.pt));
+            wxPoint2DDouble transformedHandlePos(m.TransformPoint(handlePos));
+            bool state = m_mousePos.GetDistanceSquare(transformedHandlePos) <= 20.25;
+            if (state != handle.state) {
+                handle.state = state;
+                somethingChanged = true;
+            }
+        }
+
+        if (somethingChanged)
+            Refresh();
+    }
+}
+
+void SketchCanvasPanel::OnSketchEntered(wxMouseEvent& /*event*/)
+{
+    SetFocus();
+}
+
+void SketchCanvasPanel::OnSketchMouseWheel(wxMouseEvent& event)
+{
+    m_wheelRotation += event.GetWheelRotation();
+    m_wheelRotation = std::clamp(m_wheelRotation, 0, MouseWheelLimit);
+    if (!m_wheelRotation)
+        m_canvasTranslation = wxPoint2DDouble();
+
+    // todo? - take zoom and/or canvas translation into account
+    m_normalizedZoomPt = UItoNormalized(event.GetPosition());
+
+    Refresh();
+}
+
+void SketchCanvasPanel::OnSketchMidDown(wxMouseEvent& event)
+{
+    m_mousePos = event.GetPosition();
+}
+
+// Usable area rect: BorderWidth+1, BorderWidth+1, sz.GetWidth()-2*BorderWidth-2, sz.GetHeight()-2*BorderWidth-2;
+
+wxPoint2DDouble SketchCanvasPanel::UItoNormalized(const wxPoint2DDouble& pt) const
+{
+    wxPoint o(BorderWidth + 1, BorderWidth + 1);
+    wxSize sz(GetSize() - wxSize(2 * BorderWidth - 2, 2 * BorderWidth - 2));
+
+    double x = double(pt.m_x - o.x) / sz.GetWidth();
+    double y = double(pt.m_y - o.y) / sz.GetHeight();
+
+    return wxPoint2DDouble(x, 1. - y);
+}
+
+wxPoint2DDouble SketchCanvasPanel::NormalizedToUI(const wxPoint2DDouble& pt) const
+{
+    wxPoint o(BorderWidth + 1, BorderWidth + 1);
+    wxSize sz(GetSize() - wxSize(2 * BorderWidth - 2, 2 * BorderWidth - 2));
+
+    double x = pt.m_x * sz.GetWidth();
+    double y = pt.m_y * sz.GetHeight();
+    return wxPoint2DDouble(o.x + x, o.y + (sz.GetHeight() - y - 1));
+}
+
+bool SketchCanvasPanel::IsControlPoint(const HandlePoint& handlePt)
+{
+    auto hpt = handlePt.handlePointType;
+    return hpt == QuadraticControlPt || hpt == CubicControlPt1 || hpt == CubicControlPt2;
+}
+
+void SketchCanvasPanel::UpdatePathState(PathState pathState)
+{
+    m_pathState = pathState;
+
+    switch (m_pathState) {
+    case Undefined:
+        m_parentPanel->m_startPathBtn->Enable();
+        m_parentPanel->m_endPathBtn->Disable();
+        m_parentPanel->m_closePathBtn->Disable();
+        break;
+    case DefineStartPoint:
+        m_parentPanel->m_startPathBtn->Disable();
+        m_parentPanel->m_endPathBtn->Disable();
+        m_parentPanel->m_closePathBtn->Disable();
+        break;
+    case LineToNewPoint:
+    case QuadraticCurveToNewPoint:
+    case CubicCurveToNewPoint:
+        m_parentPanel->m_startPathBtn->Disable();
+        m_parentPanel->m_endPathBtn->Enable();
+        m_parentPanel->m_closePathBtn->Enable();
+        break;
+    }
+
+    Refresh();
+
+    // If we're Undefined, have some handles, and no path
+    // selected, I think we've added a new one!!
+    if (m_pathState == Undefined && !m_handles.empty() && m_parentPanel->m_pathsListBox->GetSelection() < 0) {
+        auto path = CreatePathFromHandles();
+        if (path != nullptr) {
+            SketchEffectSketch& sketch(m_parentPanel->m_sketch);
+            sketch.appendPath(path);
+            int n = static_cast<int>(sketch.pathCount());
+            wxString str;
+            str.sprintf("Path %d", n);
+            m_parentPanel->m_pathsListBox->Insert(str, n - 1);
+            m_parentPanel->m_pathsListBox->Select(n - 1);
+        }
+    }
+}
+
+void SketchCanvasPanel::ResetHandlesState(PathState state /*Undefined*/)
+{
+    m_handles.clear();
+    m_grabbedHandleIndex = -1;
+    m_pathClosed = false;
+    UpdatePathState(state);
+}
+
+void SketchCanvasPanel::UpdateHandlesForPath(long pathIndex)
+{
+    const SketchEffectSketch& sketch(m_parentPanel->m_sketch);
+
+    if (pathIndex < 0 || pathIndex >= sketch.paths().size())
+        return;
+
+    ResetHandlesState();
+
+    auto iter = sketch.paths().cbegin();
+    std::advance(iter, pathIndex);
+
+    auto pathSegments((*iter)->segments());
+    m_handles.push_back(HandlePoint(pathSegments.front()->StartPoint()));
+    for (auto iter = pathSegments.cbegin(); iter != pathSegments.cend(); ++iter) {
+        std::shared_ptr<SketchPathSegment> pathSegment = *iter;
+
+        std::shared_ptr<SketchQuadraticBezier> quadratic;
+        std::shared_ptr<SketchCubicBezier> cubic;
+        if (std::dynamic_pointer_cast<SketchLine>(pathSegment) != nullptr) {
+            m_handles.push_back(HandlePoint(pathSegment->EndPoint()));
+        } else if ((quadratic = std::dynamic_pointer_cast<SketchQuadraticBezier>(pathSegment)) != nullptr) {
+            m_handles.push_back(HandlePoint(quadratic->ControlPoint(), QuadraticControlPt));
+            m_handles.push_back(HandlePoint(quadratic->EndPoint(), QuadraticCurveEnd));
+        } else if ((cubic = std::dynamic_pointer_cast<SketchCubicBezier>(pathSegment)) != nullptr) {
+            m_handles.push_back(HandlePoint(cubic->ControlPoint1(), CubicControlPt1));
+            m_handles.push_back(HandlePoint(cubic->ControlPoint2(), CubicControlPt2));
+            m_handles.push_back(HandlePoint(cubic->EndPoint(), CubicCurveEnd));
+        }
+    }
+
+    if ((*iter)->isClosed() && m_handles.size() >= 3) {
+        m_handles.pop_back();
+        m_pathClosed = true;
+    }
+
+    Refresh();
+}
+
+void SketchCanvasPanel::UpdatePathFromHandles(long handleIndex)
+{
+    SketchEffectSketch& sketch(m_parentPanel->m_sketch);
+    auto paths(sketch.paths());
+
+    auto pathIndex = m_parentPanel->m_pathsListBox->GetSelection();
+    if (pathIndex < 0 || pathIndex >= paths.size())
+        return;
+
+    auto iter = paths.cbegin();
+    std::advance(iter, pathIndex);
+
+    auto segments = (*iter)->segments();
+    if (segments.empty())
+        return;
+
+    int index = 0;
+    auto normalizedHandlePt(m_handles[handleIndex].pt);
+
+    // Can early-return when adjusting the start-point of the path
+    if (handleIndex == index++) {
+        segments.front()->SetStartPoint(normalizedHandlePt);
+
+        // yuck... closed paths have an extra SketchLine to close the path, so if we update
+        //         the start point, we need to update that last 'extra' segment
+        if ((*iter)->isClosed())
+            segments.back()->SetEndPoint(normalizedHandlePt);
+        m_parentPanel->sketchUpdatedFromCanvasPanel();
+        return;
+    }
+
+    for (int segmentIndex = 0; segmentIndex < segments.size(); ++segmentIndex) {
+        std::shared_ptr<SketchPathSegment> segment = segments[segmentIndex];
+        std::shared_ptr<SketchQuadraticBezier> quadratic;
+        std::shared_ptr<SketchCubicBezier> cubic;
+
+        if (std::dynamic_pointer_cast<SketchLine>(segment) != nullptr) {
+            if (handleIndex == index++) {
+                segment->SetEndPoint(normalizedHandlePt);
+                if (segmentIndex < segments.size() - 1)
+                    segments[segmentIndex + 1]->SetStartPoint(normalizedHandlePt);
+                break;
+            }
+        } else if ((quadratic = std::dynamic_pointer_cast<SketchQuadraticBezier>(segment)) != nullptr) {
+            if (handleIndex == index++) {
+                quadratic->SetControlPoint(normalizedHandlePt);
+                break;
+            }
+            if (handleIndex == index++) {
+                segment->SetEndPoint(normalizedHandlePt);
+                if (segmentIndex < segments.size() - 1)
+                    segments[segmentIndex + 1]->SetStartPoint(normalizedHandlePt);
+                break;
+            }
+        } else if ((cubic = std::dynamic_pointer_cast<SketchCubicBezier>(segment)) != nullptr) {
+            if (handleIndex == index++) {
+                cubic->SetControlPoint1(normalizedHandlePt);
+                break;
+            }
+            if (handleIndex == index++) {
+                cubic->SetControlPoint2(normalizedHandlePt);
+                break;
+            }
+            if (handleIndex == index++) {
+                segment->SetEndPoint(normalizedHandlePt);
+                if (segmentIndex < segments.size() - 1)
+                    segments[segmentIndex + 1]->SetStartPoint(normalizedHandlePt);
+                break;
+            }
+        }
+    }
+    m_parentPanel->sketchUpdatedFromCanvasPanel();
+}
+
+void SketchCanvasPanel::UpdatePathFromHandles()
+{
+    // todo
+}
+
+std::shared_ptr<SketchEffectPath> SketchCanvasPanel::CreatePathFromHandles() const
+{
+    if (m_handles.size() < 2)
+        return nullptr;
+
+    auto path = std::make_shared<SketchEffectPath>();
+    for (size_t index = 0; index < m_handles.size() - 1;) {
+        std::shared_ptr<SketchPathSegment> segment;
+
+        switch (m_handles[index + 1].handlePointType) {
+        case Point:
+            segment = std::make_shared<SketchLine>(m_handles[index].pt, m_handles[index + 1].pt);
+            ++index;
+            break;
+        case QuadraticControlPt:
+            segment = std::make_shared<SketchQuadraticBezier>(m_handles[index].pt,
+                                                              m_handles[index + 1].pt,
+                                                              m_handles[index + 2].pt);
+            index += 2;
+            break;
+        case CubicControlPt1:
+            segment = std::make_shared<SketchCubicBezier>(m_handles[index].pt,
+                                                          m_handles[index + 1].pt,
+                                                          m_handles[index + 2].pt,
+                                                          m_handles[index + 3].pt);
+            index += 3;
+            break;
+        }
+
+        if (segment != nullptr)
+            path->appendSegment(segment);
+    }
+    if (m_pathClosed)
+        path->closePath();
+
+    return path;
+}
+
+void SketchCanvasPanel::setBackgroundBitmap(std::unique_ptr<wxBitmap> bm)
+{
+    m_bgBitmap = std::move(bm);
+    Refresh();
+}

--- a/xLights/effects/assist/SketchCanvasPanel.h
+++ b/xLights/effects/assist/SketchCanvasPanel.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <wx/geometry.h>
+#include <wx/image.h>
+#include <wx/panel.h>
+
+#include <memory>
+#include <vector>
+
+class SketchAssistPanel;
+class SketchEffectPath;
+
+class wxBitmap;
+class wxFilePickerCtrl;
+
+class SketchCanvasPanel : public wxPanel
+{
+public:
+    enum PathState { Undefined,
+                     DefineStartPoint,
+                     LineToNewPoint,
+                     QuadraticCurveToNewPoint,
+                     CubicCurveToNewPoint };
+
+    SketchCanvasPanel(SketchAssistPanel* parentPanel, wxWindow* parent, wxWindowID id = wxID_ANY,
+                      const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+    virtual ~SketchCanvasPanel() = default;
+
+    bool AcceptsFocus() const override
+    {
+        return true;
+    }
+
+    void setBackgroundBitmap(std::unique_ptr<wxBitmap> bm);
+    void UpdatePathState(PathState state);
+    void ResetHandlesState(PathState pathState = Undefined);
+    void UpdateHandlesForPath(long pathIndex);
+    void ClosePath()
+    {
+        m_pathClosed = true;
+    }
+
+    void OnSketchKeyDown(wxKeyEvent& event); // for SketchAssistPanel access
+
+private:
+    enum HandlePointType { Point,
+                           QuadraticControlPt,
+                           QuadraticCurveEnd,
+                           CubicControlPt1,
+                           CubicControlPt2,
+                           CubicCurveEnd };
+
+    struct HandlePoint {
+        HandlePoint(wxPoint2DDouble _pt, HandlePointType _handlePointType = Point) :
+            pt(_pt),
+            handlePointType(_handlePointType)
+        {}
+        wxPoint2DDouble pt;
+        bool state = false;
+        HandlePointType handlePointType = Point;
+    };
+
+    DECLARE_EVENT_TABLE()
+
+    void OnSketchPaint(wxPaintEvent& event);
+    void OnSketchLeftDown(wxMouseEvent& event);
+    void OnSketchLeftUp(wxMouseEvent& event);
+    void OnSketchMouseMove(wxMouseEvent& event);
+    void OnSketchEntered(wxMouseEvent& event);
+    void OnSketchMouseWheel(wxMouseEvent& event);
+    void OnSketchMidDown(wxMouseEvent& event);
+
+    wxPoint2DDouble UItoNormalized(const wxPoint2DDouble& pt) const;
+    wxPoint2DDouble NormalizedToUI(const wxPoint2DDouble& pt) const;
+    static bool IsControlPoint(const HandlePoint& handlePt);
+    void UpdatePathFromHandles(long handleIndex);
+    void UpdatePathFromHandles();
+    std::shared_ptr<SketchEffectPath> CreatePathFromHandles() const;
+
+    // Handles and PathState are for the currently active path
+    std::vector<HandlePoint> m_handles;
+    std::vector<HandlePoint>::size_type m_grabbedHandleIndex = -1;
+    PathState m_pathState = Undefined;
+    bool m_pathClosed = false;
+
+    SketchAssistPanel* const m_parentPanel;
+    std::unique_ptr<wxBitmap> m_bgBitmap;
+    int m_wheelRotation = 0;
+    wxPoint2DDouble m_normalizedZoomPt;
+    wxPoint2DDouble m_canvasTranslation;
+    double m_matrixComponents[6];
+    wxPoint2DDouble m_mousePos;
+};

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -1044,6 +1044,10 @@
 		<Unit filename="effects/assist/AssistPanel.h" />
 		<Unit filename="effects/assist/PicturesAssistPanel.cpp" />
 		<Unit filename="effects/assist/PicturesAssistPanel.h" />
+		<Unit filename="effects/assist/SketchAssistPanel.cpp" />
+		<Unit filename="effects/assist/SketchAssistPanel.h" />
+		<Unit filename="effects/assist/SketchCanvasPanel.cpp" />
+		<Unit filename="effects/assist/SketchCanvasPanel.h" />
 		<Unit filename="effects/assist/xlGridCanvasEmpty.cpp" />
 		<Unit filename="effects/assist/xlGridCanvasEmpty.h" />
 		<Unit filename="effects/assist/xlGridCanvasMorph.cpp" />


### PR DESCRIPTION
Implementing this based on feedback from Dan and Gil. I'm leaving the now-unused SketchPathDialog code for now, in case I missed anything. I'll remove it later on.