### PR TITLE
Header accidentally in WX section

### DIFF
--- a/xSchedule/PlayList/PlayListItemProjectorPanel.cpp
+++ b/xSchedule/PlayList/PlayListItemProjectorPanel.cpp
@@ -13,11 +13,11 @@
 #include "PlayListDialog.h"
 
 #include "../ProjectorCodes.h"
+#include "../../xLights/outputs/SerialOutput.h"
 
 //(*InternalHeaders(PlayListItemProjectorPanel)
 #include <wx/intl.h>
 #include <wx/string.h>
-#include "../../xLights/outputs/SerialOutput.h"
 //*)
 
 //(*IdInit(PlayListItemProjectorPanel)


### PR DESCRIPTION
Moved header outside of wx section to keep codeblocks wxsmith from wiping it.