### PR TITLE
#3851 - Use list item generated ID so effect is stored properly

### DIFF
--- a/xLights/SearchPanel.cpp
+++ b/xLights/SearchPanel.cpp
@@ -207,8 +207,8 @@ void SearchPanel::FindSettings()
             auto effs = elay->GetEffects();
             for (auto* eff : effs) {
                 if (ContainsSetting(eff, search, regex, value)) {
-                    ListCtrl_Results->InsertItem(ListCtrl_Results->GetItemCount(), wxString::Format("%s [%s,%s] %s %s", value, FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), eff->GetEffectName(), tmpname));
-                    ListCtrl_Results->SetItemPtrData(ListCtrl_Results->GetItemCount() - 1, (wxUIntPtr)eff);
+                    auto id = ListCtrl_Results->InsertItem(ListCtrl_Results->GetItemCount(), wxString::Format("%s [%s,%s] %s %s", value, FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), eff->GetEffectName(), tmpname));
+                    ListCtrl_Results->SetItemPtrData(id, (wxUIntPtr)eff);
                 }
             }
         }
@@ -224,8 +224,8 @@ void SearchPanel::FindSettings()
                             auto effs = elay->GetEffects();
                             for (auto* eff : effs) {
                                 if (ContainsSetting(eff, search, regex, value)) {
-                                    ListCtrl_Results->InsertItem(ListCtrl_Results->GetItemCount() , wxString::Format("%s [%s,%s] %s %s", value, FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), eff->GetEffectName(), tmpname));
-                                    ListCtrl_Results->SetItemPtrData(ListCtrl_Results->GetItemCount() - 1, (wxUIntPtr)eff);
+                                    auto id = ListCtrl_Results->InsertItem(ListCtrl_Results->GetItemCount() , wxString::Format("%s [%s,%s] %s %s", value, FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), eff->GetEffectName(), tmpname));
+                                    ListCtrl_Results->SetItemPtrData(id, (wxUIntPtr)eff);
                                 }
                             }
                         }

--- a/xLights/SelectPanel.cpp
+++ b/xLights/SelectPanel.cpp
@@ -222,8 +222,8 @@ void SelectPanel::populateEffectsList()
                 std::vector<Effect*> effs = elay->GetEffectsByTypeAndTime(type, starttime, endtime);
                 for (Effect* eff : effs) {
                     if (ContainsColor(eff)) {
-                        ListCtrl_Select_Effects->InsertItem(ListCtrl_Select_Effects->GetItemCount(), wxString::Format("[%s,%s] %s", FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), tmpname));
-                        ListCtrl_Select_Effects->SetItemPtrData(ListCtrl_Select_Effects->GetItemCount() - 1, (wxUIntPtr)eff);
+                        auto id = ListCtrl_Select_Effects->InsertItem(ListCtrl_Select_Effects->GetItemCount(), wxString::Format("[%s,%s] %s", FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), tmpname));
+                        ListCtrl_Select_Effects->SetItemPtrData(id, (wxUIntPtr)eff);
                     }
                 }
             }
@@ -239,8 +239,8 @@ void SelectPanel::populateEffectsList()
                                 std::vector<Effect*> effs = elay->GetEffectsByTypeAndTime(type, starttime, endtime);
                                 for (Effect* eff : effs) {
                                     if (ContainsColor(eff)) {
-                                        ListCtrl_Select_Effects->InsertItem(ListCtrl_Select_Effects->GetItemCount() , wxString::Format("[%s,%s] %s", FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), tmpname));
-                                        ListCtrl_Select_Effects->SetItemPtrData(ListCtrl_Select_Effects->GetItemCount() - 1, (wxUIntPtr)eff);
+                                        auto id = ListCtrl_Select_Effects->InsertItem(ListCtrl_Select_Effects->GetItemCount() , wxString::Format("[%s,%s] %s", FORMATTIME(eff->GetStartTimeMS()), FORMATTIME(eff->GetEndTimeMS()), tmpname));
+                                        ListCtrl_Select_Effects->SetItemPtrData(id, (wxUIntPtr)eff);
                                     }
                                 }
                             }


### PR DESCRIPTION
The old code was guessing the assigned list ID.  I just kept it from the InsertItem and used it in SetItemPtrData and the problem went away.