### PR TITLE
Missing refresh call

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2735,6 +2735,7 @@ void LayoutPanel::OnButtonSavePreviewClick(wxCommandEvent& event)
     SaveEffects();
     if (xlights->IsControllersAndLayoutTabSaveLinked()) {
         xlights->SaveNetworksFile();
+        xlights->UpdateLayoutSave(); // SaveEffects tried to do this, but if the saves are linked it is marked dirty til nets are saved.
     }
 }
 


### PR DESCRIPTION
See #3648, but this addresses only part of that issue.

On master, when the save of controllers and layout is synced, and there's a layout and controller change, the layout save button is pink, as it should be, but when you click save, it stays pink.

This is because the save process saves the layout, then updates the button color, then if linked it saves network.  But because network was still unsaved when the button color was updated, it stays pink.

I added a call to set the color again in this scenario.