### PR TITLE
Show friendly names for known devices in the Import From Controller dialog

### DIFF
--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -3211,6 +3211,16 @@ void CustomModelDialog::OnButton_ImportFromControllerClick(wxCommandEvent& event
             int32_t startchannel = 1;
             int nullnumber = 0;
             it->SetTransientData(startchannel, nullnumber);
+
+            // If there's another controller already known with the same IP, give the discovered controller the same name
+            // Otherwise it'll have a default Twinkly name created from the MAC address that isn't particularly useful if you have lots of devices.
+            if (const Controller* existingController = _outputManager->GetControllerWithIP(it->GetIP())) {
+                const std::string& existingName = existingController->GetName();
+                if (existingName.size() > 0) {
+                    it->SetName(existingName);
+                }
+            }
+
             choices.push_back(it->GetLongDescription());
         }
     }


### PR DESCRIPTION
Previously these would all be the names returned from discovery, eg "Twinkly_ABC123". Now, if the device is one that's known to xLights (ie there's a controller with a matching IP), then use that friendly name instead. When I've had dozens of devices online, I'd have to go to the Twinkly app and find the MAC address of the device I wanted to select the correct one.

In this screenshot, the second device's friendly name is "Twinkly Cluster 400 1", and the dialog previously showed "Twinkly_E89F6D".

<img width="568" alt="image" src="https://github.com/smeighan/xLights/assets/7349637/57272706-3e25-4e65-af40-3fa8e9246adc">

Alternative solutions could be:
1) Give TwinklyOutput::PrepareDiscovery knowledge of the main output manager, and have it do the same operation but slightly more encapsulated. This would need reconciling with xLightsFrame::OnButtonDiscoverClick's use of PrepareDiscovery.
2) Have TwinklyOutput::PrepareDiscovery ask the device for its name to get the name previously assigned in the Twinkly app, which the user may not have done - they're more likely to have a familiar name set on the xLights controller.