### PR TITLE
Dont create media dir that is invalid in xsq #5087

### DIFF
--- a/xLights/SequencePackage.cpp
+++ b/xLights/SequencePackage.cpp
@@ -213,6 +213,7 @@ void SequencePackage::Extract()
                     if (ext == "xsq") {
                         _xsqFile = fnOutput;
                         _xsqName = fnOutput.GetName();
+                        _xsqName.erase(std::remove(_xsqName.begin(), _xsqName.end(), ','), _xsqName.end());
                     } else if (ext == "xml") {
                         if (fnOutput.GetName() == "xlights_rgbeffects") {
                             wxXmlDocument rgbEffects;
@@ -230,6 +231,7 @@ void SequencePackage::Extract()
                                 if (doc.GetRoot()->GetName() == "xsequence") {
                                     _xsqFile = fnOutput;
                                     _xsqName = fnOutput.GetName();
+                                    _xsqName.erase(std::remove(_xsqName.begin(), _xsqName.end(), ','), _xsqName.end());
                                 }
                             }
                         }


### PR DESCRIPTION
Since an Import, import media by default is based on sequence name it allows it to create a directory that contains commas. Commas in the path of shader, images etc will break in the xsq file. #5087 