### PR TITLE
Use the Restorable Width and Height for resize #5468

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5503,8 +5503,9 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
 
     Model* selectedModel = modelPreview->GetModels()[selectedindex];
     std::string selectedType = selectedModel->GetDisplayAs();
-    float width = selectedModel->GetWidth();
-    float height = selectedModel->GetHeight();
+    float width = selectedModel->GetRestorableMWidth();
+    float height = selectedModel->GetRestorableMHeight();
+    float depth = selectedModel->GetRestorableMDepth();
 
     bool isBoxed = false;
     if ((dynamic_cast<ModelWithScreenLocation<BoxedScreenLocation>*>(selectedModel) != nullptr)) {
@@ -5560,7 +5561,7 @@ void LayoutPanel::PreviewModelResize(bool sameWidth, bool sameHeight)
                 if (sameWidth) {
                     modelPreview->GetModels()[i]->SetWidth(width);
                     if (z_scale) {
-                        modelPreview->GetModels()[i]->GetBaseObjectScreenLocation().SetMDepth(width);
+                        modelPreview->GetModels()[i]->GetBaseObjectScreenLocation().SetMDepth(depth);
                     }
                 }
 

--- a/xLights/models/BaseObject.cpp
+++ b/xLights/models/BaseObject.cpp
@@ -337,6 +337,18 @@ float BaseObject::GetDepth() const {
     return GetBaseObjectScreenLocation().GetMDepth();
 }
 
+float BaseObject::GetRestorableMWidth() const {
+    return GetBaseObjectScreenLocation().GetRestorableMWidth();
+}
+
+float BaseObject::GetRestorableMHeight() const {
+    return GetBaseObjectScreenLocation().GetRestorableMHeight();
+}
+
+float BaseObject::GetRestorableMDepth() const {
+    return GetBaseObjectScreenLocation().GetRestorableMDepth();
+}
+
 float BaseObject::GetHcenterPos() {
     return GetBaseObjectScreenLocation().GetHcenterPos();
 }

--- a/xLights/models/BaseObject.h
+++ b/xLights/models/BaseObject.h
@@ -89,6 +89,9 @@ public:
     float GetWidth() const;
     float GetHeight() const;
     float GetDepth() const;
+    float GetRestorableMWidth() const;
+    float GetRestorableMHeight() const;
+    float GetRestorableMDepth() const;
 
     const std::string &Name() const { return name;}
     const std::string &GetName() const { return name;}


### PR DESCRIPTION
Expose the restorable  values as they are the correct values to use in the resize operation. 
Also add the proper depth value rather then cheat with the width value. 
This code path is used for custom models - tested with lines, stars and polys just to verify. #5468