### PR TITLE
Don't resolve bad.address to 255.255.255.255, eliminate duplcate FPP …

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -63,6 +63,7 @@
 #include "../FSEQFile.h"
 #include "../Discovery.h"
 #include "../utils/CurlManager.h"
+#include "../utils/ip_utils.h"
 
 #include "Falcon.h"
 #include "Minleon.h"
@@ -1695,7 +1696,15 @@ bool FPP::UploadUDPOutputsForProxy(OutputManager* outputManager) {
     for (const auto& it : outputManager->GetControllers()) {
         auto c = dynamic_cast<ControllerEthernet*>(it);
         if (c != nullptr) {
-            if (c->GetFPPProxy() == ipAddress) {
+            std::string proxy_ip = ip_utils::ResolveIP(c->GetFPPProxy());
+            std::string ipAddress_ip = ip_utils::ResolveIP(ipAddress);
+            if (
+                    (::Lower(c->GetFPPProxy()) == ::Lower(ipAddress)) 
+                 || (::Lower(proxy_ip) == ::Lower(ipAddress)) 
+                 || (::Lower(c->GetFPPProxy()) == ::Lower(ipAddress_ip))
+                 || (::Lower(proxy_ip) == ::Lower(ipAddress_ip))
+                ) 
+            {
                 selected.push_back(c);
             }
         }
@@ -3795,12 +3804,15 @@ std::list<FPP*> FPP::GetInstances(wxWindow* frame, OutputManager* outputManager)
     for (auto& it : outputManager->GetControllers()) {
         auto eth = dynamic_cast<ControllerEthernet*>(it);
         if (eth != nullptr && eth->GetIP() != "" && eth->GetIP() != "MULTICAST") {
-            startAddresses.push_back(eth->GetIP());
+            startAddresses.push_back(::Lower(eth->GetResolvedIP()));
             if (eth->GetFPPProxy() != "") {
-                startAddresses.push_back(eth->GetFPPProxy());
+                startAddresses.push_back(::Lower(ip_utils::ResolveIP(eth->GetFPPProxy())));
             }
         }
     }
+
+    startAddresses.sort();
+    startAddresses.unique();
 
     Discovery discovery(frame, outputManager);
     FPP::PrepareDiscovery(discovery, startAddresses);

--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -111,6 +111,9 @@ namespace ip_utils
             if (r == "0.0.0.0") {
                 r = ip;
             }
+            if (r == "255.255.255.255") {
+                r = ip;
+            }
             __resolvedIPMap[ip] = r;
             return __resolvedIPMap[ip];
         }


### PR DESCRIPTION
1. In "xLights/utils/ip_utils.cpp" 
"bad.address" was being resolved as 255.255.255.255.  Mirroring the behavior of "0.0.0.0" we can ignore this result and return the original value.

2. In "xLights/controllers/FPP.cpp" function "FPP::GetInstances"
  To prevent unexpected duplicate entries in the FPP connect dialog, we can attempt to resolve the IP or at least use the lowercase version of the address.  Currently, FPP01.local, fpp01.local, and 192.168.1.25 if entered as proxies for different controllers, can appear in the FPP connect dialog as separate devices when they all resolve to the same IP.    
  NOTE:  The result of this change is that the FPP connect dialog would almost always only show:
     single HOSTNAME and IP address:   FPP01 -192.168.1.25
          vs.
     multiple HOSTNAME and DNS names:  FPP01 - FPP01.local, FPP01 - fpp01.local, FPP01 -192.168.1.25
  
3. In "xLights/controllers/FPP.cpp" function "FPP::UploadUDPOutputsForProxy"
In order for UDP Out Mode: "Proxied" to work correctly currently, the proxy address of the controller must exactly match the address as displayed in FPP Connect.  So, if 2 is implemented we also need to resolve the controller proxy addresses when determining if the device should be a proxy.  In theory, we could just compare the lowercase result of ResolveIP of the c->GetFPPProxy() and "ipAddress".  However, without having enough experience and test data, I'm not sure this covers all cases and exceptions, so I compared both addresses and the resolved IPs.  If either match, then enable proxy for UDP.  This may be paranoia, but I felt it was safer than making other assumptions.

@dkulp I know you know the FPP connect section very well.  I was hoping for feedback before approving this pull request.  Feel free to blow this up and do it yourself if you have a better way.

Closes #3942
