### PR TITLE
Update EffectsPanel.cpp to fix issue #3777

### DIFF
--- a/xLights/EffectsPanel.cpp
+++ b/xLights/EffectsPanel.cpp
@@ -75,6 +75,7 @@ EffectsPanel::EffectsPanel(wxWindow *parent, EffectManager *manager, wxTimer *ti
         fgs->Add(panel, 1, wxALL|wxEXPAND|wxALIGN_LEFT|wxALIGN_TOP, 2);
 
         sw->SetSizer(fgs);
+	sw->SetScrollRate(5, 5);
         fgs->Fit(sw);
         fgs->SetSizeHints(sw);
 


### PR DESCRIPTION
First time looking at the code, so take this with a grain of salt, as I'm not sure what else this change effects.  However, its one line of code to get the vertical scroll bar on the effects panel without having to resize or refresh it.  I used the same SetScrollRate settings found later in the file at line 292.