### PR TITLE
add bulk edit for shadow model for to allow clear of invalid data.

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -157,6 +157,7 @@ const long LayoutPanel::ID_PREVIEW_BULKEDIT_PIXELSIZE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_PIXELSTYLE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_TRANSPARENCY = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_BLACKTRANSPARENCY = wxNewId();
+const long LayoutPanel::ID_PREVIEW_BULKEDIT_SHADOWMODELFOR = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_CONTROLLERGAMMA = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_CONTROLLERCOLOURORDER = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_CONTROLLERBRIGHTNESS = wxNewId();
@@ -1993,6 +1994,38 @@ void LayoutPanel::BulkEditBlackTranparency() {
         // see comment in BulkEditActive()
         xlights->GetOutputModelManager()->ClearSelectedModel();
         xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditBlackTranparency");
+        // reselect all the models
+        ReselectTreeModels(selectedModelPaths);
+    }
+}
+
+void LayoutPanel::BulkEditShadowModelFor()
+{
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+    // remember the selected models
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
+    wxArrayString choices;
+    choices.Add("");
+
+    for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
+        if (modelPreview->GetModels()[i]->GetName() != selectedBaseObject->GetName()) {
+            choices.Add(modelPreview->GetModels()[i]->GetName());
+        }
+    }
+
+    wxSingleChoiceDialog dlg(this, "", "Select the model to shadow.", choices);
+    dlg.SetSelection(0);
+    OptimiseDialogPosition(&dlg);
+
+    if (dlg.ShowModal() == wxID_OK) {
+        for (Model* model : modelsToEdit) {
+            model->SetShadowModelFor(dlg.GetStringSelection());
+        }
+
+        // see comment in BulkEditActive()
+        xlights->GetOutputModelManager()->ClearSelectedModel();
+        xlights->GetOutputModelManager()->AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BulkEditBlackShadowModelFor");
         // reselect all the models
         ReselectTreeModels(selectedModelPaths);
     }
@@ -4503,6 +4536,7 @@ void LayoutPanel::AddBulkEditOptionsToMenu(wxMenu* mnuBulkEdit) {
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_PIXELSTYLE, "Pixel Style");
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_TRANSPARENCY, "Transparency");
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_BLACKTRANSPARENCY, "Black Transparency");
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SHADOWMODELFOR, "Shadow Model For");
 
         mnuBulkEdit->AppendSeparator();
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION, "Controller Port");
@@ -4723,6 +4757,8 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
         BulkEditTransparency();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_BLACKTRANSPARENCY) {
         BulkEditBlackTranparency();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_SHADOWMODELFOR) {
+        BulkEditShadowModelFor();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PREVIEW) {
         BulkEditControllerPreview();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_DIMMINGCURVES) {
@@ -7450,6 +7486,8 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
         BulkEditTransparency();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_BLACKTRANSPARENCY) {
         BulkEditBlackTranparency();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_SHADOWMODELFOR) {
+        BulkEditShadowModelFor();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PREVIEW) {
         BulkEditControllerPreview();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_DIMMINGCURVES) {

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -165,6 +165,7 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_BULKEDIT_PIXELSTYLE;
         static const long ID_PREVIEW_BULKEDIT_TRANSPARENCY;
         static const long ID_PREVIEW_BULKEDIT_BLACKTRANSPARENCY;
+        static const long ID_PREVIEW_BULKEDIT_SHADOWMODELFOR;
         static const long ID_PREVIEW_BULKEDIT_CONTROLLERDIRECTION;
         static const long ID_PREVIEW_BULKEDIT_CONTROLLERSTARTNULLNODES;
         static const long ID_PREVIEW_BULKEDIT_CONTROLLERENDNULLNODES;
@@ -345,6 +346,7 @@ class LayoutPanel: public wxPanel
         void BulkEditPixelStyle();
         void BulkEditTransparency();
         void BulkEditBlackTranparency();   
+        void BulkEditShadowModelFor();
         void BulkEditControllerConnection(int type);
         void BulkEditControllerPreview();
         void BulkEditDimmingCurves();


### PR DESCRIPTION
We have had several users with many models incorrectly set as a shadow model for "something". This bulk edit is primarily meant to allow this to be fixed. However, it can be used to set. Helpers were observed not fixing this because it was time-consuming to fix.