### PR TITLE
Add two new transformation types

### DIFF
--- a/xLights/BufferPanel.cpp
+++ b/xLights/BufferPanel.cpp
@@ -174,6 +174,8 @@ BufferPanel::BufferPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, co
 	BufferTransform->Append(_("Rotate 180"));
 	BufferTransform->Append(_("Flip Vertical"));
 	BufferTransform->Append(_("Flip Horizontal"));
+    BufferTransform->Append(_("Rotate CC 90 Flip Horizontal"));
+    BufferTransform->Append(_("Rotate CW 90 Flip Horizontal"));
 	BufferSizer->Add(BufferTransform, 1, wxALL|wxEXPAND, 2);
 	BitmapButton_BufferTransform = new xlLockButton(ScrolledWindow1, ID_BITMAPBUTTON_CHOICE_BufferTransform, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHOICE_BufferTransform"));
 	BitmapButton_BufferTransform->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -56,6 +56,8 @@
 #include "../xSchedule/wxJSON/jsonreader.h"
 #include "CachedFileDownloader.h"
 
+#include <algorithm>
+
 #define MOST_STRINGS_WE_EXPECT 480
 
 const long Model::ID_LAYERSIZE_INSERT = wxNewId();
@@ -3701,10 +3703,11 @@ void Model::DumpBuffer(std::vector<NodeBaseClassPtr> &newNodes,
     }
 }
 
-void Model::ApplyTransform(const std::string &type,
-                    std::vector<NodeBaseClassPtr> &newNodes,
-                    int &bufferWi, int &bufferHi) const {
-    //"Rotate CC 90", "Rotate CW 90", "Rotate 180", "Flip Vertical", "Flip Horizontal",
+void Model::ApplyTransform(const std::string& type,
+                           std::vector<NodeBaseClassPtr>& newNodes,
+                           int& bufferWi, int& bufferHi) const
+{
+    //"Rotate CC 90", "Rotate CW 90", "Rotate 180", "Flip Vertical", "Flip Horizontal", "Rotate CC 90 Flip Horizontal", "Rotate CW 90 Flip Horizontal"
     if (type == "None") {
         return;
     } else if (type == "Rotate 180") {
@@ -3731,18 +3734,40 @@ void Model::ApplyTransform(const std::string &type,
                 SetCoords(it2, bufferHi - it2.bufY - 1, it2.bufX);
             }
         }
-        int tmp = bufferHi;
-        bufferHi = bufferWi;
-        bufferWi = tmp;
+        std::swap(bufferWi, bufferHi);
     } else if (type == "Rotate CC 90") {
         for (int x = 0; x < newNodes.size(); x++) {
             for (auto& it2 : newNodes[x]->Coords) {
                 SetCoords(it2, it2.bufY, bufferWi - it2.bufX - 1);
             }
         }
-        int tmp = bufferHi;
-        bufferHi = bufferWi;
-        bufferWi = tmp;
+        std::swap(bufferWi, bufferHi);
+    } else if (type == "Rotate CC 90 Flip Horizontal") {
+        for (int x = 0; x < newNodes.size(); x++) {
+            for (auto& it2 : newNodes[x]->Coords) {
+                SetCoords(it2, it2.bufY, bufferWi - it2.bufX - 1);
+            }
+        }
+        std::swap(bufferWi, bufferHi);
+
+        for (size_t x = 0; x < newNodes.size(); x++) {
+            for (auto& it2 : newNodes[x]->Coords) {
+                SetCoords(it2, it2.bufX, bufferHi - it2.bufY - 1);
+            }
+        }
+    } else if (type == "Rotate CW 90 Flip Horizontal") {
+        for (size_t x = 0; x < newNodes.size(); x++) {
+            for (auto& it2 : newNodes[x]->Coords) {
+                SetCoords(it2, bufferHi - it2.bufY - 1, it2.bufX);
+            }
+        }
+        std::swap(bufferWi, bufferHi);
+
+        for (size_t x = 0; x < newNodes.size(); x++) {
+            for (auto& it2 : newNodes[x]->Coords) {
+                SetCoords(it2, it2.bufX, bufferHi - it2.bufY - 1);
+            }
+        }
     }
 }
 

--- a/xLights/wxsmith/BufferPanel.wxs
+++ b/xLights/wxsmith/BufferPanel.wxs
@@ -109,6 +109,8 @@
 																<item>Rotate 180</item>
 																<item>Flip Vertical</item>
 																<item>Flip Horizontal</item>
+																<item>Rotate CC 90 Flip Horizontal</item>
+																<item>Rotate CW 90 Flip Horizontal</item>
 															</content>
 															<selection>0</selection>
 															<handler function="OnBufferTransformSelect" entry="EVT_CHOICE" />


### PR DESCRIPTION
A small addition requested by Clyde Lindsey. Adding two additional transform types (which are just combinations of existing ones). For cases where the same effect is layered multiple times, this can allow "the pattern to be completed" as seen with the pinwheel effect here.... the two blue arms utilize the new transform types. The red and green ones use the six existing transforms.
![capture](https://user-images.githubusercontent.com/3072583/230700701-08b6f90f-7f9b-4007-8014-46e12e5aeef7.png)
