### PR TITLE
#5226 - Flag Keep Channel Number for Wled/EsPixelStick

### DIFF
--- a/xLights/controllers/ControllerCaps.cpp
+++ b/xLights/controllers/ControllerCaps.cpp
@@ -290,7 +290,14 @@ ControllerCaps* ControllerCaps::GetControllerConfigByID(const std::string& ID) {
     }
     return nullptr;
 }
-
+ControllerCaps* ControllerCaps::GetControllerConfigByVendor(const std::string& vendor) {
+    LoadControllers();
+    auto v = __controllers.find(vendor);
+    if (v != __controllers.end()) {
+            return v->second.begin()->second.front();
+    }
+    return nullptr;
+}
 ControllerCaps* ControllerCaps::GetControllerConfigByModel( const std::string& model, const std::string& variant)
 {
     LoadControllers();

--- a/xLights/controllers/ControllerCaps.h
+++ b/xLights/controllers/ControllerCaps.h
@@ -54,6 +54,7 @@ public:
     static ControllerCaps* GetControllerConfig(const std::string& vendor, const std::string& model, const std::string& variant);
     static ControllerCaps* GetControllerConfig(const Controller* const controller);
     static ControllerCaps* GetControllerConfigByID(const std::string& ID);
+    static ControllerCaps* GetControllerConfigByVendor(const std::string& vendor);
     static ControllerCaps* GetControllerConfigByModel(const std::string& model, const std::string& variant);
     static ControllerCaps* GetControllerConfigByAlternateName(const std::string& vendor, const std::string& model, const std::string& variant);
 

--- a/xLights/controllers/ESPixelStick.cpp
+++ b/xLights/controllers/ESPixelStick.cpp
@@ -359,7 +359,7 @@ bool ESPixelStick::SetInputUniverses(Controller* controller, wxWindow* parent) {
                 DDPOutput* ddp = dynamic_cast<DDPOutput*>(outputs.front());
                 if (ddp) {
                     if (ddp->IsKeepChannelNumbers()) {
-                        DisplayError("The DDP 'Keep Channel Numbers' option is not support with ESPixelStick, Please Disable");
+                        DisplayError("The DDP 'Keep Channel Numbers' option is not supported with ESPixelStick. Please disable.");
                         return false;
                     }
                 }

--- a/xLights/outputs/Controller.cpp
+++ b/xLights/outputs/Controller.cpp
@@ -1092,6 +1092,21 @@ void Controller::ValidateProperties(OutputManager* om, wxPropertyGrid* propGrid)
             p->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
         }
     }
+
+    p = propGrid->GetPropertyByName("KeepChannelNumbers");
+    if (p != nullptr) {
+        ControllerCaps* c = nullptr;
+        if (!_model.empty()) {
+            c = ControllerCaps::GetControllerConfig(_vendor, _model, _variant);
+        } else {
+            c = ControllerCaps::GetControllerConfigByVendor(_vendor);
+        }
+        if (c && c->DDPStartsAtOne() && p->GetValue() == true) {
+            p->SetBackgroundColour(*wxRED);
+        } else {
+            p->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
+        }
+    }
 }
 
 void Controller::HandleExpanded(wxPropertyGridEvent& event, bool expanded)


### PR DESCRIPTION
If setting up a controller with DDPStartsAtOne setting, flag if Keep Channel Number is checked