### PR TITLE
Restore ColorWashPanel being editable in wxsmith

### DIFF
--- a/xLights/effects/ColorWashPanel.cpp
+++ b/xLights/effects/ColorWashPanel.cpp
@@ -11,6 +11,21 @@
 #include "ColorWashPanel.h"
 #include "ColorWashEffect.h"
 
+//(*InternalHeaders(ColorWashPanel)
+#include <wx/bitmap.h>
+#include <wx/bmpbuttn.h>
+#include <wx/checkbox.h>
+#include <wx/image.h>
+#include <wx/intl.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/slider.h>
+#include <wx/stattext.h>
+#include <wx/string.h>
+#include <wx/textctrl.h>
+//*)
+
+//(*IdInit(ColorWashPanel)
 const long ColorWashPanel::ID_STATICTEXT_ColorWash_Cycles = wxNewId();
 const long ColorWashPanel::IDD_SLIDER_ColorWash_Cycles = wxNewId();
 const long ColorWashPanel::ID_VALUECURVE_ColorWash_Cycles = wxNewId();
@@ -23,47 +38,22 @@ const long ColorWashPanel::ID_BITMAPBUTTON_CHECKBOX_ColorWash_HFade = wxNewId();
 const long ColorWashPanel::ID_CHECKBOX_ColorWash_ReverseFades = wxNewId();
 const long ColorWashPanel::ID_CHECKBOX_ColorWash_Shimmer = wxNewId();
 const long ColorWashPanel::ID_CHECKBOX_ColorWash_CircularPalette = wxNewId();
+//*)
 
 BEGIN_EVENT_TABLE(ColorWashPanel,wxPanel)
+//(*EventTable(ColorWashPanel)
+//*)
 END_EVENT_TABLE()
 
 ColorWashPanel::ColorWashPanel(wxWindow* parent) : xlEffectPanel(parent)
 {
+    //(*Initialize(ColorWashPanel)
 	wxFlexGridSizer* FlexGridSizer114;
 	wxFlexGridSizer* FlexGridSizer124;
 	wxFlexGridSizer* FlexGridSizer1;
 	wxFlexGridSizer* FlexGridSizer37;
 	wxFlexGridSizer* FlexGridSizer75;
 	wxFlexGridSizer* FlexGridSizer9;
-
-#if 0
-wxSmith-generated layout (updated for ReverseFadesCheckBox):
-
-37 (0 x 1) main layout
- \
-  9 (0 x 4) (1:4 in 37) 
-   \
-    "Count" (1:4 in 9)
-    1 (0 x 2) (2:4 in 9)
-     \
-      SliderCycles (1:2 in 1)
-      BitmapButton_ColorWash_CyclesVC (2:2 in 1)
-    CyclesTextCtrl (3:4 in 9)
-    BitmapButton_ColorWashCount (4:4 in 9)
-  75 (0 x 5) (2:4 in 37)
-    \
-     VFadeCheckBox (1:4 in 75)
-     BitmapButton_ColorWashVFade (2:4 in 75)
-     HFadeCheckBox (3:4 in 75)
-     BitmapButton_ColorWashHFade (4:4 in 75)
-     ReverseFadeCheckBox(4:5 in 75)
-  114 (0 x 1) (3:4 in 37)
-     \
-      124 (0 x 2) (1:1 in 114)
-         \ 
-          ShimmerCheckBox (1:2 in 124)
-          CircularPaletteCheckBox (2:2 in 124)
-#endif
 
 	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
 
@@ -122,6 +112,7 @@ wxSmith-generated layout (updated for ReverseFadesCheckBox):
 	Connect(ID_BITMAPBUTTON_SLIDER_ColorWash_Cycles,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ColorWashPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_ColorWash_VFade,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ColorWashPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_ColorWash_HFade,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ColorWashPanel::OnLockButtonClick);
+    //*)
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&ColorWashPanel::OnVCChanged, 0, this);
 	Connect(wxID_ANY, EVT_VALIDATEWINDOW, (wxObjectEventFunction)&ColorWashPanel::OnValidateWindow, 0, this);
@@ -135,6 +126,8 @@ wxSmith-generated layout (updated for ReverseFadesCheckBox):
 
 ColorWashPanel::~ColorWashPanel()
 {
+    //(*Destroy(ColorWashPanel)
+    //*)
 }
 
 void ColorWashPanel::ValidateWindow()

--- a/xLights/effects/ColorWashPanel.h
+++ b/xLights/effects/ColorWashPanel.h
@@ -10,6 +10,15 @@
  * License: https://github.com/smeighan/xLights/blob/master/License.txt
  **************************************************************/
 
+//(*Headers(ColorWashPanel)
+#include <wx/panel.h>
+class wxBitmapButton;
+class wxCheckBox;
+class wxFlexGridSizer;
+class wxSlider;
+class wxStaticText;
+class wxTextCtrl;
+//*)
 
 #include "../BulkEditControls.h"
 #include "EffectPanelUtils.h"
@@ -22,7 +31,8 @@ public:
 	virtual ~ColorWashPanel();
 	virtual void ValidateWindow() override;
 
