### PR TITLE
Write FPP connect upload results to the status bar.

### DIFF
--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -1112,10 +1112,21 @@ void FPPConnectDialog::doUpload(FPPUploadProgressDialog *prgs, std::vector<bool>
         }
         row++;
     }
+
+    xLightsFrame* xlframe = static_cast<xLightsFrame*>(GetParent());
     if (messages != "") {
         wxMessageBox(messages, "Problems Uploading", wxOK | wxCENTRE, this);
+        xlframe->SetStatusText("FPP Connect Upload had errors or warnings", 0);
+        prgs->EndModal(2);
+    } else {
+        if (cancelled) {
+            xlframe->SetStatusText("FPP Connect Upload Cancelled", 0);        
+            prgs->EndModal(1);
+        } else {
+            xlframe->SetStatusText("FPP Connect Upload Complete", 0);   
+            prgs->EndModal(0);
+        }
     }
-    prgs->EndModal(cancelled ? 1 : 0);
 }
 
 void FPPConnectDialog::CreateDriveList()

--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -1115,8 +1115,9 @@ void FPPConnectDialog::doUpload(FPPUploadProgressDialog *prgs, std::vector<bool>
 
     xLightsFrame* xlframe = static_cast<xLightsFrame*>(GetParent());
     if (messages != "") {
-        wxMessageBox(messages, "Problems Uploading", wxOK | wxCENTRE, this);
+        logger_base.warn("FPP Connect Upload had errors or warnings:\n" + messages);
         xlframe->SetStatusText("FPP Connect Upload had errors or warnings", 0);
+        wxMessageBox(messages, "Problems Uploading", wxOK | wxCENTRE, this);
         prgs->EndModal(2);
     } else {
         if (cancelled) {


### PR DESCRIPTION
Similar to upload outputs, have FPP connect upload also write its results to the status bar.

Note if an error or warning occurs and that information is added to the messages variable then a dialog already appears.

Prompted By:
https://github.com/smeighan/xLights/issues/4081