### PR TITLE
Fix potential divide-by-zero crash

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -5483,7 +5483,8 @@ void Model::DeleteHandle(int handle) {
 }
 
 int Model::GetStrandLength(int strand) const {
-    return GetNodeCount() / GetNumStrands();
+    int numStrands = std::max( 1, GetNumStrands() );
+    return GetNodeCount() / numStrands;
 }
 
 int Model::MapToNodeIndex(int strand, int node) const {


### PR DESCRIPTION
I hit a crash when importing a sequence into a relatively-new layout. It may very well be that something is wrong in this new layout but with this change the sequence seems to work just fine. I have imported other sequences into this layout without issue and there are no "Check Sequence" errors. It seems like a low-risk change but I'm not exactly sure what is leading to the divide-by-zero crash.