-	BulkEditCheckBox* CircularPaletteCheckBox;
+    //(*Declarations(ColorWashPanel)
+    BulkEditCheckBox* CircularPaletteCheckBox;
 	BulkEditCheckBox* HFadeCheckBox;
 	BulkEditCheckBox* ShimmerCheckBox;
 	BulkEditCheckBox* VFadeCheckBox;
@@ -34,7 +44,9 @@ public:
 	xlLockButton* BitmapButton_ColorWashHFade;
 	xlLockButton* BitmapButton_ColorWashVFade;
     BulkEditCheckBox* ReverseFadesCheckBox;
+    //*)
 
+    //(*Identifiers(ColorWashPanel)
 	static const long ID_STATICTEXT_ColorWash_Cycles;
 	static const long IDD_SLIDER_ColorWash_Cycles;
 	static const long ID_VALUECURVE_ColorWash_Cycles;
@@ -47,6 +59,11 @@ public:
 	static const long ID_CHECKBOX_ColorWash_ReverseFades;
 	static const long ID_CHECKBOX_ColorWash_Shimmer;
 	static const long ID_CHECKBOX_ColorWash_CircularPalette;
+    //*)
+
+    //(*Handlers(ColorWashPanel)
+    //*)
+
 
 	DECLARE_EVENT_TABLE()
 };

--- a/xLights/wxsmith/ColorWashPanel.wxs
+++ b/xLights/wxsmith/ColorWashPanel.wxs
@@ -72,7 +72,7 @@
 			</object>
 			<object class="sizeritem">
 				<object class="wxFlexGridSizer" variable="FlexGridSizer75" member="no">
-					<cols>4</cols>
+					<cols>5</cols>
 					<growablecols>2</growablecols>
 					<object class="sizeritem">
 						<object class="wxCheckBox" name="ID_CHECKBOX_ColorWash_VFade" subclass="BulkEditCheckBox" variable="VFadeCheckBox" member="yes">
@@ -110,6 +110,14 @@
 						</object>
 						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 						<border>1</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxCheckBox" name="ID_CHECKBOX_ColorWash_ReverseFades" subclass="BulkEditCheckBox" variable="ReverseFadesCheckBox" member="yes">
+							<label>Reverse Fades</label>
+						</object>
+						<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
 						<option>1</option>
 					</object>
 				</object>

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -850,8 +850,8 @@
 		<Unit filename="effects/CirclesPanel.h" />
 		<Unit filename="effects/ColorWashEffect.cpp" />
 		<Unit filename="effects/ColorWashEffect.h" />
-		<Unit filename="effects/ColorWashPanel.cpp" />
-		<Unit filename="effects/ColorWashPanel.h" />
+                <Unit filename="effects/ColorWashPanel.cpp" />
+                <Unit filename="effects/ColorWashPanel.h" />
 		<Unit filename="effects/CurtainEffect.cpp" />
 		<Unit filename="effects/CurtainEffect.h" />
 		<Unit filename="effects/CurtainPanel.cpp" />
@@ -1397,6 +1397,7 @@
 		<Unit filename="wxsmith/ColorCurveDialog.wxs" />
 		<Unit filename="wxsmith/ColorManagerDialog.wxs" />
 		<Unit filename="wxsmith/ColorPanel.wxs" />
+                <Unit filename="wxsmith/ColorWashPanel.wxs" />
 		<Unit filename="wxsmith/ColourReplaceDialog.wxs" />
 		<Unit filename="wxsmith/ColoursPanel.wxs" />
 		<Unit filename="wxsmith/ControllerConnectionDialog.wxs" />
@@ -1678,6 +1679,7 @@
 					<wxPanel wxs="wxsmith/ButterflyPanel.wxs" src="effects/ButterflyPanel.cpp" hdr="effects/ButterflyPanel.h" fwddecl="1" i18n="1" name="ButterflyPanel" language="CPP" />
 					<wxPanel wxs="wxsmith/CandlePanel.wxs" src="effects/CandlePanel.cpp" hdr="effects/CandlePanel.h" fwddecl="1" i18n="1" name="CandlePanel" language="CPP" />
 					<wxPanel wxs="wxsmith/CirclesPanel.wxs" src="effects/CirclesPanel.cpp" hdr="effects/CirclesPanel.h" fwddecl="1" i18n="1" name="CirclesPanel" language="CPP" />
+                                        <wxPanel wxs="wxsmith/ColorWashPanel.wxs" src="effects/ColorWashPanel.cpp" hdr = "effects/ColorWashPanel.h" fwddecl="1" i18n="1" name="CirclesPanel" language="CPP" />
 					<wxPanel wxs="wxsmith/CurtainPanel.wxs" src="effects/CurtainPanel.cpp" hdr="effects/CurtainPanel.h" fwddecl="1" i18n="1" name="CurtainPanel" language="CPP" />
 					<wxPanel wxs="wxsmith/DMXPanel.wxs" src="effects/DMXPanel.cpp" hdr="effects/DMXPanel.h" fwddecl="1" i18n="1" name="DMXPanel" language="CPP" />
 					<wxPanel wxs="wxsmith/FacesPanel.wxs" src="effects/FacesPanel.cpp" hdr="effects/FacesPanel.h" fwddecl="1" i18n="1" name="FacesPanel" language="CPP" />


### PR DESCRIPTION
Sorry, I broke this in an earlier merge... effect panels should still work in the UI builder.