### PR TITLE
Fixes always on top render progress and fpp upload progress dialogs.

### DIFF
--- a/xLights/RenderProgressDialog.cpp
+++ b/xLights/RenderProgressDialog.cpp
@@ -32,7 +32,7 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
 	//(*Initialize(RenderProgressDialog)
 	wxFlexGridSizer* FlexGridSizer1;
 
-	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxSTAY_ON_TOP|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, _T("wxID_ANY"));
+	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, _T("wxID_ANY"));
 	FlexGridSizer1 = new wxFlexGridSizer(2, 1, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);

--- a/xLights/controllers/FPPUploadProgressDialog.cpp
+++ b/xLights/controllers/FPPUploadProgressDialog.cpp
@@ -24,7 +24,7 @@ FPPUploadProgressDialog::FPPUploadProgressDialog(wxWindow* parent,wxWindowID id)
     wxFlexGridSizer* FlexGridSizer1;
     wxFlexGridSizer* FlexGridSizer2;
 
-    Create(parent, id, _("Upload Progress"), wxDefaultPosition, wxDefaultSize, wxSTAY_ON_TOP|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, _T("id"));
+    Create(parent, id, _("Upload Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, _T("id"));
     SetMinSize(wxSize(400,-1));
     FlexGridSizer1 = new wxFlexGridSizer(3, 1, 0, 0);
     FlexGridSizer1->AddGrowableCol(0);

--- a/xLights/wxsmith/FPPUploadProgressDialog.wxs
+++ b/xLights/wxsmith/FPPUploadProgressDialog.wxs
@@ -3,7 +3,7 @@
 	<object class="wxDialog" name="FPPUploadProgressDialog">
 		<title>Upload Progress</title>
 		<minsize>400,-1</minsize>
-		<style>wxSTAY_ON_TOP|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<rows>3</rows>

--- a/xLights/wxsmith/RenderProgressDialog.wxs
+++ b/xLights/wxsmith/RenderProgressDialog.wxs
@@ -3,7 +3,7 @@
 	<object class="wxDialog" name="RenderProgressDialog">
 		<title>Rendering Progress</title>
 		<id_arg>0</id_arg>
-		<style>wxSTAY_ON_TOP|wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<rows>2</rows>


### PR DESCRIPTION
Fixes #3906

This removes the wxSTAY_ON_TOP style from RenderProgressDialog and FPPUploadProgressDialog, as this style causes the dialog box to say on top of all windows including windows that are not part of lights.

Only tested in Windows 11 Pro 21H2

(Updated to include the changes required to support codeblocks.)