### PR TITLE
More sketch effect settings

### DIFF
--- a/xLights/effects/SketchEffect.cpp
+++ b/xLights/effects/SketchEffect.cpp
@@ -130,9 +130,12 @@ void SketchEffect::SetDefaultParameters()
 
     SetCheckBoxValue(p->CheckBox_MotionEnabled, false);
 
+    SetSliderValue(p->Slider_SketchBackgroundOpacity, 0x30);
     SetSliderValue(p->Slider_DrawPercentage, SketchPanel::DrawPercentageDef);
     SetSliderValue(p->Slider_Thickness, SketchPanel::ThicknessDef);
     SetSliderValue(p->Slider_MotionPercentage, SketchPanel::MotionPercentageDef);
+
+    p->FilePicker_SketchBackground->SetFileName(wxFileName());
 
     p->ValidateWindow();
 }
@@ -173,6 +176,9 @@ AssistPanel* SketchEffect::GetAssistPanel(wxWindow* parent, xLightsFrame* /*xl_f
     sketchAssistPanel->SetSketchUpdateCallback(lambda);
     //sketchAssistPanel->SetxLightsFrame(xl_frame);
     assistPanel->AddPanel(sketchAssistPanel, wxALL | wxEXPAND);
+
+    m_sketchAssistPanel = sketchAssistPanel;
+    updateSketchAssistBackground();
 
     return assistPanel;
 }
@@ -248,4 +254,15 @@ void SketchEffect::renderSketch(const SketchEffectSketch& sketch, wxImage& img, 
         }
         cumulativeLength += pathLength;
     }
+}
+
+void SketchEffect::updateSketchAssistBackground() const
+{
+    if (m_panel == nullptr || m_sketchAssistPanel == nullptr)
+        return;
+
+    wxString path(m_panel->FilePicker_SketchBackground->GetFileName().GetFullPath());
+    int opacity = m_panel->Slider_SketchBackgroundOpacity->GetValue();
+
+    m_sketchAssistPanel->UpdateSketchBackground(path, opacity);
 }

--- a/xLights/effects/SketchEffect.h
+++ b/xLights/effects/SketchEffect.h
@@ -4,6 +4,7 @@
 
 class wxImage;
 
+class SketchAssistPanel;
 class SketchEffectSketch;
 class SketchPanel;
 
@@ -39,5 +40,13 @@ protected:
                       double drawPercentage, int lineThickness, bool hasMotion, double motionPercentage,
                       const xlColorVector& colors);
 
+    void updateSketchAssistBackground() const;
+
+    // Since SketchEffect and SketchPanel are more-or-less singletons,
+    // having a raw pointer to the effect's panel is sufficient
     SketchPanel* m_panel = nullptr;
+
+    // Assist panels come and go and are owned by the window passed into
+    // GetAssistPanel()... so we just store the latest one as a weak_ptr
+    SketchAssistPanel* m_sketchAssistPanel = nullptr;
 };

--- a/xLights/effects/SketchPanel.cpp
+++ b/xLights/effects/SketchPanel.cpp
@@ -1,8 +1,13 @@
 #include "SketchPanel.h"
 #include "BulkEditControls.h"
+#include "assist/SketchAssistPanel.h"
+#include "../xLightsMain.h"
 
+#include <wx/filepicker.h>
 #include <wx/hyperlink.h>
 #include <wx/sizer.h>
+#include <wx/slider.h>
+#include <wx/statline.h>
 #include <wx/stattext.h>
 #include <wx/utils.h>
 
@@ -18,12 +23,36 @@ namespace
 
     const char demoVideoURL[] = "https://vimeo.com/696352082";
     const char demoVideoURL2[] = "https://vimeo.com/698053599";
+
+    const wxString imgSelect("Select an image file");
+    const wxString imgFilters("*.jpg;*.gif;*.png;*.bmp;*.jpeg");
+
+    SketchAssistPanel* getSketchAssistPanel(wxWindow* win)
+    {
+        xLightsFrame* frame = nullptr;
+        for (wxWindow* w = win->GetParent(); w != nullptr; w = w->GetParent()) {
+            xLightsFrame* f = dynamic_cast<xLightsFrame*>(w);
+            if (f != nullptr) {
+                frame = f;
+                break;
+            }
+        }
+        if (frame != nullptr) {
+            auto pane(frame->m_mgr->GetPane("EffectAssist"));
+            auto w = wxWindow::FindWindowByName("ID_PANEL_SKETCH_ASSIST", pane.window);
+            if (w != nullptr)
+                return dynamic_cast<SketchAssistPanel*>(w);
+        }
+        return nullptr;
+    }
 }
 
 BEGIN_EVENT_TABLE(SketchPanel, wxPanel)
 END_EVENT_TABLE()
 
 const long SketchPanel::ID_TEXTCTRL_SketchDef = wxNewId();
+const long SketchPanel::ID_FILEPICKER_SketchBackground = wxNewId();
+const long SketchPanel::ID_SLIDER_SketchBackgroundOpacity = wxNewId();
 const long SketchPanel::ID_SLIDER_DrawPercentage = wxNewId();
 const long SketchPanel::ID_TEXTCTRL_DrawPercentage = wxNewId();
 const long SketchPanel::ID_VALUECURVE_DrawPercentage = wxNewId();
@@ -40,14 +69,7 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
 {
     Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
 
-    auto mainSizer = new wxFlexGridSizer(3, 1, 5, 0);
-    mainSizer->AddGrowableRow(2);
-    mainSizer->AddGrowableCol(0);
-
-    // Effect Info
-    auto effectInfoSizer = new wxFlexGridSizer(3, 1, 0, 0);
-    effectInfoSizer->AddGrowableCol(0);
-
+    // EffectInfo controls
     auto effectDescText = new wxTextCtrl(this, wxID_ANY, effectInfoText,
                                          wxDefaultPosition, wxDefaultSize,
                                          wxTE_NO_VSCROLL | wxTE_MULTILINE | wxTE_READONLY | wxBORDER_NONE);
@@ -56,28 +78,33 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
     auto effectDescLink = new wxHyperlinkCtrl(this, wxID_ANY, "Sketch Effect Demo", demoVideoURL);
     auto effectMoreLink = new wxHyperlinkCtrl(this, wxID_ANY, "Sketch Tracing Demo", demoVideoURL2);
 
-    effectInfoSizer->Add(effectDescText, 1, wxALL | wxEXPAND, 0);
-    effectInfoSizer->Add(effectDescLink, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 0);
-    effectInfoSizer->Add(effectMoreLink, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 0);
-
-    // Sketch Definition
-    auto sketchDefSizer = new wxFlexGridSizer(4, 3, 0, 0);
-    sketchDefSizer->AddGrowableCol(1);
-
-    // Sketch
-    auto label = new wxStaticText(this, wxID_ANY, "Sketch:");
-    TextCtrl_SketchDef = new BulkEditTextCtrl(this, ID_TEXTCTRL_SketchDef, wxEmptyString, wxDefaultPosition, wxDLG_UNIT(this, wxSize(20, -1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_SketchDef"));
+    // Sketch controls
+    auto sketchLabel = new wxStaticText(this, wxID_ANY, "Sketch:");
+    TextCtrl_SketchDef = new BulkEditTextCtrl(this, ID_TEXTCTRL_SketchDef, wxEmptyString, wxDefaultPosition,
+                                              wxDLG_UNIT(this, wxSize(20, -1)), 0,
+                                              wxDefaultValidator, _T("ID_TEXTCTRL_SketchDef"));
     TextCtrl_SketchDef->SetEditable(false);
 
-    sketchDefSizer->Add(label, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
-    sketchDefSizer->Add(TextCtrl_SketchDef, 1, wxALL | wxEXPAND, 2);
-    sketchDefSizer->AddStretchSpacer();
+    auto bgLabel = new wxStaticText(this, wxID_ANY, "Background:");
+    FilePicker_SketchBackground = new wxFilePickerCtrl(this, ID_FILEPICKER_SketchBackground,
+                                                       wxEmptyString, imgSelect, imgFilters,
+                                                       wxDefaultPosition, wxDefaultSize,
+                                                       wxFLP_FILE_MUST_EXIST | wxFLP_OPEN | wxFLP_USE_TEXTCTRL,
+                                                       wxDefaultValidator, "ID_FILEPICKER_SketchBackground");
+    FilePicker_SketchBackground->GetTextCtrl()->SetEditable(false);
 
+    auto opacityLabel = new wxStaticText(this, wxID_ANY, "Opacity:");
+    Slider_SketchBackgroundOpacity = new wxSlider(this, ID_SLIDER_SketchBackgroundOpacity, 0x30, 0x00, 0xff,
+                                                  wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, "ID_SLIDER_SketchBackgroundOpacity");
+
+    auto separator = new wxStaticLine(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+
+    // Settings controls
+    //
     // Bulk Edit is weird... apparently the secret sauce is for the
     // TextCtrl id to be "IDD_" instead of "ID_"
 
-    // Draw Percentage
-    auto label2 = new wxStaticText(this, wxID_ANY, "Draw Percentage:");
+    auto drawPctLabel = new wxStaticText(this, wxID_ANY, "Draw Percentage:");
     Slider_DrawPercentage = new BulkEditSlider(this, ID_SLIDER_DrawPercentage,
                                                DrawPercentageDef, DrawPercentageMin, DrawPercentageMax,
                                                wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_DrawPercentage"));
@@ -87,17 +114,7 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
                                                    wxEmptyString, wxDefaultPosition,
                                                    wxDLG_UNIT(this, wxSize(20, -1)), 0, wxDefaultValidator, _T("IDD_TEXTCTRL_DrawPercentage"));
 
-    auto drawPctControlsSizer = new wxFlexGridSizer(1, 2, 0, 0);
-    drawPctControlsSizer->AddGrowableCol(0);
-    drawPctControlsSizer->Add(Slider_DrawPercentage, 1, wxALL | wxEXPAND, 0);
-    drawPctControlsSizer->Add(BitmapButton_DrawPercentage, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
-    
-    sketchDefSizer->Add(label2, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
-    sketchDefSizer->Add(drawPctControlsSizer, 1, wxALL | wxEXPAND, 2);
-    sketchDefSizer->Add(TextCtrl_DrawPercentage, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-
-    // Thickness
-    auto label3 = new wxStaticText(this, wxID_ANY, "Thickness:");
+    auto thicknessLabel = new wxStaticText(this, wxID_ANY, "Thickness:");
     Slider_Thickness = new BulkEditSlider(this, ID_SLIDER_Thickness,
                                           ThicknessDef, ThicknessMin, ThicknessMax,
                                           wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Thickness"));
@@ -107,17 +124,7 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
                                               wxEmptyString, wxDefaultPosition,
                                               wxDLG_UNIT(this, wxSize(20, -1)), 0, wxDefaultValidator, _T("IDD_TEXTCTRL_Thickness"));
 
-    auto thicknessControlsSizer = new wxFlexGridSizer(1, 2, 0, 0);
-    thicknessControlsSizer->AddGrowableCol(0);
-    thicknessControlsSizer->Add(Slider_Thickness, 1, wxALL | wxEXPAND, 2);
-    thicknessControlsSizer->Add(BitmapButton_Thickness, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
-
-    sketchDefSizer->Add(label3, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
-    sketchDefSizer->Add(thicknessControlsSizer, 1, wxALL | wxEXPAND, 2);
-    sketchDefSizer->Add(TextCtrl_Thickness, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-
-    // Motion
-    auto label4 = new wxStaticText(this, wxID_ANY, "Motion:");
+    auto motionLabel = new wxStaticText(this, wxID_ANY, "Motion:");
     CheckBox_MotionEnabled = new BulkEditCheckBox(this, ID_CHECKBOX_MotionEnabled, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_MotionEnabled"));
     Slider_MotionPercentage = new BulkEditSlider(this, ID_SLIDER_MotionPercentage,
                                                  MotionPercentageDef, MotionPercentageMin, MotionPercentageMax,
@@ -129,23 +136,62 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
                                                      wxEmptyString, wxDefaultPosition,
                                                      wxDLG_UNIT(this, wxSize(20, -1)), 0, wxDefaultValidator, _T("IDD_TEXTCTRL_MotionPercentage"));
 
-    auto motionControlsSizer = new wxFlexGridSizer(1, 3, 0, 0);
-    motionControlsSizer->AddGrowableCol(1);
-    motionControlsSizer->Add(CheckBox_MotionEnabled, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-    motionControlsSizer->Add(Slider_MotionPercentage, 1, wxALL | wxEXPAND, 2);
-    motionControlsSizer->Add(BitmapButton_MotionPercentage, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
+    // Sizers - main gets effectInfoSizer, sketchSizer, separator, and settingsSizer
+    auto mainSizer = new wxFlexGridSizer(7, 1, 0, 0);
+    mainSizer->AddGrowableRow(6);
+    mainSizer->AddGrowableCol(0);
 
-    sketchDefSizer->Add(label4, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
-    sketchDefSizer->Add(motionControlsSizer, 1, wxALL | wxEXPAND, 2);
-    sketchDefSizer->Add(TextCtrl_MotionPercentage, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-
-    // Etc
+    auto effectInfoSizer = new wxFlexGridSizer(3, 1, 0, 0);
+    effectInfoSizer->AddGrowableCol(0);
+    effectInfoSizer->Add(effectDescText, 1, wxALL | wxEXPAND, 0);
+    effectInfoSizer->Add(effectDescLink, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 0);
+    effectInfoSizer->Add(effectMoreLink, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 0);
     mainSizer->Add(effectInfoSizer, 1, wxALL | wxEXPAND, 2);
-    mainSizer->Add(sketchDefSizer, 1, wxALL | wxEXPAND, 2);
+
+    auto sketchSizer = new wxFlexGridSizer(3, 2, 0, 0);
+    sketchSizer->AddGrowableCol(1);
+    sketchSizer->Add(sketchLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    sketchSizer->Add(TextCtrl_SketchDef, 1, wxALL | wxEXPAND, 2);
+    sketchSizer->Add(bgLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    sketchSizer->Add(FilePicker_SketchBackground, 1, wxALL | wxEXPAND, 2);
+    sketchSizer->Add(opacityLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    sketchSizer->Add(Slider_SketchBackgroundOpacity, 1, wxALL | wxEXPAND, 2);
+    mainSizer->Add(sketchSizer, 1, wxALL | wxEXPAND, 2);
+
+    mainSizer->AddSpacer(5);
+    mainSizer->Add(separator, 1, wxALL | wxEXPAND, 2);
+    mainSizer->AddSpacer(5);
+
+    auto settingsSizer = new wxFlexGridSizer(3, 5, 0, 0);
+    settingsSizer->AddGrowableCol(2);
+
+    settingsSizer->Add(drawPctLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->AddStretchSpacer();
+    settingsSizer->Add(Slider_DrawPercentage, 1, wxALL | wxEXPAND, 2);
+    settingsSizer->Add(BitmapButton_DrawPercentage, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->Add(TextCtrl_DrawPercentage, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+
+    settingsSizer->Add(thicknessLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->AddStretchSpacer();
+    settingsSizer->Add(Slider_Thickness, 1, wxALL | wxEXPAND, 2);
+    settingsSizer->Add(BitmapButton_Thickness, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->Add(TextCtrl_Thickness, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+
+    settingsSizer->Add(motionLabel, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->Add(CheckBox_MotionEnabled, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->Add(Slider_MotionPercentage, 1, wxALL | wxEXPAND, 2);
+    settingsSizer->Add(BitmapButton_MotionPercentage, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
+    settingsSizer->Add(TextCtrl_MotionPercentage, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+
+    mainSizer->Add(settingsSizer, 1, wxALL | wxEXPAND, 2);
+
 
 	SetSizer(mainSizer);
     mainSizer->Fit(this);
     mainSizer->SetSizeHints(this);
+
+    Connect(ID_FILEPICKER_SketchBackground, wxEVT_COMMAND_FILEPICKER_CHANGED, (wxObjectEventFunction)&SketchPanel::OnFilePickerCtrl_FileChanged);
+    Connect(ID_SLIDER_SketchBackgroundOpacity, wxEVT_COMMAND_SLIDER_UPDATED, (wxObjectEventFunction)&SketchPanel::OnSlider_BgAlphaChanged);
 
     Connect(ID_VALUECURVE_DrawPercentage, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchPanel::OnVCButtonClick);
     Connect(ID_VALUECURVE_Thickness, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchPanel::OnVCButtonClick);
@@ -175,10 +221,32 @@ void SketchPanel::ValidateWindow()
     TextCtrl_DrawPercentage->Enable(!motion);
     
     Slider_MotionPercentage->Enable(motion);
+    BitmapButton_MotionPercentage->Enable(motion);
     TextCtrl_MotionPercentage->Enable(motion);
+}
+
+void SketchPanel::OnFilePickerCtrl_FileChanged(wxCommandEvent& event)
+{
+    updateSketchAssist(getSketchAssistPanel(this));
+}
+
+void SketchPanel::OnSlider_BgAlphaChanged(wxCommandEvent& /*event*/)
+{
+    updateSketchAssist(getSketchAssistPanel(this));
 }
 
 void SketchPanel::OnCheckBox_MotionClick(wxCommandEvent& /*event*/)
 {
     ValidateWindow();
+}
+
+void SketchPanel::updateSketchAssist(SketchAssistPanel* panel)
+{
+    if (panel == nullptr)
+        return;
+
+    wxString path(FilePicker_SketchBackground->GetFileName().GetFullPath());
+    int opacity = Slider_SketchBackgroundOpacity->GetValue();
+
+    panel->UpdateSketchBackground(path, opacity);
 }

