### PR TITLE
Add Redo to Menu and Clear Effect after Redo/Undo #4246

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -757,11 +757,13 @@ void EffectsGrid::OnGridPopup(wxCommandEvent& event) {
     } else if (id == ID_GRID_MNU_UNDO) {
         logger_base.debug("OnGridPopup - UNDO");
         mSelectedEffect = nullptr; // lets clear it as the undo may delete that effect ... and i cant be sure
+        mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().UndoLastStep();
         sendRenderDirtyEvent();
     } else if (id == ID_GRID_MNU_REDO) {
         logger_base.debug("OnGridPopup - REDO");
         mSelectedEffect = nullptr; // lets clear it as the redo may delete that effect ... and i cant be sure
+        mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().RedoLastStep();
         sendRenderDirtyEvent();
     } else if (id == ID_GRID_MNU_ALIGN_START_TIMES) {

--- a/xLights/sequencer/MainSequencer.cpp
+++ b/xLights/sequencer/MainSequencer.cpp
@@ -1067,15 +1067,30 @@ void MainSequencer::OnChar(wxKeyEvent& event)
         case 'z':
         case 'Z':
         case WXK_CONTROL_Z:
-            if (event.CmdDown() || event.ControlDown()) {
-                if( mSequenceElements != nullptr &&
-                   mSequenceElements->get_undo_mgr().CanUndo() ) {
-                    mSequenceElements->get_undo_mgr().UndoLastStep();
-                    PanelEffectGrid->ClearSelection();
-                    PanelEffectGrid->Draw();
-                    PanelEffectGrid->sendRenderDirtyEvent();
+            if(!event.ShiftDown()) {
+                if ((event.CmdDown() || event.ControlDown())) {
+                    if( mSequenceElements != nullptr &&
+                        mSequenceElements->get_undo_mgr().CanUndo() ) {
+                        mSequenceElements->get_undo_mgr().UndoLastStep();
+                        mSequenceElements->UnSelectAllEffects();
+                        PanelEffectGrid->ClearSelection();
+                        PanelEffectGrid->Draw();
+                        PanelEffectGrid->sendRenderDirtyEvent();
+                    }
+                    event.StopPropagation();
                 }
-                event.StopPropagation();
+            } else {
+                if ((event.CmdDown() || event.ControlDown())) {
+                    if( mSequenceElements != nullptr &&
+                        mSequenceElements->get_undo_mgr().CanRedo() ) {
+                        mSequenceElements->get_undo_mgr().RedoLastStep();
+                        mSequenceElements->UnSelectAllEffects();
+                        PanelEffectGrid->ClearSelection();
+                        PanelEffectGrid->Draw();
+                        PanelEffectGrid->sendRenderDirtyEvent();
+                    }
+                    event.StopPropagation();
+                }
             }
             break;
         case 'y':
@@ -1085,6 +1100,7 @@ void MainSequencer::OnChar(wxKeyEvent& event)
                 if( mSequenceElements != nullptr &&
                    mSequenceElements->get_undo_mgr().CanRedo() ) {
                     mSequenceElements->get_undo_mgr().RedoLastStep();
+                    mSequenceElements->UnSelectAllEffects();
                     PanelEffectGrid->ClearSelection();
                     PanelEffectGrid->Draw();
                     PanelEffectGrid->sendRenderDirtyEvent();
@@ -1246,6 +1262,7 @@ void MainSequencer::DoUndo(wxCommandEvent& event) {
     if (PanelEffectGrid == nullptr) return;
 
     if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanUndo() ) {
+        mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().UndoLastStep();
         PanelEffectGrid->ClearSelection();
         PanelEffectGrid->Draw();
@@ -1257,6 +1274,7 @@ void MainSequencer::DoRedo(wxCommandEvent& event) {
     if (PanelEffectGrid == nullptr) return;
 
     if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanRedo() ) {
+        mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().RedoLastStep();
         PanelEffectGrid->ClearSelection();
         PanelEffectGrid->Draw();

--- a/xLights/wxsmith/xLightsframe.wxs
+++ b/xLights/wxsmith/xLightsframe.wxs
@@ -1172,6 +1172,11 @@
 					<accel>Ctrl-z</accel>
 					<bitmap code='GetMenuItemBitmapBundle(&quot;wxART_UNDO&quot;)' />
 				</object>
+				<object class="wxMenuItem" name="wxID_REDO" variable="MenuItem_REDO" member="yes">
+					<label>Redo</label>
+					<accel>Ctrl-y</accel>
+					<bitmap code='GetMenuItemBitmapBundle(&quot;wxART_REDO&quot;)' />
+				</object>
 				<object class="separator" />
 				<object class="wxMenuItem" name="wxID_CUT" variable="MenuItem34" member="yes">
 					<label>Cut</label>
@@ -1588,7 +1593,7 @@
 				</object>
 				<object class="wxMenuItem" name="ID_MNU_ZOOM" variable="MenuItem_Zoom" member="yes">
 					<label>Zoom Room Help</label>
-					<help>Access the free Zoom Room for Help.</help>
+					<help>Access the free Zoom Room for Help</help>
 					<handler function="OnMenuItem_ZoomSelected" entry="EVT_MENU" />
 				</object>
 				<object class="wxMenuItem" name="ID_MENUITEM1" variable="MenuItem_ShowKeyBindings" member="yes">

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -130,6 +130,7 @@
 #include "../include/control-play-blue-icon.xpm"
 
 #include <xlsxwriter.h>
+#include <CheckSequenceReport.h>
 
 #include "wxWEBPHandler/wx/imagwebp.h"
 
@@ -140,7 +141,6 @@
 #include <wx/image.h>
 #include <wx/intl.h>
 #include <wx/string.h>
-#include <CheckSequenceReport.h>
 //*)
 
 #define TOOLBAR_SAVE_VERSION "0003:"
@@ -957,6 +957,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     MenuItem37 = new wxMenuItem(Menu3, wxID_UNDO, _("Undo\tCtrl-z"), wxEmptyString, wxITEM_NORMAL);
     MenuItem37->SetBitmap(GetMenuItemBitmapBundle("wxART_UNDO"));
     Menu3->Append(MenuItem37);
+    MenuItem_REDO = new wxMenuItem(Menu3, wxID_REDO, _("Redo\tCtrl-y"), wxEmptyString, wxITEM_NORMAL);
+    MenuItem_REDO->SetBitmap(GetMenuItemBitmapBundle("wxART_REDO"));
+    Menu3->Append(MenuItem_REDO);
     Menu3->AppendSeparator();
     MenuItem34 = new wxMenuItem(Menu3, wxID_CUT, _("Cut\tCTRL-x"), wxEmptyString, wxITEM_NORMAL);
     MenuItem34->SetBitmap(GetMenuItemBitmapBundle("wxART_CUT"));

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1007,6 +1007,7 @@ public:
     wxMenuItem* MenuItem_PurgeRenderCache;
     wxMenuItem* MenuItem_PurgeVendorCache;
     wxMenuItem* MenuItem_QuietVol;
+    wxMenuItem* MenuItem_REDO;
     wxMenuItem* MenuItem_RemapCustom;
     wxMenuItem* MenuItem_SD_HP;
     wxMenuItem* MenuItem_SD_MP;


### PR DESCRIPTION
There is some confusion that undo is not undoing the property changes - it does but you need to be sure to reselect the effect. Prior to this change the effect still showed selected when it really isnt. Once you select the effect (again) it will show the "redo-ed" values. #4246 The existing code is setting it as unselected but the visuals were not updated. Also added ctrl-shift-X for a Redo to match many standards keys.