### PR TITLE
Clarify FPP connect status #5457

### DIFF
--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -572,7 +572,11 @@ void FPPConnectDialog::PopulateFPPInstanceList(wxProgressDialog *prgs) {
                 doUploadCheckbox->SetValue(false);
                 doUploadCheckbox->Enable(false);
 
-                label = new wxStaticText(FPPInstanceList, wxID_ANY, "Unavailable/Unsupported", wxDefaultPosition, wxDefaultSize, 0, "ID_STATIC_TEXT_FS_" + rowStr);
+                if (!inst->fullVersion.empty()) {
+                    label = new wxStaticText(FPPInstanceList, wxID_ANY, "Unsupported", wxDefaultPosition, wxDefaultSize, 0, "ID_STATIC_TEXT_FS_" + rowStr);
+                }else {
+                    label = new wxStaticText(FPPInstanceList, wxID_ANY, "Unavailable", wxDefaultPosition, wxDefaultSize, 0, "ID_STATIC_TEXT_FS_" + rowStr);
+                }
                 FPPInstanceSizer->Add(label, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
             } else {
                 wxChoice *Choice1 = new wxChoice(FPPInstanceList, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, FSEQ_COL + rowStr);


### PR DESCRIPTION
Don't show "Unsupported" if an fpp instance is simply offline. #5457. Keeping the offline fpp controllers listed alerts the user that uploaded sequences may have missed being uploaded to an offline fpp controller.