--- a/xLights/effects/SketchPanel.h
+++ b/xLights/effects/SketchPanel.h
@@ -6,6 +6,10 @@ class BulkEditCheckBox;
 class BulkEditSlider;
 class BulkEditTextCtrl;
 class BulkEditValueCurveButton;
+class SketchAssistPanel;
+
+class wxFilePickerCtrl;
+class wxSlider;
 
 class SketchPanel : public xlEffectPanel
 {
@@ -17,6 +21,8 @@ public:
 
     // controls are public to allow SketchEffect access
     BulkEditTextCtrl* TextCtrl_SketchDef = nullptr;
+    wxFilePickerCtrl* FilePicker_SketchBackground = nullptr;
+    wxSlider* Slider_SketchBackgroundOpacity = nullptr;
     BulkEditSlider* Slider_DrawPercentage = nullptr;
     BulkEditValueCurveButton* BitmapButton_DrawPercentage = nullptr;
     BulkEditTextCtrl* TextCtrl_DrawPercentage = nullptr;
@@ -42,6 +48,8 @@ public:
 
 protected:
     static const long ID_TEXTCTRL_SketchDef;
+    static const long ID_FILEPICKER_SketchBackground;
+    static const long ID_SLIDER_SketchBackgroundOpacity;
     static const long ID_SLIDER_DrawPercentage;
     static const long ID_TEXTCTRL_DrawPercentage;
     static const long ID_VALUECURVE_DrawPercentage;
@@ -56,5 +64,9 @@ protected:
  private:
     DECLARE_EVENT_TABLE()
 
+    void OnFilePickerCtrl_FileChanged(wxCommandEvent& event);
+    void OnSlider_BgAlphaChanged(wxCommandEvent& event);
     void OnCheckBox_MotionClick(wxCommandEvent& event);
+
+    void updateSketchAssist(SketchAssistPanel* panel);
 };

