### PR TITLE
Add support for rgb color image models

### DIFF
--- a/xLights/models/ImageModel.cpp
+++ b/xLights/models/ImageModel.cpp
@@ -140,16 +140,6 @@ void ImageModel::DisableUnusedProperties(wxPropertyGridInterface *grid)
     if (p != nullptr) {
         p->Enable(false);
     }
-
-    p = grid->GetPropertyByName("ModelStringType");
-    if (p != nullptr) {
-        wxArrayString labels = ((wxEnumProperty*)p)->GetChoices().GetLabels();
-        std::for_each(labels.begin(), labels.end(), [&p](wxString label) {
-            if (!label.StartsWith("Single Color")) {
-                ((wxEnumProperty*)p)->DeleteChoice(((wxEnumProperty*)p)->GetChoices().Index(label));
-            }
-        });
-    }
 }
 
 int ImageModel::OnPropertyGridChange(wxPropertyGridInterface *grid, wxPropertyGridEvent& event) {
@@ -244,7 +234,10 @@ void ImageModel::DisplayEffectOnWindow(ModelPreview* preview, double pointSize)
         int w, h;
         preview->GetSize(&w, &h);
 
-        xlTexture *texture = _images[preview->GetName().ToStdString()];
+        bool drawColor = (StringType != "Single Color" && StringType != "Single Color Intensity" && StringType != "Node Single Color");
+
+        xlTexture* texture = _images[preview->GetName().ToStdString()];
+        xlTexture* textureColorOverlay = _images[preview->GetName().ToStdString() + "_color_overlay"];
         if (texture == nullptr && FileExists(_imageFile)) {
             wxImage img(_imageFile);
             if (img.IsOk()) {
@@ -260,12 +253,46 @@ void ImageModel::DisplayEffectOnWindow(ModelPreview* preview, double pointSize)
                         }
                     }
                 }
+                int maxBrightness = 0;
+                if (drawColor) {
+                    // Color Image mode selected. Convert image to grayscale image so custom color can be applied later
+                    for (int x = 0; x < img.GetWidth(); x++) {
+                        for (int y = 0; y < img.GetHeight(); y++) {
+                            int r = img.GetRed(x, y);
+                            int g = img.GetGreen(x, y);
+                            int b = img.GetBlue(x, y);
+                            // Colorimetric (perceptual luminance-preserving) conversion to grayscale
+                            int c = (r*0.2126 + g*0.7152 + b*0.0722) / 3; // Weights from https://en.wikipedia.org/wiki/Grayscale
+                            maxBrightness = MAX(c, maxBrightness);
+                            img.SetRGB(x, y, c, c, c);
+                        }
+                    }
+                }
                 width = img.GetWidth();
                 height = img.GetHeight();
                 texture = ctx->createTexture(img);
                 texture->SetName(GetName());
                 texture->Finalize();
+
+                // Modify image for color overlay
+                if (drawColor) {
+                    if (!mAlpha) {
+                        img.InitAlpha();
+                    }
+                    for (int x = 0; x < img.GetWidth(); x++) {
+                        for (int y = 0; y < img.GetHeight(); y++) {
+                            int l = img.GetGreen(x, y); // Take green as luminance. Red, Green, Blue should now be equal after grayscale conversion
+                            int a = img.GetAlpha(x, y);
+                            l = (l * 255) / maxBrightness;
+                            img.SetAlpha(x, y, MIN(a, l));
+                        }
+                    }
+                }
+                textureColorOverlay = ctx->createTexture(img);
+                textureColorOverlay->SetName(GetName() + "_color_overlay");
+                textureColorOverlay->Finalize();
             }
