### PR TITLE
New Layer Blending Styles (Highlight, Highlight Vibrant)

### DIFF
--- a/xLights/PixelBuffer.cpp
+++ b/xLights/PixelBuffer.cpp
@@ -1095,6 +1095,8 @@ static std::map<std::string, MixTypes> MixTypesMap = {
     { "Shadow 2 on 1", MixTypes::Mix_Shadow_2on1 },
     { "Layered", MixTypes::Mix_Layered },
     { "Normal", MixTypes::Mix_Normal },
+    { "Highlight", MixTypes::Mix_Highlight },
+    { "Highlight Vibrant", MixTypes::Mix_Highlight_Vibrant },
     { "Additive", MixTypes::Mix_Additive },
     { "Subtractive", MixTypes::Mix_Subtractive },
     { "Brightness", MixTypes::Mix_AsBrightness },
@@ -1328,6 +1330,35 @@ void PixelBufferClass::mixColors(const wxCoord &x, const wxCoord &y, xlColor &fg
         bg = hsv1.value > effectMixThreshold ? bg : fg; // if effect 2 is non black
         break;
     }
+    case MixTypes::Mix_Highlight:
+    {
+        bool effect1HasColor = (fg.red > 0 || fg.green > 0 || fg.blue > 0);
+        bool effect2HasColor = (bg.red > 0 || bg.green > 0 || bg.blue > 0);
+        HSVValue hsv1 = bg.asHSV();
+
+        if (effect1HasColor && (effect2HasColor || hsv1.value > effectMixThreshold)) {
+            bg = fg;
+        }
+    } break;
+    case MixTypes::Mix_Highlight_Vibrant:
+    {
+        HSVValue hsv1 = bg.asHSV();
+        if (hsv1.value > effectMixThreshold) {
+            
+            int r = fg.red + bg.red;
+            int g = fg.green + bg.green;
+            int b = fg.blue + bg.blue;
+
+            if (r > 255)
+                r = 255;
+            if (g > 255)
+                g = 255;
+            if (b > 255)
+                b = 255;
+
+            bg.Set(r, g, b);
+        }
+    } break;
     case MixTypes::Mix_Additive:
         {
             int r = fg.red + bg.red;

--- a/xLights/PixelBuffer.h
+++ b/xLights/PixelBuffer.h
@@ -47,7 +47,9 @@ enum class MixTypes
     Mix_Subtractive,
     Mix_AsBrightness,
     Mix_Max,
-    Mix_Min
+    Mix_Min,
+    Mix_Highlight,
+    Mix_Highlight_Vibrant
 };
 
 class Effect;

--- a/xLights/TimingPanel.cpp
+++ b/xLights/TimingPanel.cpp
@@ -344,6 +344,8 @@ TimingPanel::TimingPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, co
     Choice_LayerMethod->Append(_("Average"));
     Choice_LayerMethod->Append(_("Bottom-Top"));
     Choice_LayerMethod->Append(_("Left-Right"));
+    Choice_LayerMethod->Append(_("Highlight"));
+    Choice_LayerMethod->Append(_("Highlight Vibrant"));
     Choice_LayerMethod->Append(_("Additive"));
     Choice_LayerMethod->Append(_("Subtractive"));
     Choice_LayerMethod->Append(_("Brightness"));
@@ -360,8 +362,8 @@ TimingPanel::TimingPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, co
                                      "* 2 is Mask: (Shadow) Effect 2 will cast a shadow onto Effect 1 for every Effect 2 pixel that has a non-black value.\n"
                                      "* 1 is Unmask: Unmask like but colours are revealed with no fade. Black becomes white.\n"
                                      "* 2 is Unmask: Unmask like but colours are revealed with no fade. Black becomes white.\n"
-                                     "* 1 is True Unmask:  (Mask) Only allow Effect 2 to show through when Effect 1 has a non-black pixel.\n"
-                                     "* 2 is True Unmask:  (Mask) Only allow Effect 1 to show through when Effect 2 has a non-black pixel.\n"
+                                     "* 1 is True Unmask: (Mask) Only allow Effect 2 to show through when Effect 1 has a non-black pixel.\n"
+                                     "* 2 is True Unmask: (Mask) Only allow Effect 1 to show through when Effect 2 has a non-black pixel.\n"
                                      "* Shadow 1 on 2: Take brightness and Saturation from 1, use hue from 2\n"
                                      "* Shadow 2 on 1: Take brightness and Saturation from 2, use hue from 1\n"
                                      "* 1 reveals 2: (Superimpose) Effect 1 reveals Effect 2\n"
@@ -370,8 +372,10 @@ TimingPanel::TimingPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, co
                                      "* Average: Take value of Effect  and Add it to Value from Effect 2. Average the sum\n"
                                      "* Bottom-top: Effect 1 is put on bottom of model, Effect 2 is put on top in a split screen display\n"
                                      "* Left-Right: Effect goes 1 goes on the left side, Effect 2 on the right. Split screen goes down middle of model.\n"
-                                     "* Additive -  Take value of Effect 1  and Add it to Value from Effect 2.\n"
-                                     "* Subtractive -  Take value of Effect 1  and Subtract it from the Value from Effect 2.\n"
+                                     "* Highlight - Creates highlights by showcasing Effect 1's color where available, while using Effect 2's color where Effect 1 lacks color\n"
+                                     "* Highlight Vibrant - Intensifies Effect 2's color where Effect 1 has content, without affectinng black or dark areas\n"
+                                     "* Additive - Take value of Effect 1 and Add it to Value from Effect 2.\n"
+                                     "* Subtractive - Take value of Effect 1 and Subtract it from the Value from Effect 2.\n"
                                      "* Brightness - Multiply each colour channel value of both layers and divide by 255.\n"
                                      "* Max - Take the maximum value for each channel from both effects\n"
                                      "* Min - Take the minimum value for each channel from both effects\n"


### PR DESCRIPTION
Adding 2 new Layer Blending options as I have had to do different tricks to get similar effects whilst sequencing.
I wanted a way to highlight the existing effects, for example a shockwave on a HD Prop, and just highlighting the effects under it when it passes over..

Highlight Vibrant:  
This will keep Effect 2's color and if there is color on Effect 1 add them together like the additive effect..  If there is no color on effect 2 then we wont light up.

![BlendingHighlightVibrant](https://github.com/smeighan/xLights/assets/25444831/119b9236-227d-4dd9-9c2e-2b9014d3e8ec)
![BlendingHighlightVibrant1](https://github.com/smeighan/xLights/assets/25444831/8fb9e14b-7ec6-4771-89a4-9f6900b4e7d2)


Highlight:  
Whilst I was at it decided to add this one as well, works similar to the Highlight Vibrant, but rather than adding the colors together,  it will only show color from Effect 1, it is basically the reverse of Layered, where only effect 1 will show where there is something on Effect 2 and not black.

![BlendingHighlight](https://github.com/smeighan/xLights/assets/25444831/01045b74-d7c6-40d0-9a14-dd5ad6214f89)
