### PR TITLE
Remove invisible unicode character in AlphxPix 4 settings.

### DIFF
--- a/controllers/holidaycoro.xcontroller
+++ b/controllers/holidaycoro.xcontroller
@@ -10,7 +10,7 @@
 			<MaxPixelPort>4</MaxPixelPort>
 			<MaxSerialPort>1</MaxSerialPort>
 			<MaxSerialPortChannels>512</MaxSerialPortChannels>
-			<MaxPixelPortChannels>2040‬</MaxPixelPortChannels>
+			<MaxPixelPortChannels>2040</MaxPixelPortChannels>
 			<AllInputUniversesMustBeSameSize/>
             <NeedsFullUniverseForSerial/>
 			<SupportsAutoLayout/>


### PR DESCRIPTION
This was causing issues with the controller visualiser for these devices,
always giving 0 maximum pixels per port.
