### PR TITLE
add debuging for resolvedIPMap

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -3871,6 +3871,10 @@ std::list<FPP*> FPP::GetInstances(wxWindow* frame, OutputManager* outputManager)
     startAddresses.sort();
     startAddresses.unique();
 
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    std::string ip_cache_dump = "Resolved IP Cache: " + ip_utils::DumpResolvedIPMap();
+    logger_base.debug(ip_cache_dump.c_str());
+
     Discovery discovery(frame, outputManager);
     FPP::PrepareDiscovery(discovery, startAddresses);
     discovery.Discover();

--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -22,6 +22,15 @@ namespace ip_utils
 {
     static std::map<std::string, std::string> __resolvedIPMap;
 
+    std::string DumpResolvedIPMap(void)
+    {
+        std::string dump = "";
+        for (auto a : __resolvedIPMap) {
+            dump += a.first + "=>" + a.second + ";";
+        }
+        return dump;
+    }
+
 	bool IsIPValid(const std::string& ip)
     {
         wxString ips = wxString(ip).Trim(false).Trim(true);

--- a/xLights/utils/ip_utils.h
+++ b/xLights/utils/ip_utils.h
@@ -20,4 +20,5 @@ namespace ip_utils
 	std::string CleanupIP(const std::string& ip);
 	std::string ResolveIP(const std::string& ip);
 
+	std::string DumpResolvedIPMap(void);
 };


### PR DESCRIPTION
It appears that some name.local addresses are not being initially resolved to IP addresses, at least on a Mac.

Feel free to kill this if you have a better idea.

std::string ResolveIP(const std::string& IP) in ip_utils.cpp is not always resolving valid names to ip4 addressses.