### PR TITLE
#3712 Option 2 - Code consolidation

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -448,7 +448,6 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
                                         // Default style
                                         wxPG_DEFAULT_STYLE);
     propertyEditor->SetExtraStyle(wxWS_EX_PROCESS_IDLE | wxPG_EX_HELP_AS_TOOLTIPS);
-    LayoutUtils::CreateImageList(m_imageList);
 
     wxFlexGridSizer* FlexGridSizerModels = new wxFlexGridSizer(0, 1, 0, 0);
 	FlexGridSizerModels->AddGrowableCol(0);
@@ -596,7 +595,7 @@ wxTreeListCtrl* LayoutPanel::CreateTreeListCtrl(long style, wxPanel* panel)
         tree = new wxTreeListCtrl(panel, ID_TREELISTVIEW_MODELS,
                                   wxDefaultPosition, wxDefaultSize,
                                   style, "ID_TREELISTVIEW_MODELS");
-    tree->SetImages(m_imageList);
+    tree->SetImages(LayoutUtils::getGlobalImageList());
 
     tree->AppendColumn(MODELCOLNAME,
                        wxCOL_WIDTH_AUTOSIZE,

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -494,7 +494,6 @@ class LayoutPanel: public wxPanel
         int previewBackgroundBrightness = 100;
         int previewBackgroundAlpha = 100;
         wxPanel* main_sequencer = nullptr;
-        wxVector<wxBitmapBundle> m_imageList;
 
         bool editing_models = true;
         bool is_3d = false;

--- a/xLights/LayoutUtils.cpp
+++ b/xLights/LayoutUtils.cpp
@@ -18,58 +18,38 @@
 
 namespace LayoutUtils
 {
-    void CreateImageList(wxVector<wxBitmapBundle> & imageList)
+    wxVector<wxBitmapBundle>& getGlobalImageList()
     {
-        imageList.push_back(wxArtProvider::GetBitmapBundle("wxART_NORMAL_FILE", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_GROUP_CLOSED", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_GROUP_OPEN", wxART_LIST));
-        imageList.push_back(BitmapCache::GetModelGroupIcon());
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_ARCH_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CANE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CIRCLE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CHANNELBLOCK_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CUBE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CUSTOM_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_DMX_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_ICICLE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_IMAGE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_LINE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_MATRIX_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_POLY_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SPHERE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SPINNER_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_STAR_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SUBMODEL_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_TREE_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_WINDOW_ICON", wxART_LIST));
-        imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_WREATH_ICON", wxART_LIST));
-    }
+        static wxVector<wxBitmapBundle> imageList;
+        static bool loaded = false;
+        if (!loaded) {
+            loaded = true;
 
-    void CreateImageList(wxImageList* imageList)
-    {
-        imageList->Add(wxArtProvider::GetIcon("wxART_NORMAL_FILE", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_GROUP_CLOSED", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_GROUP_OPEN", wxART_LIST));
-        imageList->Add(BitmapCache::GetModelGroupIcon().GetIcon(wxDefaultSize));
-        imageList->Add(wxArtProvider::GetIcon("xlART_ARCH_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_CANE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_CIRCLE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_CHANNELBLOCK_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_CUBE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_CUSTOM_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_DMX_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_ICICLE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_IMAGE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_LINE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_MATRIX_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_POLY_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_SPHERE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_SPINNER_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_STAR_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_SUBMODEL_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_TREE_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_WINDOW_ICON", wxART_LIST));
-        imageList->Add(wxArtProvider::GetIcon("xlART_WREATH_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("wxART_NORMAL_FILE", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_GROUP_CLOSED", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_GROUP_OPEN", wxART_LIST));
+            imageList.push_back(BitmapCache::GetModelGroupIcon());
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_ARCH_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CANE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CIRCLE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CHANNELBLOCK_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CUBE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_CUSTOM_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_DMX_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_ICICLE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_IMAGE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_LINE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_MATRIX_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_POLY_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SPHERE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SPINNER_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_STAR_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_SUBMODEL_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_TREE_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_WINDOW_ICON", wxART_LIST));
+            imageList.push_back(wxArtProvider::GetBitmapBundle("xlART_WREATH_ICON", wxART_LIST));
+        }
+        return imageList;
     }
 
     int GetModelTreeIcon(std::string const& type, GroupMode mode)

--- a/xLights/LayoutUtils.h
+++ b/xLights/LayoutUtils.h
@@ -51,8 +51,6 @@ namespace LayoutUtils
         
     };
 
-    void CreateImageList(wxVector<wxBitmapBundle> & imageList);
-    void CreateImageList(wxImageList* imageList);
+    wxVector<wxBitmapBundle>& getGlobalImageList();
     int GetModelTreeIcon(std::string const& type, GroupMode mode);
-
 };

--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -689,10 +689,7 @@ bool xLightsImportChannelMapDialog::InitImport(std::string checkboxText) {
         TreeListCtrl_Mapping->AppendColumn(new wxDataViewColumn("Color", new ColorRenderer(), 2, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));
     }
 
-    m_imageList = std::make_unique<wxImageList>(16, 16, true);
-    LayoutUtils::CreateImageList(m_imageList.get());
-
-    ListCtrl_Available->SetImageList(m_imageList.get(), wxIMAGE_LIST_SMALL);
+    ListCtrl_Available->SetSmallImages(LayoutUtils::getGlobalImageList());
 
     TreeListCtrl_Mapping->SetMinSize(wxSize(0, 300));
     SizerMap->Add(TreeListCtrl_Mapping, 1, wxALL | wxEXPAND, 5);

--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -523,7 +523,6 @@ protected:
         SequencePackage* _xsqPkg {nullptr};
 
         std::vector<std::unique_ptr<ImportChannel>> importChannels;
-        std::unique_ptr<wxImageList> m_imageList;
 
 		DECLARE_EVENT_TABLE()
 


### PR DESCRIPTION
This approach cuts down the code that builds the image list to one copy, for one data structure, and holds it globally.
While the code is cleaner, this changes the object lifecycle and API calls for the dialog, so someone who understands this on a deep level would have to approve.