### PR TITLE
Add ability to press ENTER to save a submodel name

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -362,6 +362,7 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     //Connect(ID_GRID1, wxEVT_CHAR, (wxObjectEventFunction)&SubModelsDialog::OnGridChar);
     Connect(wxID_ANY, wxEVT_CLOSE_WINDOW, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
     Connect(wxID_CANCEL, wxEVT_BUTTON, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
+    Connect(ID_TEXTCTRL_NAME, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&SubModelsDialog::ApplySubmodelName);
 
     TextCtrl_Name->Bind(wxEVT_KILL_FOCUS, &SubModelsDialog::OnTextCtrl_NameText_KillFocus, this);
 


### PR DESCRIPTION
Currently when editing a submodel, if you edit the name and then click on a different submodel, you will lose the name you typed.
When pressing ENTER nothing happens, it only calls the ApplySubmodelName when the focus is lost.
I tend to create batches of submodels, so i name them first and then work on each. 

I have added the Connect to enable the user the Press the ENTER button to save the submodel name.
![SubmodelEnter](https://user-images.githubusercontent.com/25444831/227268248-3fc6b743-acbb-47ff-a544-04453f042b89.jpg)
