### PR TITLE
Add new WLED controller

### DIFF
--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -140,7 +140,7 @@
         </Variant>
     </Controller>
     <Controller Name="E8-WiFi">
-        <Variant Name="" Base="WLED:ESP32WLEDSettings">
+        <Variant Name="E8-WiFi" Base="WLED:ESP32WLEDSettings">
             <MaxPixelPort>8</MaxPixelPort>
             <MaxSerialPort>0</MaxSerialPort>
             <Port1>4</Port1>
@@ -151,6 +151,18 @@
             <Port6>21</Port6>
             <Port7>23</Port7>
             <Port8>22</Port8>
+        </Variant>
+         <Variant Name="E8-WiFi Plus" Base="WLED:ESP32WLEDSettings">
+            <MaxPixelPort>8</MaxPixelPort>
+            <MaxSerialPort>0</MaxSerialPort>
+            <Port1>5</Port1>
+            <Port2>12</Port2>
+            <Port3>4</Port3>
+            <Port4>27</Port4>
+            <Port5>17</Port5>
+            <Port6>26</Port6>
+            <Port7>33</Port7>
+            <Port8>25</Port8>
         </Variant>
     </Controller>
     <Controller Name="ESP3DEUXQuattro">


### PR DESCRIPTION
Created a controller variant for the new controller and positioned it beneath the existing E8-WiFi to conserve space. This placement was chosen because the two controllers, while similar, have distinct pin configurations.