### PR TITLE
Fix for #4134

### DIFF
--- a/xLights/ColorCurveDialog.cpp
+++ b/xLights/ColorCurveDialog.cpp
@@ -168,9 +168,9 @@ ColorCurveDialog::ColorCurveDialog(wxWindow* parent, ColorCurve* cc, wxColourDat
         end = eff->GetEndTimeMS();
     }
 
-    Element* timingElement = xLightsApp::GetFrame()->GetMainSequencer()->PanelEffectGrid->GetActiveTimingElement();
+    auto timingElement = xLightsApp::GetFrame()->GetMainSequencer()->PanelEffectGrid->GetActiveTimingElement();
 
-    _ccp = new ColorCurvePanel(_cc, timingElement, start, end, colorData, this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER);
+    _ccp = new ColorCurvePanel(_cc, timingElement.get(), start, end, colorData, this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER);
     _ccp->SetMinSize(wxSize(500, 80));
     _ccp->SetType(_cc->GetType());
     FlexGridSizer6->Add(_ccp, 1, wxALL | wxEXPAND, 2);

--- a/xLights/RenderCache.cpp
+++ b/xLights/RenderCache.cpp
@@ -397,7 +397,7 @@ static bool doOnEffectsInternal(Element *em, std::function<bool(Effect*)>& func)
     if (em->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
         ModelElement *me = (ModelElement*)em;
         for (int x = 0; x < me->GetSubModelCount(); x++) {
-            if (doOnEffectsInternal(me->GetSubModel(x), func)) {
+            if (doOnEffectsInternal(me->GetSubModel(x).get(), func)) {
                 return true;
             }
         }

--- a/xLights/SearchPanel.cpp
+++ b/xLights/SearchPanel.cpp
@@ -150,7 +150,7 @@ std::vector<wxString> SearchPanel::GetModelList() const
             auto* mel = dynamic_cast<ModelElement*>(el);
             if (mel != nullptr) {
                 for (int x = 0; x < mel->GetSubModelAndStrandCount(); ++x) {
-                    auto* sme = mel->GetSubModel(x);
+                    auto sme = mel->GetSubModel(x);
                     if (sme != nullptr) {
                         for (size_t j = 0; j < sme->GetEffectLayerCount(); j++) {
                             auto* elay = sme->GetEffectLayer(j);
@@ -221,7 +221,7 @@ void SearchPanel::FindSettings()
             auto* mel = dynamic_cast<ModelElement*>(el);
             if (mel != nullptr) {
                 for (int x = 0; x < mel->GetSubModelAndStrandCount(); ++x) {
-                    auto* sme = mel->GetSubModel(x);
+                    auto sme = mel->GetSubModel(x);
                     if (sme != nullptr) {
                         for (size_t j = 0; j < sme->GetEffectLayerCount(); j++) {
                             auto* elay = sme->GetEffectLayer(j);

--- a/xLights/SelectPanel.cpp
+++ b/xLights/SelectPanel.cpp
@@ -166,7 +166,7 @@ void SelectPanel::populateModelsList(const std::string& effectType)
             ModelElement* mel = dynamic_cast<ModelElement*>(el);
             if (mel != nullptr) {
                 for (int x = 0; x < mel->GetSubModelAndStrandCount(); ++x) {
-                    SubModelElement* sme = mel->GetSubModel(x);
+                    auto sme = mel->GetSubModel(x);
                     if (sme != nullptr) {
                         for (size_t j = 0; j < sme->GetEffectLayerCount(); j++) {
                             EffectLayer* elay = sme->GetEffectLayer(j);
@@ -233,7 +233,7 @@ void SelectPanel::populateEffectsList()
                 ModelElement* mel = dynamic_cast<ModelElement*>(el);
                 if (mel != nullptr) {
                     for (int x = 0; x < mel->GetSubModelAndStrandCount(); ++x) {
-                        SubModelElement* sme = mel->GetSubModel(x);
+                        auto sme = mel->GetSubModel(x);
                         if (sme != nullptr) {
                             for (size_t j = 0; j < sme->GetEffectLayerCount(); j++) {
                                 EffectLayer* elay = sme->GetEffectLayer(j);

--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -2267,7 +2267,7 @@ void xLightsFrame::ImportSuperStar(const wxFileName& filename)
     for (size_t i = 0; i < _sequenceElements.GetElementCount(); i++) {
         if (auto p = _sequenceElements.GetElement(i))
             model = p->shared_from_this();
-        if (!model || model->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
+        if (model && model->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
             if (model->GetName() == model_name) {
                 model_found = true;
                 break;

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -748,7 +748,7 @@ bool xLightsFrame::EnsureSequenceElementsAreOrderedCorrectly(const std::string M
         }
 
         // Grab the existing elements
-        std::list<SubModelElement*> oldList;
+        std::list<std::shared_ptr<SubModelElement>> oldList;
         for (int i = 0; i < elementToCheck->GetSubModelCount(); i++) {
             oldList.push_back(elementToCheck->GetSubModel(i));
         }
@@ -774,10 +774,7 @@ bool xLightsFrame::EnsureSequenceElementsAreOrderedCorrectly(const std::string M
             }
         }
 
-        // delete any that are no longer there
-        for (auto it = oldList.begin(); it != oldList.end(); ++it) {
-            delete *it;
-        }
+        // oldList will go out of scope destroying any ones that weren't put back.
 
         return true;
     }

--- a/xLights/ValueCurveDialog.cpp
+++ b/xLights/ValueCurveDialog.cpp
@@ -311,9 +311,9 @@ ValueCurveDialog::ValueCurveDialog(wxWindow* parent, ValueCurve* vc, bool slider
         Choice_TimingTrack->Append(te->GetName());
     }
 
-    Element* timingElement = xLightsApp::GetFrame()->GetMainSequencer()->PanelEffectGrid->GetActiveTimingElement();
+    auto timingElement = xLightsApp::GetFrame()->GetMainSequencer()->PanelEffectGrid->GetActiveTimingElement();
 
-    _vcp = new ValueCurvePanel(this, timingElement, start, end, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER);
+    _vcp = new ValueCurvePanel(this, timingElement.get(), start, end, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER);
     _vcp->SetMinSize(wxSize(200, 100));
     _vcp->SetValue(_vc);
     _vcp->SetType(_vc->GetType());

--- a/xLights/ViewsModelsPanel.cpp
+++ b/xLights/ViewsModelsPanel.cpp
@@ -2496,13 +2496,13 @@ void ViewsModelsPanel::RemoveModelFromLists(const std::string& modelName)
 {
     for (size_t i = 0; i < ListCtrlModels->GetItemCount(); ++i) {
         if (ListCtrlModels->GetItemText(i, 1) == modelName) {
-            ListCtrlModels->SetItemPtrData(i, (wxUIntPtr)0);
+            ListCtrlModels->SetItemPtrData(i, (wxUIntPtr)ElementId::kInvalidElementId);
             break;
         }
     }
     for (size_t i = 0; i < ListCtrlNonModels->GetItemCount(); ++i) {
         if (ListCtrlNonModels->GetItemText(i, 1) == modelName) {
-            ListCtrlNonModels->SetItemPtrData(i, (wxUIntPtr)0);
+            ListCtrlNonModels->SetItemPtrData(i, (wxUIntPtr)ElementId::kInvalidElementId);
             break;
         }
     }

--- a/xLights/ViewsModelsPanel.h
+++ b/xLights/ViewsModelsPanel.h
@@ -67,6 +67,7 @@ class ViewsModelsPanel : public wxPanel
     bool _dragRowModel = false;
     bool _dragRowNonModel = false;
     std::list<std::string> _undo;
+    std::vector<std::shared_ptr<Element>> _localElements;
 
     void PopulateViews();
     void SortNonModels();

--- a/xLights/effects/PianoEffect.cpp
+++ b/xLights/effects/PianoEffect.cpp
@@ -723,8 +723,7 @@ std::map<int, std::list<std::pair<float, float>>> PianoEffect::LoadTimingTrack(c
                 }
             }
 
-            // std::eraseif
-            std::remove_if(tracker.begin(), tracker.end(), [](std::tuple<int, int, int> t) { return std::get<0>(t) == -1; });
+            tracker.erase(std::remove_if(tracker.begin(), tracker.end(), [](std::tuple<int, int, int> t) { return std::get<0>(t) == -1; }), tracker.end());
         }
 
         // clean up anything left in the tracker

--- a/xLights/graphics/opengl/xlOGL3GraphicsContext.cpp
+++ b/xLights/graphics/opengl/xlOGL3GraphicsContext.cpp
@@ -1790,41 +1790,26 @@ public:
         LOG_GL_ERRORV(glGenBuffers(1, &indexBuffer));
 
 
-        if (vertices.size() > 0)
-        {
-            LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, vbuffer));
-            LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(float), &vertices[0], GL_STATIC_DRAW));
+        LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, vbuffer));
+        LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(float), vertices.data(), GL_STATIC_DRAW));
 
-            LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, tbuffer));
-            LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, tvertices.size() * sizeof(float), &tvertices[0], GL_STATIC_DRAW));
-        }
+        LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, tbuffer));
+        LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, tvertices.size() * sizeof(float), tvertices.data(), GL_STATIC_DRAW));
 
-        if (normals.size() > 0)
-        {
-            LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, nbuffer));
-            LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(float), &normals[0], GL_STATIC_DRAW));
-        }
+        LOG_GL_ERRORV(glBindBuffer(GL_ARRAY_BUFFER, nbuffer));
+        LOG_GL_ERRORV(glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(float), normals.data(), GL_STATIC_DRAW));
         
