### PR TITLE
Update sketch effect for closed paths with motion

### DIFF
--- a/xLights/effects/SketchEffect.cpp
+++ b/xLights/effects/SketchEffect.cpp
@@ -34,6 +34,11 @@ namespace
                    ? (loOut + (hiOut - loOut) * interpolater((x - loIn) / (hiIn - loIn)))
                    : ((loOut + hiOut) / 2);
     }
+
+    double calcPercentage(double v, double s, double e)
+    {
+        return (v - s) / (e - s);
+    }
 }
 
 SketchEffect::SketchEffect(int id) :
@@ -185,16 +190,29 @@ void SketchEffect::renderSketch(const SketchEffectSketch& sketch, wxImage& img, 
     double maxProgress = hasMotion ? (1. + motionPercentage) : 1.;
     double adjustedProgress = interpolate(progress, 0., 0., 1., maxProgress, LinearInterpolater());
 
-    // ... but we do a different adjustment for the non-motion case
-    if (!hasMotion) {
+    // ... but we do a slightly different adjustment for the non-motion case
+    if (!hasMotion)
         adjustedProgress = interpolate(progress, 0.0, 0.0, drawPercentage, 1.0, LinearInterpolater());
-    }
-    
-
+  
     double totalLength = 0.;
     for (const auto& path : paths)
         totalLength += path->Length();
-    
+
+    // Single closed path with motion is a special case for now... since the motion is supposed to
+    // wrap to the beginning of the path, it's unclear when we would ever move on to the next path
+    // unless a new setting was added
+    if (hasMotion && paths.size() == 1 && paths.front()->isClosed()) {
+        auto path = paths.front();
+        wxColor color(colors[0].asWxColor());
+        wxPen pen(color, lineThickness);
+        gc->SetPen(pen);
+
+        path->drawPartialPath(gc.get(), sz, progress, progress + motionPercentage);
+        if (progress + motionPercentage > 1.)
+            path->drawPartialPath(gc.get(), sz, 0., progress + motionPercentage - 1.);
+        return;
+    }
+ 
     double cumulativeLength = 0.;
     int i = 0;
     for (auto iter = paths.cbegin(); iter != paths.cend(); ++iter, ++i)
@@ -209,11 +227,11 @@ void SketchEffect::renderSketch(const SketchEffectSketch& sketch, wxImage& img, 
             (*iter)->drawEntirePath(gc.get(), sz);
         else {
             double percentageAtStartOfThisPath = cumulativeLength / totalLength;
-            double percentageThroughThisPath = (adjustedProgress - percentageAtStartOfThisPath) / (percentageAtEndOfThisPath - percentageAtStartOfThisPath);
+            double percentageThroughThisPath = calcPercentage(adjustedProgress, percentageAtStartOfThisPath, percentageAtEndOfThisPath);
             if (!hasMotion)
                 (*iter)->drawPartialPath(gc.get(), sz, std::nullopt, percentageThroughThisPath);
             else {
-                double drawPercentageThroughThisPath = (adjustedProgress - motionPercentage - percentageAtStartOfThisPath) / (percentageAtEndOfThisPath - percentageAtStartOfThisPath);
+                double drawPercentageThroughThisPath = calcPercentage(adjustedProgress - motionPercentage, percentageAtStartOfThisPath, percentageAtEndOfThisPath);
                 drawPercentageThroughThisPath = std::clamp(drawPercentageThroughThisPath, 0., 1.);
 
                 (*iter)->drawPartialPath(gc.get(), sz, drawPercentageThroughThisPath, percentageThroughThisPath);

--- a/xLights/effects/SketchPanel.cpp
+++ b/xLights/effects/SketchPanel.cpp
@@ -102,7 +102,7 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
     thicknessControlsSizer->Add(BitmapButton_Thickness, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
 
     sketchDefSizer->Add(label3, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
-    sketchDefSizer->Add(thicknessControlsSizer, 1, wxALL | wxEXPAND, 0);
+    sketchDefSizer->Add(thicknessControlsSizer, 1, wxALL | wxEXPAND, 2);
     sketchDefSizer->Add(TextCtrl_Thickness, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
     // Motion


### PR DESCRIPTION
For a closed path with motion enabled, it makes sense that it should always draw a "motion percentage" length of the path, wrapping from the end of the path into the start. That way if the effect is repeated via copy and pasting the effect (there is currently no Cycles option), the motion will be continuous between the effect instances.

This does potentially introduce some unexpected behavior because having just a single closed path is now a special case. For tracing an image with motion enabled, it may be preferable to have the start and end points of the curve to be close together but not actually closed.