### PR TITLE
[feature] Adding ability to adjust the frequency of the "Auto" eye blink

### DIFF
--- a/xLights/effects/FacesEffect.h
+++ b/xLights/effects/FacesEffect.h
@@ -41,16 +41,17 @@ protected:
     virtual xlEffectPanel* CreatePanel(wxWindow* parent) override;
 
 private:
+    const std::map<std::string, int> eyeBlinkMap;
     void mouth(RenderBuffer& buffer, int Phoneme, int BufferHt, int BufferWt, bool shimmer);
     void drawline1(RenderBuffer& buffer, int Phoneme, int x1, int x2, int y1, int y2, int colorIdx);
-    void drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, int BufferHt, int BufferWi);
+    void drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, const std::string& eyeBlinkFreq, int BufferHt, int BufferWi);
     void facesCircle(RenderBuffer& buffer, int Phoneme, int xc, int yc, double radius, int start_degrees, int end_degrees, int colorIdx);
     void drawline3(RenderBuffer& buffer, int Phoneme, int x1, int x2, int y6, int y7, int colorIdx);
 
-    void RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, bool face_outline, uint8_t alpha, bool suppressShimmer);
-    void RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, bool face_outline, uint8_t alpha, bool suppressShimmer);
+    void RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, uint8_t alpha, bool suppressShimmer);
+    void RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, uint8_t alpha, bool suppressShimmer);
     void RenderFaces(RenderBuffer& buffer, SequenceElements* elements, const std::string& faceDefintion,
-                     const std::string& Phoneme, const std::string& track, const std::string& eyes, bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer);
+                     const std::string& Phoneme, const std::string& track, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer);
     std::string MakeKey(int bufferWi, int bufferHt, std::string dirstr, std::string picture, std::string stf);
     uint8_t CalculateAlpha(SequenceElements* elements, int leadFrames, bool fade, const std::string& timingTrack, RenderBuffer& buffer);
     bool ShimmerState(RenderBuffer& buffer) const;

--- a/xLights/effects/FacesPanel.cpp
+++ b/xLights/effects/FacesPanel.cpp
@@ -44,6 +44,9 @@ const long FacesPanel::ID_CHECKBOX_Faces_Fade = wxNewId();
 const long FacesPanel::ID_CHECKBOX_Faces_TransparentBlack = wxNewId();
 const long FacesPanel::IDD_SLIDER_Faces_TransparentBlack = wxNewId();
 const long FacesPanel::ID_TEXTCTRL_Faces_TransparentBlack = wxNewId();
+const long FacesPanel::ID_STATICTEXT_EYEBLINKFREQUENCY = wxNewId();
+const long FacesPanel::ID_CHOICE_Faces_EyeBlinkFrequency = wxNewId();
+
 //*)
 
 BEGIN_EVENT_TABLE(FacesPanel,wxPanel)
