### PR TITLE
enh hostname validation

### DIFF
--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -1245,30 +1245,12 @@ bool IsIPValidOrHostname(const std::string& ip, bool iponly)
         return true;
     }
 
-    if (ip == "") return false;
+    static wxRegEx regxIPAddr("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
 
-    bool hasChar = false;
-    bool hasDot = false;
-    //hostnames need at least one char in it if fully qualified
-    //if not fully qualified (no .), then the hostname only COULD be just numeric
-    for (size_t y = 0; y < ip.length(); y++) {
-        char x = ip[y];
-        if ((x >= 'a' && x <= 'z') || (x >= 'A' && x <= 'Z') || x == '-') {
-            hasChar = true;
-        }
-        if (x == '.') {
-            hasDot = true;
-        }
+    if (regxIPAddr.Matches(ips)) {
+        return true;
     }
-    if (hasChar || (!hasDot && !hasChar)) {
-        if (iponly) return true;
-        wxIPV4address addr;
-        addr.Hostname(ip);
-        wxString ipAddr = addr.IPAddress();
-        if (ipAddr != "0.0.0.0") {
-            return true;
-        }
-    }
+    
     return false;
 }
 


### PR DESCRIPTION
foo.local is allowed as ctrl ip address, sometimes it highlights red. Also, Output to Lights seems to think this is a problem and asks for validation even though ctrl status is green. 
simplify the validation of valid host names.

FPP-connect can also use some work so "condense" foo.local and its corresponding fpp - ip into just one view.