### PR TITLE
Show fpp connect results in status bar

### DIFF
--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -1123,10 +1123,21 @@ void FPPConnectDialog::doUpload(FPPUploadProgressDialog *prgs, std::vector<bool>
         }
         row++;
     }
+    xLightsFrame* xlframe = static_cast<xLightsFrame*>(GetParent());
     if (messages != "") {
+        xlframe->SetStatusText("FPP Connect Upload had errors or warnings", 0);
         wxMessageBox(messages, "Problems Uploading", wxOK | wxCENTRE, this);
-    }
-    prgs->EndModal(cancelled ? 1 : 0);
+        logger_base.warn("FPP Connect Upload had errors or warnings:\n" + messages);
+        prgs->EndModal(2);
+    } else {
+        if (cancelled) {
+            xlframe->SetStatusText("FPP Connect Upload Cancelled", 0);
+            prgs->EndModal(1);
+        } else {
+            xlframe->SetStatusText("FPP Connect Upload Complete", 0);
+            prgs->EndModal(0);
+        }
+    };
 }
 
 bool FPPConnectDialog::GetCheckValue(const std::string &col) {


### PR DESCRIPTION
The messages variable has new lines of unknown length, so including it in the status bar won't work.
I did, however, add logging so that the same text that appears in the dialog is added to the log.  Some of these messages are already logged, which keeps them together and easier to understand.

(I had a glitch with the previous PR, and had to recreate it.)

Prompted by https://github.com/smeighan/xLights/issues/4081