@@ -90,6 +93,7 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer97->Add(Choice_Faces_TimingTrack, 1, wxALL|wxEXPAND, 5);
 	StaticBoxSizer2->Add(FlexGridSizer97, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
 	FlexGridSizer47->Add(StaticBoxSizer2, 1, wxALL|wxEXPAND, 5);
+    
 	FlexGridSizer98 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer98->AddGrowableCol(1);
 	StaticText14 = new wxStaticText(this, ID_STATICTEXT15, _("Face Definition"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT15"));
@@ -104,7 +108,20 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Choice_Faces_Eyes->SetSelection( Choice_Faces_Eyes->Append(_("Auto")) );
 	Choice_Faces_Eyes->Append(_("(off)"));
 	FlexGridSizer98->Add(Choice_Faces_Eyes, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
+    //Eye Blink Frequency
+    StaticText_Faces_EyeBlinkFrequency = new wxStaticText(this,  ID_STATICTEXT_EYEBLINKFREQUENCY, _("Eye Blink Frequency"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_EYEBLINKFREQUENCY"));
+    FlexGridSizer98->Add(StaticText_Faces_EyeBlinkFrequency, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    Choice_Faces_EyeBlinkFrequency = new BulkEditChoice(this, ID_CHOICE_Faces_EyeBlinkFrequency, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Faces_EyeBlinkFrequency"));
+    Choice_Faces_EyeBlinkFrequency->Append(_("Slowest"));
+    Choice_Faces_EyeBlinkFrequency->Append(_("Slow"));
+    Choice_Faces_EyeBlinkFrequency->SetSelection( Choice_Faces_EyeBlinkFrequency->Append(_("Normal")) );
+    Choice_Faces_EyeBlinkFrequency->Append(_("Fast"));
+    Choice_Faces_EyeBlinkFrequency->Append(_("Fastest"));
+    FlexGridSizer98->Add(Choice_Faces_EyeBlinkFrequency, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    
+    FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    
 	CheckBox_Faces_Outline = new BulkEditCheckBox(this, ID_CHECKBOX_Faces_Outline, _("Show outline"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Faces_Outline"));
 	CheckBox_Faces_Outline->SetValue(false);
 	FlexGridSizer98->Add(CheckBox_Faces_Outline, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
@@ -117,7 +134,8 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Choice1 = new BulkEditStateChoice(this, ID_CHOICE_Faces_UseState, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Faces_UseState"));
 	FlexGridSizer98->Add(Choice1, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
+	
+    FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	CheckBox_SuppressWhenNotSinging = new BulkEditCheckBox(this, ID_CHECKBOX_Faces_SuppressWhenNotSinging, _("Suppress when not singing"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Faces_SuppressWhenNotSinging"));
 	CheckBox_SuppressWhenNotSinging->SetValue(false);
@@ -125,6 +143,7 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText1 = new wxStaticText(this, ID_STATICTEXT_Faces_Lead_Frames, _("Lead In/Out Frames"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Faces_Lead_Frames"));
 	FlexGridSizer1->Add(StaticText1, 1, wxALL|wxEXPAND, 5);
+    
 	SpinCtrl_LeadFrames = new wxSpinCtrl(this, ID_SPINCTRL_Faces_LeadFrames, _T("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0, _T("ID_SPINCTRL_Faces_LeadFrames"));
 	SpinCtrl_LeadFrames->SetValue(_T("0"));
 	FlexGridSizer1->Add(SpinCtrl_LeadFrames, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
@@ -152,6 +171,7 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Connect(ID_CHECKBOX_Faces_Outline,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_Faces_OutlineClick);
 	Connect(ID_CHECKBOX_Faces_SuppressWhenNotSinging,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_SuppressWhenNotSingingClick);
 	Connect(ID_CHECKBOX_Faces_Fade,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_FadeClick);
+    Connect(ID_CHOICE_Faces_Eyes,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyesSelected);
 	//*)
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&FacesPanel::OnVCChanged, 0, this);
@@ -202,6 +222,22 @@ void FacesPanel::ValidateWindow()
 	else {
         Choice1->Enable(false);
     }
+    
+    // @@@
+    wxString type = Choice_Faces_Eyes->GetStringSelection();
+    if (type == "Auto")
+    {
+        Choice_Faces_EyeBlinkFrequency->Enable();
+    }
+    else
+    {
+        Choice_Faces_EyeBlinkFrequency->Disable();
+    }
+}
+
+void FacesPanel::OnChoice_Faces_EyesSelected(wxCommandEvent& event)
+{
+    ValidateWindow();
 }
 
 void FacesPanel::OnMouthMovementTypeSelected(wxCommandEvent& event)
@@ -222,3 +258,4 @@ void FacesPanel::OnCheckBox_Faces_OutlineClick(wxCommandEvent& event)
 {
 	ValidateWindow();
 }
+

--- a/xLights/effects/FacesPanel.h
+++ b/xLights/effects/FacesPanel.h
@@ -55,6 +55,8 @@ class FacesPanel: public xlEffectPanel
 		wxStaticText* StaticText1;
 		wxStaticText* StaticText2;
 		wxStaticText* StaticText71;
+        wxStaticText* StaticText_Faces_EyeBlinkFrequency;
+        BulkEditChoice* Choice_Faces_EyeBlinkFrequency;
 		//*)
 
 	protected:
@@ -79,6 +81,8 @@ class FacesPanel: public xlEffectPanel
 		static const long ID_CHECKBOX_Faces_TransparentBlack;
 		static const long IDD_SLIDER_Faces_TransparentBlack;
 		static const long ID_TEXTCTRL_Faces_TransparentBlack;
+        static const long ID_STATICTEXT_EYEBLINKFREQUENCY;
+        static const long ID_CHOICE_Faces_EyeBlinkFrequency;
 		//*)
 
 	public:
@@ -88,6 +92,7 @@ class FacesPanel: public xlEffectPanel
 		void OnCheckBox_SuppressWhenNotSingingClick(wxCommandEvent& event);
 		void OnCheckBox_FadeClick(wxCommandEvent& event);
 		void OnCheckBox_Faces_OutlineClick(wxCommandEvent& event);
+        void OnChoice_Faces_EyesSelected(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/sequencer/Effect.cpp
+++ b/xLights/sequencer/Effect.cpp
@@ -65,6 +65,7 @@ public:
 
         data["E_CHOICE_CoroFaces_Phoneme"] = "E_CHOICE_Faces_Phoneme";
         data["E_CHOICE_CoroFaces_Eyes"] = "E_CHOICE_Faces_Eyes";
+        data["E_CHOICE_CoroFaces_EyeBlinkFrequency"] = "E_CHOICE_Faces_EyeBlinkFrequency";
         data["E_CHECKBOX_CoroFaces_Outline"] = "E_CHECKBOX_Faces_Outline";
         data["E_CHECKBOX_CoroFaces_InPapagayo"] = "";
         data["E_CHECKBOX_Faces_InPapagayo"] = "";


### PR DESCRIPTION
[feature] Adding ability to adjust the frequency of the "Auto" eye blink

Came upon some discussion online where users wanted to speed up the blinking on some props, with one idea to allow a drop down on the Faces Effect Panel. I found that the current implementation is typically a random int between 4500 and 5500 ms (with some logic around Phenoms and resting which has been preserved). Created more of a scale from "Slowest" to "Fastest", with the default of "Normal" that preserves the existing numbers.

I tested new sequences, checked their save files, reloaded correctly. I also checked older sequences opening in the new format at saw that eye blinking behavior was 'upgraded'.

If there are other testing avenues needed, please advise and I will address