### PR TITLE
Fix height calculations for Arches and Candy Canes

### DIFF
--- a/xLights/models/ArchesModel.cpp
+++ b/xLights/models/ArchesModel.cpp
@@ -122,9 +122,7 @@ int ArchesModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyG
         AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ArchesModel::OnPropertyGridChange::ArchesCount");
         AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "ArchesModel::OnPropertyGridChange::ArchesCount");
         AddASAPWork(OutputModelManager::WORK_UPDATE_PROPERTYGRID, "ArchesModel::OnPropertyGridChange::ArchesCount");
-        if (ModelXml->GetAttribute("Advanced", "0") == "1") {
-            AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "ArchesModel::OnPropertyGridChange::ArchesCount");
-        }
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "ArchesModel::OnPropertyGridChange::ArchesCount");
         return 0;
     } else if ("ArchesNodes" == event.GetPropertyName()) {
         ModelXml->DeleteAttribute("parm2");

--- a/xLights/models/CandyCaneModel.cpp
+++ b/xLights/models/CandyCaneModel.cpp
@@ -112,10 +112,8 @@ int CandyCaneModel::OnPropertyGridChange(wxPropertyGridInterface *grid, wxProper
         AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
         AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
         AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
-        AddASAPWork(OutputModelManager::WORK_UPDATE_PROPERTYGRID, "ArchesModel::OnPropertyGridChange::CandyCaneCount");
-        if (ModelXml->GetAttribute("Advanced", "0") == "1") {
-            AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
-        }
+        AddASAPWork(OutputModelManager::WORK_UPDATE_PROPERTYGRID, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CandyCaneModel::OnPropertyGridChange::CandyCaneCount");
         return 0;
     } else if ("CandyCaneNodes" == event.GetPropertyName()) {
         ModelXml->DeleteAttribute("parm2");
@@ -211,21 +209,22 @@ bool CandyCaneModel::IsNodeFirst(int n) const
     return (GetIsLtoR() && n == 0) || (!GetIsLtoR() && n == Nodes.size() - parm2);
 }
 
+// Canes are 3 high per width of each indivudual cane, then multiply by 2 because standard ThreePointLocation applies a / 2 for heights
 std::string CandyCaneModel::GetDimension() const
 {
     if (parm1 != 0) {
-        return GetModelScreenLocation().GetDimension(3.0 / parm1);
+        return GetModelScreenLocation().GetDimension(6.0 / parm1);
     }
-    return GetModelScreenLocation().GetDimension(1.0);
+    return GetModelScreenLocation().GetDimension(6.0);
 }
 
 void CandyCaneModel::AddDimensionProperties(wxPropertyGridInterface* grid)
 {
     if (parm1 != 0) {
-        GetModelScreenLocation().AddDimensionProperties(grid, 3.0 / parm1);
+        GetModelScreenLocation().AddDimensionProperties(grid, 6.0 / parm1);
     }
     else {
-        GetModelScreenLocation().AddDimensionProperties(grid, 1.0);
+        GetModelScreenLocation().AddDimensionProperties(grid, 6.0);
     }
 }
 

--- a/xLights/models/ThreePointScreenLocation.cpp
+++ b/xLights/models/ThreePointScreenLocation.cpp
@@ -90,7 +90,7 @@ void ThreePointScreenLocation::AddDimensionProperties(wxPropertyGridInterface* p
     TwoPointScreenLocation::AddDimensionProperties(propertyEditor, 1.0);
     float width = RulerObject::Measure(origin, point2);
     wxPGProperty* prop = propertyEditor->Append(new wxFloatProperty(wxString::Format("Height (%s)", RulerObject::GetUnitDescription()), "RealHeight", 
-                                                                     RulerObject::Measure((width * height) / 2.0 * factor * 100.0)
+                                                                     (width * height) / 2.0 * factor
                                                                     ));
     prop->ChangeFlag(wxPG_PROP_READONLY, true);
     prop->SetAttribute("Precision", 2);
@@ -113,7 +113,7 @@ float ThreePointScreenLocation::GetRealWidth() const
 float ThreePointScreenLocation::GetRealHeight() const
 {
     float width = RulerObject::Measure(origin, point2);
-    return RulerObject::Measure((width * height) / 2.0 * 1.0 * 100.0);
+    return (width * height) / 2.0 * 1.0;
 }
 
 void ThreePointScreenLocation::AddSizeLocationProperties(wxPropertyGridInterface *propertyEditor) const {


### PR DESCRIPTION
"width" was already scaled and didn't need to be scaled again.

Candy Cane height is 3 times the width of an individual cane.  
But the standard three-point height calc assumes height is 1/2 of width.

Fixes https://github.com/smeighan/xLights/issues/4168
Arch Height in dimensions is off by 2 decimal places