-        if (wireFrame.size() > 0)
-        {
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, wfIndexes));
-            LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, wireFrame.size() * sizeof(uint32_t), &wireFrame[0], GL_STATIC_DRAW));
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-        }
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, wfIndexes));
+        LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, wireFrame.size() * sizeof(uint32_t), wireFrame.data(), GL_STATIC_DRAW));
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
 
-        if (lines.size() > 0)
-        {
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, lineIndexes));
-            LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, lines.size() * sizeof(uint32_t), &lines[0], GL_STATIC_DRAW));
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-        }
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, lineIndexes));
+        LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, lines.size() * sizeof(uint32_t), lines.data(), GL_STATIC_DRAW));
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
 
-        if (indexes.size() > 0)
-        {
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer));
-            LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexes.size() * sizeof(uint32_t), &indexes[0], GL_STATIC_DRAW));
-            LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-        }
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer));
+        LOG_GL_ERRORV(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexes.size() * sizeof(uint32_t), indexes.data(), GL_STATIC_DRAW));
+        LOG_GL_ERRORV(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
 
     GLuint vbuffer = 0;

--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -156,7 +156,7 @@ public:
     int GetEndColumn() { return mRangeStartCol < mRangeEndCol ? mRangeEndCol : mRangeStartCol; }
     int GetEndRow() { return mRangeStartRow < mRangeEndRow ? mRangeEndRow : mRangeStartRow; }
     int GetMSFromColumn(int col) const;
-    Element* GetActiveTimingElement() const;
+    std::shared_ptr<Element> GetActiveTimingElement() const;
     void RaiseSelectedEffectChanged(Effect* effect, bool isNew, bool updateUI = true, bool async = false) const;
     void LockEffects(bool lock);    
     void DisableRenderEffects(bool disable);

--- a/xLights/sequencer/MainSequencer.cpp
+++ b/xLights/sequencer/MainSequencer.cpp
@@ -1623,7 +1623,7 @@ void MainSequencer::InsertTimingMarkFromRange()
             t2 = PanelTimeLine->GetTimeLength();
         }
         if (is_range) {
-            Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
+            auto e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element.lock();
             if (e != nullptr) {
                 EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
                 if (el != nullptr) {
@@ -1648,7 +1648,7 @@ void MainSequencer::InsertTimingMarkFromRange()
         else
         {
             // x1 and x2 are the same. Insert from end time of timing to the left to x2
-            Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
+            auto e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element.lock();
             if (e != nullptr) {
                 EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
                 if (el != nullptr) {
@@ -1723,7 +1723,10 @@ void MainSequencer::SplitTimingMark()
     int selectedTiming = mSequenceElements->GetSelectedTimingRow();
     if (selectedTiming >= 0)
     {
-        Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
+        auto e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element.lock();
+        if (!e)
+            return;
+
         EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
 
         if (el == nullptr)

--- a/xLights/sequencer/SequenceElements.h
+++ b/xLights/sequencer/SequenceElements.h
@@ -31,7 +31,7 @@ class TimeLine;
 class Row_Information_Struct
 {
 public:
-    Element *element;
+    std::weak_ptr<Element> element;
     int Index;
     int RowNumber;
     bool Collapsed;
@@ -216,7 +216,7 @@ private:
         const std::vector<std::string> & effectStrings,
         const std::vector<std::string> & colorPalettes,
         bool importing = false);
-    static bool SortElementsByIndex(const Element *element1, const Element *element2)
+    static bool SortElementsByIndex(const std::shared_ptr<Element>& element1, const std::shared_ptr<Element>& element2)
     {
         return (element1->GetIndex() < element2->GetIndex());
     }
@@ -224,7 +224,7 @@ private:
         int &rowIndex, int &selectedTimingRow, int &timingRowCount, int &timingColorIndex);
 
     void ClearAllViews();
-    std::vector<std::vector <Element*> > mAllViews;
+    std::vector<std::vector<std::shared_ptr<Element>>> mAllViews;
 
     // A vector of all the visible elements that may not be on screen
     // because they all do not fit. The timing elements will always

--- a/xLights/xLightsXmlFile.cpp
+++ b/xLights/xLightsXmlFile.cpp
@@ -2771,11 +2771,11 @@ void xLightsXmlFile::Save(SequenceElements& seq_elements)
 
             int num_strands = me->GetSubModelAndStrandCount();
             for (int strand = 0; strand < num_strands; strand++) {
-                SubModelElement* se = me->GetSubModel(strand);
+                auto se = me->GetSubModel(strand);
                 num_layers = se->GetEffectLayerCount();
                 wxXmlNode* effect_layer_node = nullptr;
 
-                StrandElement* strEl = dynamic_cast<StrandElement*>(se);
+                StrandElement* strEl = dynamic_cast<StrandElement*>(se.get());
                 for (int j = 0; j < num_layers; ++j) {
                     EffectLayer* layer = se->GetEffectLayer(j);
 
@@ -3209,7 +3209,7 @@ void xLightsXmlFile::AdjustEffectSettingsForVersion(SequenceElements& elements, 
                     }
                 }
                 for (int s = 0; s < me->GetSubModelAndStrandCount(); s++) {
-                    SubModelElement* se = me->GetSubModel(s);
+                    auto se = me->GetSubModel(s);
                     for (int j = 0; j < se->GetEffectLayerCount(); j++) {
                         EffectLayer* layer = se->GetEffectLayer(j);
                         for (int k = 0; k < layer->GetEffectCount(); k++) {
@@ -3220,7 +3220,7 @@ void xLightsXmlFile::AdjustEffectSettingsForVersion(SequenceElements& elements, 
                         }
                     }
                     if (se->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
-                        StrandElement* ste = dynamic_cast<StrandElement*>(se);
+                        StrandElement* ste = dynamic_cast<StrandElement*>(se.get());
                         for (int k = 0; k < ste->GetNodeLayerCount(); k++) {
                             NodeLayer* nlayer = ste->GetNodeLayer(k);
                             for (int l = 0; l < nlayer->GetEffectCount(); l++) {


### PR DESCRIPTION
Change the memory management model for Element and derivative classes to be ref-counted through the `shared_ptr` mechanism. This removes the need for the `Element` destructor to lock a mutex which can lead to deadlocks.