### PR TITLE
Reset Value Curve buttons

### DIFF
--- a/xLights/BitmapCache.cpp
+++ b/xLights/BitmapCache.cpp
@@ -601,7 +601,7 @@ wxBitmapBundle BitmapCache::GetModelGroupIcon() {
     return CreateBitmapBundleFromXPMs(16, "ModelGroup", {model_16, model_64, model_64, model_64, model_64});
 }
 wxBitmapBundle BitmapCache::GetFPPIcon() {
-    return wxBitmapBundle::FromSVG((const char*)fpp_app_icon_svg, wxSize(16, 16));
+    return wxBitmapBundle::FromSVG(fpp_app_icon_svg, sizeof(fpp_app_icon_svg), wxSize(16, 16));
 }
 
 const wxImage &BitmapCache::GetCornerIcon(int position, int size) {

--- a/xLights/effects/BarsEffect.cpp
+++ b/xLights/effects/BarsEffect.cpp
@@ -76,6 +76,7 @@ void BarsEffect::SetDefaultParameters() {
 
     bp->BitmapButton_Bars_BarCount->SetActive(false);
     bp->BitmapButton_Bars_Cycles->SetActive(false);
+    bp->BitmapButton_Bars_Center->SetActive(false);
 
     SetSliderValue(bp->Slider_Bars_BarCount, 1);
     SetSliderValue(bp->Slider_Bars_Cycles, 10);

--- a/xLights/effects/LiquidEffect.cpp
+++ b/xLights/effects/LiquidEffect.cpp
@@ -73,9 +73,12 @@ void LiquidEffect::SetDefaultParameters()
     SetCheckBoxValue(tp->CheckBox_HoldColor, true);
     SetCheckBoxValue(tp->CheckBox_MixColors, false);
     SetChoiceValue(tp->Choice_ParticleType, "Elastic");
+
     SetSliderValue(tp->Slider_LifeTime, 10000);
     SetSliderValue(tp->Slider_Despeckle, 0);
     SetSliderValue(tp->Slider_WarmUpFrames, 0);
+    SetSliderValue(tp->Slider_Liquid_Gravity, 100);
+    SetSliderValue(tp->Slider_Liquid_GravityAngle, 0);
 
     SetSliderValue(tp->Slider_X1, 50);
     SetSliderValue(tp->Slider_Y1, 100);
@@ -114,6 +117,8 @@ void LiquidEffect::SetDefaultParameters()
     SetCheckBoxValue(tp->CheckBox_FlowMusic4, false);
 
     tp->BitmapButton_LifeTime->SetActive(false);
+    tp->BitmapButton_Liquid_Gravity->SetActive(false);
+    tp->BitmapButton_Liquid_GravityAngle->SetActive(false);
 
     tp->BitmapButton_X1->SetActive(false);
     tp->BitmapButton_Y1->SetActive(false);

--- a/xLights/effects/PicturesEffect.cpp
+++ b/xLights/effects/PicturesEffect.cpp
@@ -403,6 +403,7 @@ void PicturesEffect::SetDefaultParameters() {
 
     SetSliderValue(pp->Slider_Pictures_Speed, 10);
     SetSliderValue(pp->Slider_Pictures_FR, 10);
+    SetSliderValue(pp->Slider1, 0);
     SetSliderValue(pp->Slider_PicturesXC, 0);
     SetSliderValue(pp->Slider_PicturesYC, 0);
     SetSliderValue(pp->Slider_PicturesEndXC, 0);
@@ -418,6 +419,7 @@ void PicturesEffect::SetDefaultParameters() {
     SetCheckBoxValue(pp->CheckBox_Pictures_Shimmer, false);
     SetCheckBoxValue(pp->CheckBox_LoopGIF, false);
     SetCheckBoxValue(pp->CheckBox_SuppressGIFBackground, true);
+    SetCheckBoxValue(pp->CheckBox_TransparentBlack, false);
 
     pp->FilePickerCtrl1->SetFileName(wxFileName());
 

--- a/xLights/effects/RippleEffect.cpp
+++ b/xLights/effects/RippleEffect.cpp
@@ -60,6 +60,8 @@ void RippleEffect::SetDefaultParameters()
     rp->BitmapButton_Ripple_CyclesVC->SetActive(false);
     rp->BitmapButton_Ripple_ThicknessVC->SetActive(false);
     rp->BitmapButton_Ripple_RotationVC->SetActive(false);
+    rp->BitmapButton_Ripple_XCVC->SetActive(false);
+    rp->BitmapButton_Ripple_YCVC->SetActive(false);
 
     SetChoiceValue(rp->Choice_Ripple_Object_To_Draw, "Circle");
     SetChoiceValue(rp->Choice_Ripple_Movement, "Explode");
@@ -68,6 +70,8 @@ void RippleEffect::SetDefaultParameters()
     SetSliderValue(rp->Slider_Ripple_Cycles, 10);
     SetSliderValue(rp->Slider_Ripple_Points, 5);
     SetSliderValue(rp->Slider_Ripple_Rotation, 0);
+    SetSliderValue(rp->Slider_Ripple_XC, 0);
+    SetSliderValue(rp->Slider_Ripple_YC, 0);
 
     SetCheckBoxValue(rp->CheckBox_Ripple3D, false);
 }

--- a/xLights/effects/ShapeEffect.cpp
+++ b/xLights/effects/ShapeEffect.cpp
@@ -167,6 +167,8 @@ void ShapeEffect::SetDefaultParameters() {
     sp->BitmapButton_Shape_ThicknessVC->SetActive(false);
     sp->BitmapButton_Shape_CentreXVC->SetActive(false);
     sp->BitmapButton_Shape_CentreYVC->SetActive(false);
+    sp->BitmapButton_Shapes_Velocity->SetActive(false);
+    sp->BitmapButton_Shapes_Direction->SetActive(false);
     sp->BitmapButton_Shape_LifetimeVC->SetActive(false);
     sp->BitmapButton_Shape_GrowthVC->SetActive(false);
     sp->BitmapButton_Shape_CountVC->SetActive(false);
@@ -185,6 +187,8 @@ void ShapeEffect::SetDefaultParameters() {
     SetSliderValue(sp->Slider_Shape_Lifetime, 5);
     SetSliderValue(sp->Slider_Shape_Sensitivity, 50);
     SetSliderValue(sp->Slider_Shape_Rotation, 0);
+    SetSliderValue(sp->Slider_Shapes_Velocity, 0);
+    SetSliderValue(sp->Slider_Shapes_Direction, 90);
 
     SetCheckBoxValue(sp->CheckBox_Shape_RandomLocation, true);
     SetCheckBoxValue(sp->CheckBox_Shape_FadeAway, true);

--- a/xLights/effects/TwinkleEffect.cpp
+++ b/xLights/effects/TwinkleEffect.cpp
@@ -61,9 +61,9 @@ public:
     virtual ~TwinkleRenderCache() {};
     
     std::vector<StrobeClass> strobe;
-    int num_lights;
-    int curNumStrobe;
-    std::atomic_int lights_to_renew;
+    int num_lights = 0;
+    int curNumStrobe = 0;
+    std::atomic_int lights_to_renew = 0;
 };
 
 void TwinkleEffect::SetDefaultParameters()

--- a/xLights/effects/VUMeterEffect.cpp
+++ b/xLights/effects/VUMeterEffect.cpp
@@ -127,23 +127,23 @@ std::list<std::string> VUMeterEffect::CheckEffectSettings(const SettingsMap& set
          type == "Volume Bars" ||
          type == "Waveform" ||
          type == "On" ||
-        type == "Intensity Wave" ||
-            type == "Level Bar" ||
-            type == "Level Random Bar" ||
-            type == "Note Level Bar" ||
-            type == "Note Level Random Bar" ||
-            type == "Level Pulse" ||
-            type == "Level Jump" ||
-            type == "Level Jump 100" ||
-            type == "Level Pulse Color" ||
-        type == "Level Shape" ||
-        type == "Color On" ||
-        type == "Note On" ||
-        type == "Note Level Pulse" ||
-        type == "Timing Event Jump" ||
-            type == "Dominant Frequency Colour" ||
-            type == "Dominant Frequency Colour Gradient"
-            ))
+         type == "Intensity Wave" ||
+         type == "Level Bar" ||
+         type == "Level Random Bar" ||
+         type == "Note Level Bar" ||
+         type == "Note Level Random Bar" ||
+         type == "Level Pulse" ||
+         type == "Level Jump" ||
+         type == "Level Jump 100" ||
+         type == "Level Pulse Color" ||
+         type == "Level Shape" ||
+         type == "Color On" ||
+         type == "Note On" ||
+         type == "Note Level Pulse" ||
+         type == "Timing Event Jump" ||
+         type == "Dominant Frequency Colour" ||
+         type == "Dominant Frequency Colour Gradient"
+       ))
     {
         res.push_back(wxString::Format("    ERR: VU Meter effect '%s' is pointless if there is no music. Model '%s', Start %s", type, model->GetName(), FORMATTIME(eff->GetStartTimeMS())).ToStdString());
     }

--- a/xLights/effects/VideoEffect.cpp
+++ b/xLights/effects/VideoEffect.cpp
@@ -177,7 +177,7 @@ void VideoEffect::SetDefaultParameters()
     SetChoiceValue(vp->Choice_Video_DurationTreatment, "Normal");
 
     SetCheckBoxValue(vp->CheckBox_TransparentBlack, false);
-    SetSliderValue(vp->Slider1, false);
+    SetSliderValue(vp->Slider1, 0);
 }
 
 std::list<std::string> VideoEffect::GetFileReferences(Model* model, const SettingsMap &SettingsMap) const

--- a/xLights/effects/VideoEffect.cpp
+++ b/xLights/effects/VideoEffect.cpp
@@ -175,6 +175,9 @@ void VideoEffect::SetDefaultParameters()
     vp->BitmapButton_Video_Speed->SetActive(false);
     SetCheckBoxValue(vp->CheckBox_Video_AspectRatio, false);
     SetChoiceValue(vp->Choice_Video_DurationTreatment, "Normal");
+
+    SetCheckBoxValue(vp->CheckBox_TransparentBlack, false);
+    SetSliderValue(vp->Slider1, false);
 }
 
 std::list<std::string> VideoEffect::GetFileReferences(Model* model, const SettingsMap &SettingsMap) const


### PR DESCRIPTION
A few cases where the value curve bitmap button wasn't reset when resetting the panel via SetDefaultParameters().  See issue #3775.
Also fixes #3759.
Verified that this doesn't cause any rendering differences in a small test set that tries to do a little bit of everything.
