### PR TITLE
Ripple Rotation VC

### DIFF
--- a/xLights/effects/RipplePanel.cpp
+++ b/xLights/effects/RipplePanel.cpp
@@ -217,12 +217,14 @@ RipplePanel::RipplePanel(wxWindow* parent) : xlEffectPanel(parent)
 
 	Connect(ID_VALUECURVE_Ripple_XC, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&RipplePanel::OnVCButtonClick);
 	Connect(ID_VALUECURVE_Ripple_YC, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&RipplePanel::OnVCButtonClick);
+    Connect(ID_VALUECURVE_Ripple_Rotation, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&RipplePanel::OnVCButtonClick);
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&RipplePanel::OnVCChanged, 0, this);
     Connect(wxID_ANY, EVT_VALIDATEWINDOW, (wxObjectEventFunction)&RipplePanel::OnValidateWindow, 0, this);
 
 	BitmapButton_Ripple_XCVC->GetValue()->SetLimits(RIPPLE_XC_MIN, RIPPLE_XC_MAX);
 	BitmapButton_Ripple_YCVC->GetValue()->SetLimits(RIPPLE_YC_MIN, RIPPLE_YC_MAX);
+    BitmapButton_Ripple_RotationVC->GetValue()->SetLimits(RIPPLE_ROTATION_MIN, RIPPLE_ROTATION_MAX);
 	BitmapButton_Ripple_CyclesVC->GetValue()->SetLimits(RIPPLE_CYCLES_MIN, RIPPLE_CYCLES_MAX);
     BitmapButton_Ripple_CyclesVC->GetValue()->SetDivisor(10);
     BitmapButton_Ripple_ThicknessVC->GetValue()->SetLimits(RIPPLE_THICKNESS_MIN, RIPPLE_THICKNESS_MAX);


### PR DESCRIPTION
Issue #3726.  The Ripple Effect's rotation value curve button is not hooked up on master... it appears but clicking it does nothing.

On inspection, 2 of the 5 value curve buttons are registered in the .wxs file and are attached to handlers in the auto-generated portion of the panel.  2 others are not given handlers in the .wxs file and have had their handlers done outside the auto-generated code.

Rotation wasn't connected either place.

For the moment, I have connected the rotation button outside the auto-generated stuff.  If maintainers want the wxs file updated and the code regenerated to make all 3 hookups automatic, I can attempt that fix instead.
