### PR TITLE
Add simple path re-ordering to SketchAssistPanel

### DIFF
--- a/xLights/effects/SketchEffect.cpp
+++ b/xLights/effects/SketchEffect.cpp
@@ -237,7 +237,6 @@ xlEffectPanel* SketchEffect::CreatePanel( wxWindow* parent )
     return m_panel;
 }
 
-
 void SketchEffect::renderSketch(const SketchEffectSketch& sketch, wxImage& img, double progress, double drawPercentage, int lineThickness, bool hasMotion, double motionPercentage, const xlColorVector& colors)
 {
     std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(img));

--- a/xLights/effects/SketchEffectDrawing.cpp
+++ b/xLights/effects/SketchEffectDrawing.cpp
@@ -4,6 +4,7 @@
 
 #include <wx/graphics.h>
 
+#include <algorithm>
 #include <iterator>
 #include <regex>
 #include <sstream>
@@ -556,4 +557,12 @@ void SketchEffectSketch::deletePath(int pathIndex)
     std::advance(iter, pathIndex);
 
     m_paths.erase(iter);
+}
+
+void SketchEffectSketch::swapPaths(int pathIndex0, int pathIndex1)
+{
+    if (pathIndex0 < 0 || pathIndex1 < 0 || pathIndex0 >= m_paths.size() || pathIndex1 >= m_paths.size())
+        return;
+
+    std::swap(m_paths[pathIndex0], m_paths[pathIndex1]);
 }

--- a/xLights/effects/SketchEffectDrawing.h
+++ b/xLights/effects/SketchEffectDrawing.h
@@ -98,6 +98,7 @@ public:
     void updatePath(int index, std::shared_ptr<SketchEffectPath> path);
     void reversePath(int pathIndex);
     void deletePath(int pathIndex);
+    void swapPaths(int pathIndex0, int pathIndex1);
 
 protected:
     std::vector<std::shared_ptr<SketchEffectPath>> m_paths;

--- a/xLights/effects/SketchPanel.cpp
+++ b/xLights/effects/SketchPanel.cpp
@@ -185,7 +185,6 @@ SketchPanel::SketchPanel(wxWindow* parent, wxWindowID id /*=wxID_ANY*/, const wx
 
     mainSizer->Add(settingsSizer, 1, wxALL | wxEXPAND, 2);
 
-
 	SetSizer(mainSizer);
     mainSizer->Fit(this);
     mainSizer->SetSizeHints(this);

--- a/xLights/effects/assist/SketchAssistPanel.cpp
+++ b/xLights/effects/assist/SketchAssistPanel.cpp
@@ -58,6 +58,8 @@ END_EVENT_TABLE()
 
 long SketchAssistPanel::ID_MENU_Delete = wxNewId();
 long SketchAssistPanel::ID_MENU_Reverse = wxNewId();
+long SketchAssistPanel::ID_MENU_MoveUp = wxNewId();
+long SketchAssistPanel::ID_MENU_MoveDown = wxNewId();
 
 SketchAssistPanel::SketchAssistPanel(wxWindow* parent, wxWindowID id /*wxID_ANY*/, const wxPoint& pos /*wxDefaultPosition*/, const wxSize& size /*wxDefaultSize*/) :
     wxPanel(parent, id, pos, size)
@@ -434,6 +436,15 @@ void SketchAssistPanel::OnListBox_ContextMenu(wxContextMenuEvent& event)
     mnu.Append(ID_MENU_Reverse, str);
     str.sprintf("Delete Path %d", 1 + m_pathIndexToDelete);
     mnu.Append(ID_MENU_Delete, str);
+    if (m_pathIndexToDelete != 0) {
+        str.sprintf("Move Path %d Up", 1 + m_pathIndexToDelete);
+        mnu.Append(ID_MENU_MoveUp, str);
+    }
+    if (m_pathIndexToDelete != m_pathsListBox->GetCount() - 1) {
+        str.sprintf("Move Path %d Down", 1 + m_pathIndexToDelete);
+        mnu.Append(ID_MENU_MoveDown, str);
+
+    }
     mnu.Connect(wxEVT_MENU, (wxObjectEventFunction)&SketchAssistPanel::OnPopupCommand, nullptr, this);
     PopupMenu(&mnu);
 }
@@ -449,6 +460,12 @@ void SketchAssistPanel::OnPopupCommand(wxCommandEvent& event)
         update = true;
     } else if (event.GetId() == ID_MENU_Reverse) {
         m_sketch.reversePath(m_pathIndexToDelete);
+        update = true;
+    } else if (event.GetId() == ID_MENU_MoveUp) {
+        m_sketch.swapPaths(m_pathIndexToDelete, m_pathIndexToDelete - 1);
+        update = true;
+    } else if (event.GetId() == ID_MENU_MoveDown) {
+        m_sketch.swapPaths(m_pathIndexToDelete, m_pathIndexToDelete + 1);
         update = true;
     }
 

--- a/xLights/effects/assist/SketchAssistPanel.h
+++ b/xLights/effects/assist/SketchAssistPanel.h
@@ -84,6 +84,8 @@ private:
     wxListBox* m_pathsListBox = nullptr;
     static long ID_MENU_Delete;
     static long ID_MENU_Reverse;
+    static long ID_MENU_MoveUp;
+    static long ID_MENU_MoveDown;
 
     wxString m_bgImagePath;
     wxImage m_bgImage;


### PR DESCRIPTION
This was requested by Michael Stoffrogen. Sometimes imported SVG files will have multiple paths and the order of those paths may not make sense as a sketch. So this just adds some minimal ability to re-order the paths by moving them up/down one at a time. It's not the greatest interface but slightly better than hand-editing an SVG file.