### PR TITLE
Fix HinksPix LR remote assignment for remotes 3-9 in visualizer

### DIFF
--- a/xLights/ControllerModelDialog.cpp
+++ b/xLights/ControllerModelDialog.cpp
@@ -1534,7 +1534,7 @@ public:
             } else if (label == "None") {
                 GetModel()->SetSmartRemote(0);
                 return true;
-            } else if (label >= "0" && label <= "25") {
+            } else if ((label >= "0" && label <= "9") || (label >= "10" && label <= "25")) {
                 GetModel()->SetSmartRemote(wxAtoi(label) + 1);
                 return true;
             } else if (label >= "A" && label <= "Z") {


### PR DESCRIPTION
The original code prevented directly assigning a controller to remotes 3-9 using visualizer