### PR TITLE
Fix "Prepare Audio" feature

### DIFF
--- a/xLights/AudioManager.cpp
+++ b/xLights/AudioManager.cpp
@@ -3424,7 +3424,8 @@ bool AudioManager::WriteAudioFrame(AVFormatContext *oc, AVCodecContext* codecCon
     AVSampleFormat sampleFmt = AVSampleFormat( cp->format );
 
     AVFrame *frame = av_frame_alloc();
-    frame->format = AV_SAMPLE_FMT_FLTP;
+    frame->format = AV_SAMPLE_FMT_FLT;
+    frame->channels = 2;
     frame->channel_layout = cp->channel_layout;
     frame->nb_samples = sampleCount;
 
@@ -3437,15 +3438,16 @@ bool AudioManager::WriteAudioFrame(AVFormatContext *oc, AVCodecContext* codecCon
     }
 
     AVPacket* pkt = av_packet_alloc();
+    int avretcode = 0;
     //AVPacket pkt;
     //av_init_packet(&pkt);
     pkt->data = nullptr;    // packet data will be allocated by the encoder
     pkt->size = 0;
     pkt->stream_index = st->index;
 
-    if ( avcodec_send_frame( codecContext, frame ) == 0 )
+    if ( (avretcode = avcodec_send_frame( codecContext, frame )) == 0 )
     {
-        if ( avcodec_receive_packet( codecContext, pkt) == 0 )
+        if ( (avretcode = avcodec_receive_packet( codecContext, pkt)) == 0 )
         {
             pkt->stream_index = st->index;
             if ( av_interleaved_write_frame(oc, pkt) != 0 )
@@ -3460,7 +3462,7 @@ bool AudioManager::WriteAudioFrame(AVFormatContext *oc, AVCodecContext* codecCon
 
 	av_packet_free(&pkt);
     av_frame_free(&frame);
-    return true;
+    return avretcode == 0;
 }
 
 bool AudioManager::CreateAudioFile(const std::vector<float>& left, const std::vector<float>& right, const std::string& targetFile, long bitrate)
@@ -3481,9 +3483,10 @@ bool AudioManager::CreateAudioFile(const std::vector<float>& left, const std::ve
 
             if (leftptr != nullptr)
             {
-                memcpy(samples, leftptr, clampedSize * sizeof(float));
-                samples += clampedSize;
-                memcpy(samples, rightptr, clampedSize * sizeof(float));
+                for(int i=0; i<clampedSize; i++){
+                    *(samples++) = leftptr[i];
+                    *(samples++) = rightptr[i];
+                }
                 frameIndex += frameSize;
             }
         }
@@ -3502,9 +3505,9 @@ bool AudioManager::CreateAudioFile(const std::vector<float>& left, const std::ve
     }
 
     AVCodecContext* codecContext = avcodec_alloc_context3( audioCodec );
-    codecContext->bit_rate = 128000;
+    //codecContext->bit_rate = 128000;
     codecContext->sample_fmt = AV_SAMPLE_FMT_FLT;
-    codecContext->sample_rate = 44100;
+    codecContext->sample_rate = RESAMPLE_RATE;
     codecContext->channels = 2;
     codecContext->channel_layout = AV_CH_LAYOUT_STEREO;
 

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -9682,6 +9682,11 @@ void xLightsFrame::OnMenuItem_PrepareAudioSelected(wxCommandEvent& event)
             for (const auto& it : edits) {
                 auto audio = sourceSongs[it.file];
                 if (audio != nullptr) {
+                    // ensure that the audio has been processed by setting a frame interval if its unset
+                    if (audio->GetFrameInterval() < 0){
+                        logger_base.debug("Setting default frame interval for %s.", (const char*)it.file.c_str());
+                        audio->SetFrameInterval(20);
+                    }
                     // check the data is actually loaded
                     audio->GetRawLeftData(audio->GetTrackSize() - 1);
 


### PR DESCRIPTION
This changeset restores the functionality of the Tools > Prepare Audio feature
(tested with .wav format input and output files) as previously I observed the following
issues when attempting to use such in xLights 2022.12 on macOS 12.4 on x86_64:

* xLights would hang inside of AudioManager::GetFilteredAudioData as a result of ProcessFrameData never being called. Therefore, I added a call to set a default framerate of 20FPS in the AudioManager created by the prepare audio feature.

* Output file generation would fail silently as the libavcodec PCM F32LE encoder does not support planar input, therefore refactored to packed input and improved error handling.

* Output audio would playback at the incorrect speed as a result of the output file sample rate being != the sample rate used internally by AudioManager. Therefore removed the hardcoded sample rate and replaces with the RESAMPLE_RATE preprocessor directive.