### PR TITLE
Virtual Matrix can receive RGBW channels.

### DIFF
--- a/xSchedule/VirtualMatricesDialog.cpp
+++ b/xSchedule/VirtualMatricesDialog.cpp
@@ -91,8 +91,9 @@ VirtualMatricesDialog::VirtualMatricesDialog(wxWindow* parent, OutputManager* ou
     ListView1->InsertColumn(7, "Start Channel");
     ListView1->InsertColumn(8, "Quality");
     ListView1->InsertColumn(9, "Matrix Multiplier");
+    ListView1->InsertColumn(10, "Pixel");
 
-    SetSize(950, 400);
+    SetSize(1000, 400);
 
     PopulateList();
 
@@ -175,8 +176,9 @@ void VirtualMatricesDialog::OnButton_OkClick(wxCommandEvent& event)
             matrixMultiplier = wxAtoi(ListView1->GetItemText(i, 9));
             useMatrixSize = true;
         }
+        std::string pixelChannels = ListView1->GetItemText(i, 10).ToStdString();
 
-        _vmatrices->push_back(new VirtualMatrix(_outputManager, width, height, topMost, rotation, quality, startChannel, name, size, location, useMatrixSize, matrixMultiplier));
+        _vmatrices->push_back(new VirtualMatrix(_outputManager, width, height, topMost, rotation, pixelChannels, quality, startChannel, name, size, location, useMatrixSize, matrixMultiplier));
     }
 
     EndDialog(wxID_OK);
@@ -208,6 +210,7 @@ void VirtualMatricesDialog::DoAdd()
     int height = 16;
     bool topMost = true;
     std::string rotation = "";
+    std::string pixelChannels = "";
     wxSize size = _options->GetDefaultVideoSize();
     wxPoint location = _options->GetDefaultVideoPos();
     std::string startChannel = "1";
@@ -215,7 +218,7 @@ void VirtualMatricesDialog::DoAdd()
     bool useMatrixSize = false;
     int matrixMultiplier = 1;
 
-    VirtualMatrixDialog dlg(this, _outputManager, name, rotation, quality, size, location, width, height, topMost, startChannel, useMatrixSize, matrixMultiplier, _options);
+    VirtualMatrixDialog dlg(this, _outputManager, name, rotation, pixelChannels, quality, size, location, width, height, topMost, startChannel, useMatrixSize, matrixMultiplier, _options);
 
     if (dlg.ShowModal() == wxID_OK)
     {
@@ -237,6 +240,7 @@ void VirtualMatricesDialog::DoAdd()
         {
             ListView1->SetItem(row, 9, "");
         }
+        ListView1->SetItem(row, 10, pixelChannels);
     }
 
     ValidateWindow();
@@ -264,6 +268,7 @@ void VirtualMatricesDialog::DoEdit()
     int height = wxAtoi(ListView1->GetItemText(item, 2));
     bool topMost = ListView1->GetItemText(item, 3) == "Yes";
     std::string rotation = ListView1->GetItemText(item, 4).ToStdString();
+    std::string pixelChannels = ListView1->GetItemText(item, 10).ToStdString();
     auto sz = wxSplit(ListView1->GetItemText(item, 5), ',');
     wxSize size(300, 300);
     if (sz.GetCount() == 2)
@@ -286,7 +291,7 @@ void VirtualMatricesDialog::DoEdit()
         useMatrixSize = true;
     }
 
-    VirtualMatrixDialog dlg(this, _outputManager, name, rotation, quality, size, location, width, height, topMost, startChannel, useMatrixSize, matrixMultiplier, _options);
+    VirtualMatrixDialog dlg(this, _outputManager, name, rotation, pixelChannels, quality, size, location, width, height, topMost, startChannel, useMatrixSize, matrixMultiplier, _options);
 
     if (dlg.ShowModal() == wxID_OK)
     {
@@ -307,6 +312,7 @@ void VirtualMatricesDialog::DoEdit()
         {
             ListView1->SetItem(item, 9, "");
         }
+        ListView1->SetItem(item, 10, pixelChannels);
     }
 
     ValidateWindow();
@@ -334,5 +340,6 @@ void VirtualMatricesDialog::PopulateList()
         {
             ListView1->SetItem(row, 9, "");
         }
+        ListView1->SetItem(row, 10, (*it)->GetPixelChannels());
     }
 }

