### PR TITLE
Fix for long UI block when stopping preview if there are offline Twinkly controllers

### DIFF
--- a/xLights/outputs/TwinklyOutput.cpp
+++ b/xLights/outputs/TwinklyOutput.cpp
@@ -152,7 +152,8 @@ void TwinklyOutput::Close()
         _datagram = nullptr;
     }
 
-    SetLEDMode(false);
+    if (_enabled)
+        SetLEDMode(false);
 
     IPOutput::Close();
 }


### PR DESCRIPTION
Fix for long UI block when stopping preview if there are Twinkly controllers that are unavailable but are still inactive.

This can happen if you've got Twinkly controllers in the show that are not plugged in. SetLEDMode takes a few seconds to timeout, which adds up when you have lots of controllers. Skipping SetLEDMode if the device is inactive prevents this blocking call.

In my case (20 inactive controllers), this adds up to over 1 minute wait every time I stop preview.