### PR TITLE
fix test mode for controller sync enabled with an fpp player only in the controller list

### DIFF
--- a/xLights/outputs/OutputManager.cpp
+++ b/xLights/outputs/OutputManager.cpp
@@ -1069,7 +1069,7 @@ std::list<std::string> OutputManager::GetForceIPs(const std::string& protocol) c
 
     for (const auto& it : GetControllers()) {
         auto e = dynamic_cast<ControllerEthernet*>(it);
-        if (e != nullptr && e->GetFirstOutput()->GetType() == protocol) {
+        if (e != nullptr && (it->GetOutputCount() > 0) && e->GetFirstOutput()->GetType() == protocol) {
             auto fip = e->GetForceLocalIP();
             if (std::find(begin(res), end(res), fip) == end(res))
                 res.push_back(fip);
@@ -1081,7 +1081,7 @@ std::list<std::string> OutputManager::GetForceIPs(const std::string& protocol) c
 bool OutputManager::AtLeastOneOutputUsingProtocol(const std::string& protocol) const {
 
     for (const auto& it : GetControllers()) {
-        if (it->GetFirstOutput()->GetType() == protocol) {
+        if ((it->GetOutputCount() > 0) && (it->GetFirstOutput()->GetType() == protocol)) {
             return true;
         }
     }


### PR DESCRIPTION
Rare Bug:

"Tools: Test" crashes xLights and produces warnings about active outputs if the controller sync option is enabled and an FPP configured for player-only mode is in the controller list.  This is because the player only has no outputs, and the current code assumes all controllers will have at least one output.

Ideally, someone with more experience could update GetFirstOutput() to not crash ever for an FPP player only.  ( no outputs )  There is currently an assert for this situation as it was not expected to occur when written.  A better solution is welcome, but this prevents the crash.  