### PR TITLE
Confirmation prompt when cancelling the Submodels creation dialog window

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -360,6 +360,8 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Connect(wxID_ANY, EVT_SMDROP, (wxObjectEventFunction)&SubModelsDialog::OnDrop);
     Connect(ID_GRID1, wxEVT_GRID_CELL_CHANGED,(wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellChange);
     //Connect(ID_GRID1, wxEVT_CHAR, (wxObjectEventFunction)&SubModelsDialog::OnGridChar);
+    Connect(wxID_ANY, wxEVT_CLOSE_WINDOW, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
+    Connect(wxID_CANCEL, wxEVT_BUTTON, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
 
     TextCtrl_Name->Bind(wxEVT_KILL_FOCUS, &SubModelsDialog::OnTextCtrl_NameText_KillFocus, this);
 
@@ -447,6 +449,14 @@ void SubModelsDialog::OnInit(wxInitDialogEvent& event)
 void SubModelsDialog::OnSubbufferSize(wxSizeEvent& event)
 {
     subBufferPanel->Refresh();
+}
+
+void SubModelsDialog::OnCancel(wxCloseEvent& event)
+{
+    if (wxMessageBox("Are you sure you want to close the Submodels window?", "Are you sure?", wxYES_NO | wxCENTER, this) == wxNO) {
+        return;
+    }
+    SubModelsDialog::EndDialog(wxID_CANCEL);
 }
 
 SubModelsDialog::~SubModelsDialog()

--- a/xLights/SubModelsDialog.h
+++ b/xLights/SubModelsDialog.h
@@ -316,9 +316,9 @@ private:
     void OnInit(wxInitDialogEvent& event);
     void OnNodesGridCellRightClick(wxGridEvent& event);
     void OnCheckBox_OutputToLightsClick(wxCommandEvent& event);
-    void OnCancel(wxCloseEvent& event);
     //*)
 
+    void OnCancel(wxCloseEvent& event);
     void OnPreviewLeftUp(wxMouseEvent& event);
     void OnPreviewMouseLeave(wxMouseEvent& event);
     void OnPreviewLeftDown(wxMouseEvent& event);

--- a/xLights/SubModelsDialog.h
+++ b/xLights/SubModelsDialog.h
@@ -316,6 +316,7 @@ private:
     void OnInit(wxInitDialogEvent& event);
     void OnNodesGridCellRightClick(wxGridEvent& event);
     void OnCheckBox_OutputToLightsClick(wxCommandEvent& event);
+    void OnCancel(wxCloseEvent& event);
     //*)
 
     void OnPreviewLeftUp(wxMouseEvent& event);


### PR DESCRIPTION
The submodels dialog is where a lot of time gets spent and accidentally hitting the escape key will close the window without any prompt. It is one of the few windows in xlights that doesn't have any kind of confirmation when closing.

I have added a confirmation dialog when you press the escape key on the keyboard or using the cancel button on the screen.    

We could potentially just disable the escape key being used completely if needed.

Here is a screenshot.
![ClosingSubmodels](https://user-images.githubusercontent.com/25444831/223748362-57bd1d62-80ab-4d8d-8e12-eced12e8b5d2.jpg)