--- a/xLights/effects/assist/SketchAssistPanel.h
+++ b/xLights/effects/assist/SketchAssistPanel.h
@@ -10,9 +10,7 @@
 #include <wx/panel.h>
 
 class wxButton;
-class wxFilePickerCtrl;
 class wxListBox;
-class wxSlider;
 
 class SketchAssistPanel : public wxPanel,
                           public ISketchCanvasParent
@@ -24,6 +22,8 @@ public:
     typedef std::function<void(const std::string&)> SketchUpdateCallback;
 
     SketchAssistPanel(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+
+    // Assist panels seem to be created/destroyed quite frequently when switching between effects
     virtual ~SketchAssistPanel() = default;
 
     void SetSketchDef(const std::string& sketchDef);
@@ -42,11 +42,10 @@ public:
     void NotifyPathStateUpdated(SketchCanvasPathState state) override;
     void SelectLastPath() override;
 
+    void UpdateSketchBackground(const wxString& imagePath, int opacity);
+
 private:
     DECLARE_EVENT_TABLE()
-
-    void OnFilePickerCtrl_FileChanged(wxCommandEvent& event);
-    void OnSlider_BgAlphaChanged(wxCommandEvent& event);
 
     void OnButton_StartPath(wxCommandEvent& event);
     void OnButton_EndPath(wxCommandEvent& event);
@@ -67,8 +66,6 @@ private:
     SketchUpdateCallback m_sketchUpdateCB;
 
     SketchCanvasPanel* m_sketchCanvasPanel = nullptr;
-    wxFilePickerCtrl* m_filePicker = nullptr;
-    wxSlider* m_bgAlphaSlider = nullptr;
     wxButton* m_startPathBtn = nullptr;
     wxButton* m_endPathBtn = nullptr;
     wxButton* m_closePathBtn = nullptr;
@@ -77,6 +74,7 @@ private:
     wxListBox* m_pathsListBox = nullptr;
     static long ID_MENU_Delete;
 
+    wxString m_bgImagePath;
     wxImage m_bgImage;
     unsigned char m_bitmapAlpha = 0x30;
     int m_pathIndexToDelete = -1;


### PR DESCRIPTION
This makes the sketch-effect background image and opacity into effect settings. They aren't necessary for rendering the effect but it make sequencing easier since they're no longer constantly resetting in the assist panel when copying and pasting effects.