### PR TITLE
Disable upload button during fpp upload, improve cancel handling.

### DIFF
--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -754,6 +754,9 @@ void FPPConnectDialog::LoadSequences()
 
 void FPPConnectDialog::OnButton_UploadClick(wxCommandEvent& event)
 {
+    Button_Upload->Enable(false);
+    AddFPPButton->Enable(false);
+
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     bool cancelled = false;
 
@@ -1015,7 +1018,7 @@ void FPPConnectDialog::OnButton_UploadClick(wxCommandEvent& event)
                     while (CurlManager::INSTANCE.processCurls()) {
                         wxYield();
                     }
-                    cancelled = prgs.isCancelled();
+                    cancelled |= prgs.isCancelled();
                 }
             }
             delete seq;
@@ -1063,6 +1066,8 @@ void FPPConnectDialog::OnButton_UploadClick(wxCommandEvent& event)
         EndDialog(wxID_CLOSE);
 #endif
     }
+    Button_Upload->Enable(true);
+    AddFPPButton->Enable(true);
 }
 
 void FPPConnectDialog::CreateDriveList()

--- a/xLights/controllers/FPPUploadProgressDialog.cpp
+++ b/xLights/controllers/FPPUploadProgressDialog.cpp
@@ -46,6 +46,7 @@ FPPUploadProgressDialog::FPPUploadProgressDialog(wxWindow* parent,wxWindowID id)
 
     Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&FPPUploadProgressDialog::OnCancelButtonClick);
     //*)
+    SetEscapeId(ID_BUTTON1);
     
     FlexGridSizer1->SetSizeHints(this);
 }
@@ -59,6 +60,8 @@ FPPUploadProgressDialog::~FPPUploadProgressDialog()
 
 void FPPUploadProgressDialog::OnCancelButtonClick(wxCommandEvent& event)
 {
+    CancelButton->SetLabelText("Canceling...");
+    CancelButton->Enable(false);
     cancelled = true;
 }
 


### PR DESCRIPTION
Fixes #3911.  
Prevent the upload button from being pressed while an upload is active.
Disables cancel button while a cancel is already pending and changes the button text to "Canceling..."