--- a/xSchedule/VirtualMatrix.h
+++ b/xSchedule/VirtualMatrix.h
@@ -19,6 +19,7 @@ class OutputManager;
 class ScheduleOptions;
 
 typedef enum {VM_NORMAL, VM_90, VM_270, VM_FLIP_HORIZONTAL, VM_FLIP_VERTICAL } VMROTATION;
+typedef enum {RGB, RGBW } VMPIXELCHANNELS;
 
 class VirtualMatrix 
 {
@@ -34,6 +35,7 @@ class VirtualMatrix
     wxSize _size;
     wxPoint _location;
     VMROTATION _rotation;
+    VMPIXELCHANNELS _pixelChannels;
     std::string _startChannel;
     wxImage _image;
     wxImageResizeQuality _quality;
@@ -45,12 +47,14 @@ public:
 
 		static VMROTATION EncodeRotation(const std::string rotation);
 		static std::string DecodeRotation(VMROTATION rotation);
+        static VMPIXELCHANNELS EncodePixelChannels(const std::string pixelChannels);
+        static std::string DecodePixelChannels(VMPIXELCHANNELS pixelChannels);
         static wxImageResizeQuality EncodeScalingQuality(const std::string quality, int& swsQuality);
         static std::string DecodeScalingQuality(wxImageResizeQuality quality, int swsQuality);
 
         VirtualMatrix(OutputManager* outputManager, wxXmlNode* n);
-        VirtualMatrix(OutputManager* outputManager, int width, int height, bool topMost, VMROTATION rotation, wxImageResizeQuality quality, int swsQuality, const std::string& startChannel, const std::string& name, wxSize size, wxPoint loc, bool useMatrixSize, int matrixMultiplier);
-        VirtualMatrix(OutputManager* outputManager, int width, int height, bool topMost, const std::string& rotation, const std::string& quality, const std::string& startChannel, const std::string& name, wxSize size, wxPoint loc, bool useMatrixSize, int matrixMultiplier);
+        VirtualMatrix(OutputManager* outputManager, int width, int height, bool topMost, VMROTATION rotation, VMPIXELCHANNELS pixelChannels, wxImageResizeQuality quality, int swsQuality, const std::string& startChannel, const std::string& name, wxSize size, wxPoint loc, bool useMatrixSize, int matrixMultiplier);
+        VirtualMatrix(OutputManager* outputManager, int width, int height, bool topMost, const std::string& rotation, const std::string& pixelChannels, const std::string& quality, const std::string& startChannel, const std::string& name, wxSize size, wxPoint loc, bool useMatrixSize, int matrixMultiplier);
         VirtualMatrix(OutputManager* outputManager, ScheduleOptions* options);
         virtual ~VirtualMatrix() {}
         void Frame(uint8_t*buffer, size_t size);
@@ -60,7 +64,8 @@ public:
         void Suppress(bool suppress);
         std::string GetStartChannel() const { return _startChannel; }
         long GetStartChannelAsNumber() const;
-        size_t GetChannels() const { return _width * _height * 3; }
+        int GetPixelChannelsCount() const;
+        size_t GetChannels() const { return _width * _height * GetPixelChannelsCount(); }
         void SetStartChannel(const std::string& startChannel) { if (startChannel != _startChannel) { _startChannel = startChannel; _changeCount++; } }
         std::string GetName() const { return _name; }
         void SetName(const std::string& name) { if (name != _name) { _name = name; _changeCount++; } }
@@ -72,6 +77,7 @@ public:
         bool GetUseMatrixSize() const { return _useMatrixSize; }
         int GetMatrixMultiplier() const { return _matrixMultiplier; }
         std::string GetRotation() const { return DecodeRotation(_rotation); }
+        std::string GetPixelChannels() const { return DecodePixelChannels(_pixelChannels); }
         std::string GetScalingQuality() const { return DecodeScalingQuality(_quality, _swsQuality); }
         bool IsDirty() const { return _lastSavedChangeCount != _changeCount; }
         void ClearDirty() { _lastSavedChangeCount = _changeCount; }

--- a/xSchedule/VirtualMatrixDialog.cpp
+++ b/xSchedule/VirtualMatrixDialog.cpp
@@ -28,6 +28,8 @@ const long VirtualMatrixDialog::ID_STATICTEXT1 = wxNewId();
 const long VirtualMatrixDialog::ID_SPINCTRL1 = wxNewId();
 const long VirtualMatrixDialog::ID_STATICTEXT4 = wxNewId();
 const long VirtualMatrixDialog::ID_SPINCTRL2 = wxNewId();
+const long VirtualMatrixDialog::ID_STATICTEXT9 = wxNewId();
+const long VirtualMatrixDialog::ID_CHOICE4 = wxNewId();
 const long VirtualMatrixDialog::ID_STATICTEXT2 = wxNewId();
 const long VirtualMatrixDialog::ID_CHOICE1 = wxNewId();
 const long VirtualMatrixDialog::ID_STATICTEXT5 = wxNewId();
@@ -46,8 +48,8 @@ BEGIN_EVENT_TABLE(VirtualMatrixDialog,wxDialog)
 	//*)
 END_EVENT_TABLE()
 
-VirtualMatrixDialog::VirtualMatrixDialog(wxWindow* parent, OutputManager* outputManager, std::string& name, std::string& rotation, std::string& quality, wxSize& vmsize, wxPoint& vmlocation, int& width, int& height, bool& topMost, std::string& startChannel, bool& useMatrixSize, int& matrixMultiplier, ScheduleOptions* options, wxWindowID id, const wxPoint& pos, const wxSize& size) :
-    _name(name), _width(width), _height(height), _topMost(topMost), _useMatrixSize(useMatrixSize), _matrixMultiplier(matrixMultiplier), _startChannel(startChannel), _size(vmsize), _location(vmlocation), _rotation(rotation), _quality(quality)
+VirtualMatrixDialog::VirtualMatrixDialog(wxWindow* parent, OutputManager* outputManager, std::string& name, std::string& rotation, std::string& pixelChannels, std::string& quality, wxSize& vmsize, wxPoint& vmlocation, int& width, int& height, bool& topMost, std::string& startChannel, bool& useMatrixSize, int& matrixMultiplier, ScheduleOptions* options, wxWindowID id, const wxPoint& pos, const wxSize& size) :
+    _name(name), _width(width), _height(height), _topMost(topMost), _useMatrixSize(useMatrixSize), _matrixMultiplier(matrixMultiplier), _startChannel(startChannel), _size(vmsize), _location(vmlocation), _rotation(rotation), _pixelChannels(pixelChannels), _quality(quality)
 {
     _outputManager = outputManager;
     _tempSize = _size;
@@ -78,6 +80,12 @@ VirtualMatrixDialog::VirtualMatrixDialog(wxWindow* parent, OutputManager* output
     SpinCtrl_Width = new wxSpinCtrl(this, ID_SPINCTRL2, _T("32"), wxDefaultPosition, wxDefaultSize, 0, 1, 5000, 32, _T("ID_SPINCTRL2"));
     SpinCtrl_Width->SetValue(_T("32"));
     FlexGridSizer1->Add(SpinCtrl_Width, 1, wxALL|wxEXPAND, 5);
+    StaticText9 = new wxStaticText(this, ID_STATICTEXT9, _("Pixel channels:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT9"));
+    FlexGridSizer1->Add(StaticText9, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    Choice_PixelChannels = new wxChoice(this, ID_CHOICE4, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE4"));
+    Choice_PixelChannels->SetSelection( Choice_PixelChannels->Append(_("RGB")) );
+    Choice_PixelChannels->Append(_("RGBW"));
+    FlexGridSizer1->Add(Choice_PixelChannels, 1, wxALL|wxEXPAND, 5);
     StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _("Rotation:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
     FlexGridSizer1->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     Choice_Rotation = new wxChoice(this, ID_CHOICE1, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE1"));
@@ -146,6 +154,7 @@ VirtualMatrixDialog::VirtualMatrixDialog(wxWindow* parent, OutputManager* output
 
     TextCtrl_Name->SetValue(_name);
     Choice_Rotation->SetStringSelection(_rotation);
+    Choice_PixelChannels->SetStringSelection(_pixelChannels);
     Choice_Quality->SetStringSelection(_quality);
     TextCtrl_StartChannel->SetValue(_startChannel);
     SpinCtrl_Width->SetValue(_width);
@@ -163,6 +172,7 @@ void VirtualMatrixDialog::OnButton_OkClick(wxCommandEvent& event)
 {
     _name = TextCtrl_Name->GetValue().ToStdString();
     _rotation = Choice_Rotation->GetStringSelection().ToStdString();
+    _pixelChannels = Choice_PixelChannels->GetStringSelection().ToStdString();
     _quality = Choice_Quality->GetStringSelection().ToStdString();
     _startChannel = TextCtrl_StartChannel->GetValue().ToStdString();
     _width = SpinCtrl_Width->GetValue();

--- a/xSchedule/VirtualMatrixDialog.h
+++ b/xSchedule/VirtualMatrixDialog.h
@@ -36,6 +36,7 @@ class VirtualMatrixDialog : public wxDialog
     wxSize& _size;
     wxPoint& _location;
     std::string& _rotation;
+    std::string& _pixelChannels;
     std::string& _quality;
     OutputManager* _outputManager;
     wxSize _tempSize;
@@ -44,7 +45,7 @@ class VirtualMatrixDialog : public wxDialog
 
 public:
 
-    VirtualMatrixDialog(wxWindow* parent, OutputManager* outputManager, std::string& name, std::string& rotation, std::string& quality, wxSize& vmsize, wxPoint& vmlocation, int& width, int& height, bool& topMost, std::string& _startChannel, bool& useMatrixSize, int& matrixMultiplier, ScheduleOptions* options, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+    VirtualMatrixDialog(wxWindow* parent, OutputManager* outputManager, std::string& name, std::string& rotation, std::string& pixelChannels, std::string& quality, wxSize& vmsize, wxPoint& vmlocation, int& width, int& height, bool& topMost, std::string& _startChannel, bool& useMatrixSize, int& matrixMultiplier, ScheduleOptions* options, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
     virtual ~VirtualMatrixDialog();
 
     //(*Declarations(VirtualMatrixDialog)
@@ -52,6 +53,7 @@ public:
     wxButton* Button_Ok;
     wxButton* Button_Position;
     wxCheckBox* CheckBox_Topmost;
+    wxChoice* Choice_PixelChannels;
     wxChoice* Choice_Quality;
     wxChoice* Choice_Rotation;
     wxSpinCtrl* SpinCtrl_Height;
@@ -63,6 +65,7 @@ public:
     wxStaticText* StaticText5;
     wxStaticText* StaticText6;
     wxStaticText* StaticText7;
+    wxStaticText* StaticText9;
     wxTextCtrl* TextCtrl_Name;
     wxTextCtrl* TextCtrl_StartChannel;
     //*)
@@ -76,6 +79,8 @@ protected:
     static const long ID_SPINCTRL1;
     static const long ID_STATICTEXT4;
     static const long ID_SPINCTRL2;
+    static const long ID_STATICTEXT9;
+    static const long ID_CHOICE4;
     static const long ID_STATICTEXT2;
     static const long ID_CHOICE1;
     static const long ID_STATICTEXT5;

--- a/xSchedule/wxsmith/VirtualMatrixDialog.wxs
+++ b/xSchedule/wxsmith/VirtualMatrixDialog.wxs
@@ -58,6 +58,27 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
+				<object class="wxStaticText" name="ID_STATICTEXT9" variable="StaticText9" member="yes">
+					<label>Pixel channels:</label>
+				</object>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxChoice" name="ID_CHOICE4" variable="Choice_PixelChannels" member="yes">
+					<content>
+						<item>RGB</item>
+						<item>RGBW</item>
+					</content>
+					<selection>0</selection>
+					<handler function="OnChoice_PixelChannelsSelect" entry="EVT_CHOICE" />
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
 				<object class="wxStaticText" name="ID_STATICTEXT2" variable="StaticText2" member="yes">
 					<label>Rotation:</label>
 				</object>


### PR DESCRIPTION
Hello, 

I'm new to the software and codebase, and I'm trying to make xScheduler work for my configuration.

I have an RGBW matrix that is fed by DMX channels. In order to review the content in the xScheduler's virtual matrix I added a feature to define the channel parsing logic, which gets saved in the configuration of the VirtualMatrix.

![image](https://github.com/smeighan/xLights/assets/5476273/4688f72d-c610-41db-b7d0-41b3a1cd6471)

This is performed regardless of the settings for `Output Processing`, since the hardware matrix need to receive the full range of channels.

Note, this is the first time that I modify a codeblocks project, and I am not sure that I made all the changes that are required, but I'd be happy to amend the PR if needed.
Thanks.