### PR TITLE
Highlight start node/strings in Wiring View #5385

### DIFF
--- a/xLights/models/CustomModel.h
+++ b/xLights/models/CustomModel.h
@@ -78,6 +78,7 @@ class CustomModel : public ModelWithScreenLocation<BoxedScreenLocation>
         static std::string ToCompressed(const std::vector<std::vector<std::vector<int>>>& model);
         static std::string ToCustomModel(const std::vector<std::vector<std::vector<int>>>& model);
         std::vector<std::vector<std::vector<int>>> GetData() const { return locations; }
+        int GetCustomNodeStringNumber(int node) const;
 
     protected:
         virtual void InitModel() override;
@@ -91,7 +92,6 @@ class CustomModel : public ModelWithScreenLocation<BoxedScreenLocation>
             return wxString::Format(wxT("String%i"), idx + 1).ToStdString();  // a space between "String" and "%i" breaks the start channels listed in Indiv Start Chans
         }
         std::string ComputeStringStartNode(int x) const;
-        int GetCustomNodeStringNumber(int node) const;
 
         int _depth = 1;
         std::string custom_background;


### PR DESCRIPTION
Use alternating colors similar to node layout along with highlight of start node on the wiring view. #5385 
For a custom model it still shows the node number at string 2, etc rather than restarting back at 1 since most folks want to match a printed wiring layout.
![image](https://github.com/user-attachments/assets/552973a5-29b6-40b2-8d48-8c2876d05464)