+            
         }
         if (texture) {
             float scaleX = float(w) / float(width);
@@ -300,6 +327,11 @@ void ImageModel::DisplayEffectOnWindow(ModelPreview* preview, double pointSize)
 
             preview->getCurrentSolidProgram()->addStep([=](xlGraphicsContext *ctx) {
                 ctx->drawTexture(va, texture, brightness, 255, 0, va->getCount());
+                if (drawColor) {
+                    xlColor c;
+                    Nodes[0]->GetColor(c);
+                    ctx->drawTexture(va, textureColorOverlay, c, 0, va->getCount());
+                }
                 delete va;
             });
         } else {
@@ -351,8 +383,11 @@ void ImageModel::DisplayModelOnWindow(ModelPreview* preview, xlGraphicsContext *
 
     int w, h;
     preview->GetVirtualCanvasSize(w, h);
+
+    bool drawColor = (StringType != "Single Color" && StringType != "Single Color Intensity" && StringType != "Node Single Color");
     
     xlTexture *texture = _images[preview->GetName().ToStdString()];
+    xlTexture* textureColorOverlay = _images[preview->GetName().ToStdString() + "_color_overlay"];
     if (texture == nullptr && FileExists(_imageFile)) {
         wxImage img(_imageFile);
         if (img.IsOk()) {
@@ -368,6 +403,21 @@ void ImageModel::DisplayModelOnWindow(ModelPreview* preview, xlGraphicsContext *
                     }
                 }
             }
+            int maxBrightness = 0;
+            if (drawColor) {
+                // Color Image mode selected. Convert image to grayscale image so custom color can be applied later
+                for (int x = 0; x < img.GetWidth(); x++) {
+                    for (int y = 0; y < img.GetHeight(); y++) {
+                        int r = img.GetRed(x, y);
+                        int g = img.GetGreen(x, y);
+                        int b = img.GetBlue(x, y);
+                        // Colorimetric (perceptual luminance-preserving) conversion to grayscale
+                        int c = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 3; // Weights from https://en.wikipedia.org/wiki/Grayscale
+                        maxBrightness = MAX(c, maxBrightness);
+                        img.SetRGB(x, y, c, c, c);
+                    }
+                }
+            }
             
             width = img.GetWidth();
             height = img.GetHeight();
@@ -376,6 +426,26 @@ void ImageModel::DisplayModelOnWindow(ModelPreview* preview, xlGraphicsContext *
             texture->SetName(GetName());
             texture->Finalize();
             _images[preview->GetName().ToStdString()] = texture;
+
+
+            // Modify image for color overlay
+            if (drawColor) {
+                if (!mAlpha) {
+                    img.InitAlpha();
+                }
+                for (int x = 0; x < img.GetWidth(); x++) {
+                    for (int y = 0; y < img.GetHeight(); y++) {
+                        int l = img.GetGreen(x, y); // Take green as luminance. Red and Blue should now be equal to Green after grayscale conversion
+                        int a = img.GetAlpha(x, y);
+                        l = (l * 255) / maxBrightness;
+                        img.SetAlpha(x, y, MIN(a, l));
+                    }
+                }
+            }
+            textureColorOverlay = ctx->createTexture(img);
+            textureColorOverlay->SetName(GetName() + "_color_overlay");
+            textureColorOverlay->Finalize();
+            _images[preview->GetName().ToStdString() + "_color_overlay"] = textureColorOverlay;
         }
     }
     GetModelScreenLocation().UpdateBoundingBox(Nodes);  // FIXME: Modify to only call this when position changes
@@ -408,6 +478,13 @@ void ImageModel::DisplayModelOnWindow(ModelPreview* preview, xlGraphicsContext *
             }
             GetModelScreenLocation().ApplyModelViewMatrices(ctx);
             ctx->drawTexture(va, texture, brightness, alpha, 0, va->getCount());
+            //const xlColor myColor = xlColor(0, 0, brightness, alpha);
+            
+            if (drawColor) {
+                xlColor c;
+                Nodes[0]->GetColor(c);
+                ctx->drawTexture(va, textureColorOverlay, c, 0, va->getCount());
+            }
             ctx->PopMatrix();
             delete va;
         });

--- a/xLights/models/ImageObject.cpp
+++ b/xLights/models/ImageObject.cpp
@@ -174,6 +174,7 @@ bool ImageObject::Draw(ModelPreview* preview, xlGraphicsContext *ctx, xlGraphics
         float a = (100.0 - transparency) * 255.0 / 100.0;
         uint8_t alpha = a;
 
+
         program->addStep([=](xlGraphicsContext *ctx) {
             ctx->drawTexture(va, image, brightness, alpha, 0, va->getCount());
             delete va;


### PR DESCRIPTION
Implements enhancement from issue #4008 

Image models can now have string types that allow color, and images will be colored in the preview to match.

Known issues: transparency is not handled correctly for color image models

