### PR TITLE
Fix Shape effect SVG #3784

### DIFF
--- a/xLights/effects/RippleEffect.cpp
+++ b/xLights/effects/RippleEffect.cpp
@@ -93,7 +93,7 @@ void RippleEffect::SetDefaultParameters()
     SetSliderValue(rp->Slider_Ripple_Spacing, 10);
     SetSliderValue(rp->Slider_Ripple_Outline, 10);
 
-    rp->FilePickerCtrl_SVG->SetFileName(wxFileName(""));
+    rp->FilePickerCtrl_Ripple_SVG->SetFileName(wxFileName(""));
 
     SetCheckBoxValue(rp->CheckBox_Ripple3D, false);
     SetChoiceValue(rp->Choice_Ripple_Draw_Style, "Old");

--- a/xLights/effects/RippleEffect.cpp
+++ b/xLights/effects/RippleEffect.cpp
@@ -931,7 +931,7 @@ void RippleEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Render
 {
     float oset = buffer.GetEffectTimeIntervalPosition();
     const std::string& Object_To_DrawStr = SettingsMap["CHOICE_Ripple_Object_To_Draw"];
-    std::string svgFilename = SettingsMap["FILEPICKERCTRL_SVG"];
+    std::string svgFilename = SettingsMap["FILEPICKERCTRL_Ripple_SVG"];
     const std::string& MovementStr = SettingsMap["CHOICE_Ripple_Movement"];
     int Ripple_Thickness = GetValueCurveInt("Ripple_Thickness", 3, SettingsMap, oset, RIPPLE_THICKNESS_MIN, RIPPLE_THICKNESS_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS());
     bool CheckBox_Ripple3D = SettingsMap.GetBool("CHECKBOX_Ripple3D", false);
@@ -1676,8 +1676,8 @@ void RippleEffect::Drawcandycane(RenderBuffer& buffer, int Movement, int xc, int
 std::list<std::string> RippleEffect::GetFileReferences(Model* model, const SettingsMap& SettingsMap) const
 {
     std::list<std::string> res;
-    if (SettingsMap["E_FILEPICKERCTRL_SVG"] != "") {
-        res.push_back(SettingsMap["E_FILEPICKERCTRL_SVG"]);
+    if (SettingsMap["E_FILEPICKERCTRL_Ripple_SVG"] != "") {
+        res.push_back(SettingsMap["E_FILEPICKERCTRL_Ripple_SVG"]);
     }
     return res;
 }
@@ -1688,7 +1688,7 @@ std::list<std::string> RippleEffect::CheckEffectSettings(const SettingsMap& sett
 
     std::string object = settings["E_CHOICE_Ripple_Object_To_Draw"];
     if (object == "SVG") {
-        auto svgFilename = settings.Get("E_FILEPICKERCTRL_SVG", "");
+        auto svgFilename = settings.Get("E_FILEPICKERCTRL_Ripple_SVG", "");
 
         if (svgFilename == "" || !FileExists(svgFilename)) {
             res.push_back(wxString::Format("    ERR: Ripple effect can't find SVG file '%s'. Model '%s', Start %s", svgFilename, model->GetName(), FORMATTIME(eff->GetStartTimeMS())).ToStdString());
@@ -1705,10 +1705,10 @@ std::list<std::string> RippleEffect::CheckEffectSettings(const SettingsMap& sett
 bool RippleEffect::CleanupFileLocations(xLightsFrame* frame, SettingsMap& SettingsMap)
 {
     bool rc = false;
-    wxString file = SettingsMap["E_FILEPICKERCTRL_SVG"];
+    wxString file = SettingsMap["E_FILEPICKERCTRL_Ripple_SVG"];
     if (FileExists(file)) {
         if (!frame->IsInShowFolder(file)) {
-            SettingsMap["E_FILEPICKERCTRL_SVG"] = frame->MoveToShowFolder(file, wxString(wxFileName::GetPathSeparator()) + "Images");
+            SettingsMap["E_FILEPICKERCTRL_Ripple_SVG"] = frame->MoveToShowFolder(file, wxString(wxFileName::GetPathSeparator()) + "Images");
             rc = true;
         }
     }
@@ -1719,12 +1719,16 @@ bool RippleEffect::CleanupFileLocations(xLightsFrame* frame, SettingsMap& Settin
 // This section is not doing what I want
 bool RippleEffect::needToAdjustSettings(const std::string& version)
 {
-    //return IsVersionOlder("2023.06", version) || RenderableEffect::needToAdjustSettings(version);
-    return RenderableEffect::needToAdjustSettings(version);
+    return IsVersionOlder("2023.07", version) || RenderableEffect::needToAdjustSettings(version);
+    //return RenderableEffect::needToAdjustSettings(version);
 }
 
 void RippleEffect::adjustSettings(const std::string& version, Effect* effect, bool removeDefaults)
 {
+    SettingsMap& settings = effect->GetSettings();
+    if (!settings.Get("E_FILEPICKERCTRL_SVG", "").empty() && settings.Get("E_FILEPICKERCTRL_Ripple_SVG", "").empty()) {
+        settings["E_FILEPICKERCTRL_Ripple_SVG"] = settings.Get("E_FILEPICKERCTRL_SVG", "");
+    }
     /*
     SettingsMap& settings = effect->GetSettings();
 

--- a/xLights/effects/RipplePanel.cpp
+++ b/xLights/effects/RipplePanel.cpp
@@ -35,7 +35,7 @@ const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Draw_Style = wxNewId();
 const long RipplePanel::ID_STATICTEXT_Ripple_Object_To_Draw = wxNewId();
 const long RipplePanel::ID_CHOICE_Ripple_Object_To_Draw = wxNewId();
 const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Object_To_Draw = wxNewId();
-const long RipplePanel::ID_FILEPICKERCTRL_RIPPLE_SVG = wxNewId();
+const long RipplePanel::ID_FILEPICKERCTRL_Ripple_SVG = wxNewId();
 const long RipplePanel::ID_STATICTEXT_Ripple_Movement = wxNewId();
 const long RipplePanel::ID_CHOICE_Ripple_Movement = wxNewId();
 const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Movement = wxNewId();
@@ -176,7 +176,7 @@ RipplePanel::RipplePanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer57->Add(BitmapButton_Ripple_Object_To_Draw, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 1);
 	StaticText_SVG = new wxStaticText(this, wxID_ANY, _("SVG"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
 	FlexGridSizer57->Add(StaticText_SVG, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FilePickerCtrl_Ripple_SVG = new BulkEditFilePickerCtrl(this, ID_FILEPICKERCTRL_RIPPLE_SVG, wxEmptyString, _("Choose a SIMPLE svg file"), _T("*.svg"), wxDefaultPosition, wxDefaultSize, wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_FILEPICKERCTRL_RIPPLE_SVG"));
+	FilePickerCtrl_Ripple_SVG = new BulkEditFilePickerCtrl(this, ID_FILEPICKERCTRL_Ripple_SVG, wxEmptyString, _("Choose a SIMPLE svg file"), _T("*.svg"), wxDefaultPosition, wxDefaultSize, wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_FILEPICKERCTRL_Ripple_SVG"));
 	FlexGridSizer57->Add(FilePickerCtrl_Ripple_SVG, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer57->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer57->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);

--- a/xLights/effects/RipplePanel.cpp
+++ b/xLights/effects/RipplePanel.cpp
@@ -35,7 +35,7 @@ const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Draw_Style = wxNewId();
 const long RipplePanel::ID_STATICTEXT_Ripple_Object_To_Draw = wxNewId();
 const long RipplePanel::ID_CHOICE_Ripple_Object_To_Draw = wxNewId();
 const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Object_To_Draw = wxNewId();
-const long RipplePanel::ID_FILEPICKERCTRL_SVG = wxNewId();
+const long RipplePanel::ID_FILEPICKERCTRL_RIPPLE_SVG = wxNewId();
 const long RipplePanel::ID_STATICTEXT_Ripple_Movement = wxNewId();
 const long RipplePanel::ID_CHOICE_Ripple_Movement = wxNewId();
 const long RipplePanel::ID_BITMAPBUTTON_CHOICE_Ripple_Movement = wxNewId();
@@ -176,8 +176,8 @@ RipplePanel::RipplePanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer57->Add(BitmapButton_Ripple_Object_To_Draw, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 1);
 	StaticText_SVG = new wxStaticText(this, wxID_ANY, _("SVG"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
 	FlexGridSizer57->Add(StaticText_SVG, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FilePickerCtrl_SVG = new BulkEditFilePickerCtrl(this, ID_FILEPICKERCTRL_SVG, wxEmptyString, _("Choose a SIMPLE svg file"), _T("*.svg"), wxDefaultPosition, wxDefaultSize, wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_FILEPICKERCTRL_SVG"));
-	FlexGridSizer57->Add(FilePickerCtrl_SVG, 1, wxALL|wxEXPAND, 5);
+	FilePickerCtrl_Ripple_SVG = new BulkEditFilePickerCtrl(this, ID_FILEPICKERCTRL_RIPPLE_SVG, wxEmptyString, _("Choose a SIMPLE svg file"), _T("*.svg"), wxDefaultPosition, wxDefaultSize, wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_FILEPICKERCTRL_RIPPLE_SVG"));
+	FlexGridSizer57->Add(FilePickerCtrl_Ripple_SVG, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer57->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer57->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText70 = new wxStaticText(this, ID_STATICTEXT_Ripple_Movement, _("Movement"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Ripple_Movement"));
@@ -481,10 +481,10 @@ void RipplePanel::ValidateWindow()
     }
 
 	if (newFeatures && Choice_Ripple_Object_To_Draw->GetStringSelection() == "SVG") {
-        FilePickerCtrl_SVG->Enable();
+        FilePickerCtrl_Ripple_SVG->Enable();
     } else {
-        FilePickerCtrl_SVG->Enable(false);
-        FilePickerCtrl_SVG->SetFileName(wxFileName(""));
+        FilePickerCtrl_Ripple_SVG->Enable(false);
+        FilePickerCtrl_Ripple_SVG->SetFileName(wxFileName(""));
     }
 
 	BitmapButton_Ripple_Scale->Enable(newFeatures);

--- a/xLights/effects/RipplePanel.h
+++ b/xLights/effects/RipplePanel.h
@@ -110,7 +110,7 @@ class RipplePanel: public xlEffectPanel
 		static const long ID_STATICTEXT_Ripple_Object_To_Draw;
 		static const long ID_CHOICE_Ripple_Object_To_Draw;
 		static const long ID_BITMAPBUTTON_CHOICE_Ripple_Object_To_Draw;
-		static const long ID_FILEPICKERCTRL_RIPPLE_SVG;
+		static const long ID_FILEPICKERCTRL_Ripple_SVG;
 		static const long ID_STATICTEXT_Ripple_Movement;
 		static const long ID_CHOICE_Ripple_Movement;
 		static const long ID_BITMAPBUTTON_CHOICE_Ripple_Movement;

--- a/xLights/effects/RipplePanel.h
+++ b/xLights/effects/RipplePanel.h
@@ -38,7 +38,7 @@ class RipplePanel: public xlEffectPanel
 		BulkEditChoice* Choice_Ripple_Draw_Style;
 		BulkEditChoice* Choice_Ripple_Movement;
 		BulkEditChoice* Choice_Ripple_Object_To_Draw;
-		BulkEditFilePickerCtrl* FilePickerCtrl_SVG;
+		BulkEditFilePickerCtrl* FilePickerCtrl_Ripple_SVG;
 		BulkEditSlider* Slider_Ripple_Direction;
 		BulkEditSlider* Slider_Ripple_Points;
 		BulkEditSlider* Slider_Ripple_Rotation;
@@ -110,7 +110,7 @@ class RipplePanel: public xlEffectPanel
 		static const long ID_STATICTEXT_Ripple_Object_To_Draw;
 		static const long ID_CHOICE_Ripple_Object_To_Draw;
 		static const long ID_BITMAPBUTTON_CHOICE_Ripple_Object_To_Draw;
-		static const long ID_FILEPICKERCTRL_SVG;
+		static const long ID_FILEPICKERCTRL_RIPPLE_SVG;
 		static const long ID_STATICTEXT_Ripple_Movement;
 		static const long ID_CHOICE_Ripple_Movement;
 		static const long ID_BITMAPBUTTON_CHOICE_Ripple_Movement;

--- a/xLights/wxsmith/RipplePanel.wxs
+++ b/xLights/wxsmith/RipplePanel.wxs
@@ -112,7 +112,7 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
-				<object class="wxFilePickerCtrl" name="ID_FILEPICKERCTRL_SVG" subclass="BulkEditFilePickerCtrl" variable="FilePickerCtrl_SVG" member="yes">
+				<object class="wxFilePickerCtrl" name="ID_FILEPICKERCTRL_RIPPLE_SVG" subclass="BulkEditFilePickerCtrl" variable="FilePickerCtrl_Ripple_SVG" member="yes">
 					<message>Choose a SIMPLE svg file</message>
 					<wildcard>*.svg</wildcard>
 				</object>

--- a/xLights/wxsmith/RipplePanel.wxs
+++ b/xLights/wxsmith/RipplePanel.wxs
@@ -112,7 +112,7 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
-				<object class="wxFilePickerCtrl" name="ID_FILEPICKERCTRL_RIPPLE_SVG" subclass="BulkEditFilePickerCtrl" variable="FilePickerCtrl_Ripple_SVG" member="yes">
+				<object class="wxFilePickerCtrl" name="ID_FILEPICKERCTRL_Ripple_SVG" subclass="BulkEditFilePickerCtrl" variable="FilePickerCtrl_Ripple_SVG" member="yes">
 					<message>Choose a SIMPLE svg file</message>
 					<wildcard>*.svg</wildcard>
 				</object>


### PR DESCRIPTION
#3784.  Shape effect SVG was accidentally broken when I added SVG to ripple.  The reason is something to do with having member variables with the same name, even though they aren't global.  I fixed it by changing the name in ripple panel and adding an upgrade routine.