### PR TITLE
Fixes issues with DPI-Pixels uploads for Hanson rPi-28D from #3774

### DIFF
--- a/controllers/hanson.xcontroller
+++ b/controllers/hanson.xcontroller
@@ -131,7 +131,7 @@
             <fppSerialPort1>ttyAMA0</fppSerialPort1>
             <fppStringFileName>co-pixelStrings</fppStringFileName>
 		</Variant>
-		<Variant Name="rPi-28D-DPIPixels" ID="rPi-28D-DPIPixels" Base="FPP:BaseFPPSettings">
+		<Variant Name="rPi-28D-DPIPixels" ID="rPi-28D-DPIPixels" Base="FPP:FPPStringDPIPiHat">
 			<MaxPixelPort>2</MaxPixelPort>
 			<MaxSerialPort>1</MaxSerialPort>
 			<MaxSerialPortChannels>512</MaxSerialPortChannels>
@@ -156,7 +156,7 @@
             <fppSerialPort1>ttyAMA0</fppSerialPort1>
             <fppStringFileName>co-pixelStrings</fppStringFileName>
 		</Variant>
-		<Variant Name="rPi-28D-DPIPixels-4" ID="rPi-28D-DPIPixels-4" Base="FPP:BaseFPPSettings">
+		<Variant Name="rPi-28D-DPIPixels-4" ID="rPi-28D-DPIPixels-4" Base="FPP:FPPStringDPIPiHat">
 			<MaxPixelPort>4</MaxPixelPort>
 			<MaxSerialPort>1</MaxSerialPort>
 			<MaxSerialPortChannels>512</MaxSerialPortChannels>


### PR DESCRIPTION
Closes https://github.com/FalconChristmas/fpp/issues/1538 - fixes issue introduced in bb8ea3c

Updates controller definition to use the DPIPixels Abstract Driver, rather than the default RPIWS281X driver