### PR TITLE
Chase direction fix for #3868

### DIFF
--- a/xLights/RenderBuffer.cpp
+++ b/xLights/RenderBuffer.cpp
@@ -733,7 +733,6 @@ RenderBuffer::RenderBuffer(xLightsFrame *f) : frame(f)
     frameTimeInMs = 50;
     _textDrawingContext = nullptr;
     _pathDrawingContext = nullptr;
-    tempInt = 0;
     isTransformed = false;
 }
 
@@ -1720,7 +1719,6 @@ RenderBuffer::RenderBuffer(RenderBuffer& buffer) : pixelVector(buffer.pixels, &b
     fadeinsteps = buffer.fadeinsteps;
     fadeoutsteps = buffer.fadeoutsteps;
     needToInit = buffer.needToInit;
-    tempInt = buffer.tempInt;
     allowAlpha = buffer.allowAlpha;
     dmx_buffer = buffer.dmx_buffer;
     _nodeBuffer = buffer._nodeBuffer;

--- a/xLights/RenderBuffer.cpp
+++ b/xLights/RenderBuffer.cpp
@@ -733,7 +733,7 @@ RenderBuffer::RenderBuffer(xLightsFrame *f) : frame(f)
     frameTimeInMs = 50;
     _textDrawingContext = nullptr;
     _pathDrawingContext = nullptr;
-    tempInt = tempInt2 = 0;
+    tempInt = 0;
     isTransformed = false;
 }
 
@@ -1721,7 +1721,6 @@ RenderBuffer::RenderBuffer(RenderBuffer& buffer) : pixelVector(buffer.pixels, &b
     fadeoutsteps = buffer.fadeoutsteps;
     needToInit = buffer.needToInit;
     tempInt = buffer.tempInt;
-    tempInt2 = buffer.tempInt2;
     allowAlpha = buffer.allowAlpha;
     dmx_buffer = buffer.dmx_buffer;
     _nodeBuffer = buffer._nodeBuffer;

--- a/xLights/RenderBuffer.h
+++ b/xLights/RenderBuffer.h
@@ -574,7 +574,6 @@ public:
 
     /* Places to store and data that is needed from one frame to another */
     std::map<int, EffectRenderCache*> infoCache;
-    int tempInt = 0;
 
     //place for GPU Renderers to attach extra data/objects it needs
     void *gpuRenderData = nullptr;

--- a/xLights/RenderBuffer.h
+++ b/xLights/RenderBuffer.h
@@ -575,7 +575,6 @@ public:
     /* Places to store and data that is needed from one frame to another */
     std::map<int, EffectRenderCache*> infoCache;
     int tempInt = 0;
-    int tempInt2 = 0;
 
     //place for GPU Renderers to attach extra data/objects it needs
     void *gpuRenderData = nullptr;

--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -372,14 +372,12 @@ void SingleStrandEffect::RenderSingleStrandChase(RenderBuffer &buffer,
         MaxNodes = buffer.BufferWi;
     }
 
-    int &ChaseDirection = buffer.tempInt;
+    int ChaseDirection = (chaseType == 0 || chaseType == 2 || chaseType == 6 ||
+                          chaseType == 9 || chaseType == 13 || chaseType == 14);
 
     if (buffer.needToInit)
     {
         buffer.needToInit = false;
-        // initialize it once at the beginning of this sequence.
-        ChaseDirection = (chaseType == 0 || chaseType == 2 || chaseType == 6 ||
-            chaseType == 9 || chaseType == 13 || chaseType == 14);
     }
 
     bool Mirror = false;


### PR DESCRIPTION
These variables were mostly unused, except for in chase effect.  The maintenance and lifecycle were unclear, but seemed to cause an issue, so best idea I had was to remove them, and this made the problem go away.