### PR TITLE
Fix FalconV4 16+4+2 to be 1024

### DIFF
--- a/controllers/falcon.xcontroller
+++ b/controllers/falcon.xcontroller
@@ -253,7 +253,7 @@
 		<Variant Name="16 Local Ports + 4 + 2 Smart Receiver Chains" Base="Falcon:BaseV4FalconSettings">
 			<MaxPixelPort>40</MaxPixelPort>
 			<MaxSerialPort>1</MaxSerialPort>
-			<MaxPixelPortChannels>2112</MaxPixelPortChannels>
+			<MaxPixelPortChannels>3072</MaxPixelPortChannels>
             <v4BoardMode>5</v4BoardMode>
 			<SupportsRemotes/>
 			<SupportsSmartRemotes>6</SupportsSmartRemotes>


### PR DESCRIPTION
Had wrong 704 max pixel/port vs 1024
![image](https://github.com/smeighan/xLights/assets/23619433/bc055edc-1fcd-43cc-9ae8-35bc03720d47)
