### PR TITLE
Selectively Offset parameters on remap of dmx channels

### DIFF
--- a/xLights/ValueCurve.cpp
+++ b/xLights/ValueCurve.cpp
@@ -2196,16 +2196,47 @@ void ValueCurve::ScaleAndOffsetValues(float scale, int offset)
         return (val * scale ) + offset;
     };
 
-    _parameter1 = ScaleVal(_parameter1);
-    _parameter2 = ScaleVal(_parameter2);
-    _parameter3 = ScaleVal(_parameter3);
-    _parameter4 = ScaleVal(_parameter4);
+    std::vector<int> parametersToScale;
 
-    if (_type == "Custom")
-    {
-        for (auto& it : _values)
-        {
+    if (_type == "Custom") {
+        for (auto& it : _values) {
             it.y = ScaleVal(it.y);
         }
+    } else if (_type == "Flat") {
+        parametersToScale.push_back(1);
+    } else if (_type == "Ramp" || _type == "Ramp Up/Down Hold" || _type == "Saw Tooth" || _type == "Square" || _type == "Random" || _type == "Music" || _type == "Inverted Music" || 
+               _type == "Music Trigger Fade" || _type == "Timing Track Toggle" || _type == "Timing Track Fade Fixed" || _type == "Timing Track Fade Proportional") {
+        parametersToScale.push_back(1);
+        parametersToScale.push_back(2);
+    } else if (_type == "Ramp Up/Down") {
+        parametersToScale.push_back(1);
+        parametersToScale.push_back(2);
+        parametersToScale.push_back(3);
+    } else if (_type == "Parabolic Down" || _type == "Parabolic Up" || _type == "Logarithmic Up" || _type == "Logarithmic Down" || _type == "Exponential Up" || _type == "Exponential Down") {
+        parametersToScale.push_back(2);
+    } else if (_type == "Sine" || _type == "Abs Sine" || _type == "Decaying Sine") {
+        parametersToScale.push_back(4);
+    } else {
+        parametersToScale.push_back(1);
+        parametersToScale.push_back(2);
+        parametersToScale.push_back(3);
+        parametersToScale.push_back(4);
     }
+
+    for (int param : parametersToScale) {
+        switch (param) {
+        case 1:
+            _parameter1 = ScaleVal(_parameter1);
+            break;
+        case 2:
+            _parameter2 = ScaleVal(_parameter2);
+            break;
+        case 3:
+            _parameter3 = ScaleVal(_parameter3);
+            break;
+        case 4:
+            _parameter4 = ScaleVal(_parameter4);
+            break;
+        }
+    }    
 }


### PR DESCRIPTION
Currently when using the remap and changing the offset, it applies that offset to all 4 parameters.
I believe @computergeek1507 put this feature in for an easy way for people to offset the dmx values for moving heads to fix the Pan when importing sequences from vendors.

So for example I set the following on the Saw Tooth:
Start Level: 50
End Level: 100
Cycles: 3

After the offset of 20 is applied: all values were updated, even the Cycles - which is the issue here as it changes the effect drastically.
![OffsetIssue](https://github.com/smeighan/xLights/assets/25444831/61ff3928-7ee6-4309-8ca3-c0e972ed537a)

Here you can see on the Sine that it adjusted all values by 42, causing the break in the graph there.
![OffsetIssue2](https://github.com/smeighan/xLights/assets/25444831/4f578937-f7b4-44f0-95ff-1c69822fff1a)

This change I am doing will selectively pick which parameters to update based on the curve selected.
Saw Tooth will only update the Start and End Level
Sine will only adjust the Vertical Offset.