### PR TITLE
LUA Script to time batch rendered sequences

### DIFF
--- a/scripts/BatchRenderSequence.lua
+++ b/scripts/BatchRenderSequence.lua
@@ -1,0 +1,28 @@
+-- Script to open, render and close the selected sequences. 
+
+seqs = PromptSequences()
+local start_time = os.clock() -- Start timing
+for i,seq in ipairs(seqs) do 
+    properties = {}
+    properties['seq'] = seq
+    properties['promptIssues'] = 'false'
+    properties['force'] = 'true'
+    result = RunCommand('openSequence', properties)
+    Log('Render ' .. result['seq']) 
+
+    local start_time_seq = os.clock() -- Start timing
+    properties = {}
+    properties['highdef'] = 'false'
+    result = RunCommand('renderAll', properties)
+    Log('Message: ' .. result['msg'])
+    local end_time = os.clock() -- End timing	
+    Log(string.format("Render Elapsed time: %.4f seconds for %s", end_time - start_time_seq, seq))
+
+    properties = {}
+    properties['quiet'] = 'true'
+    properties['force'] = 'true'
+    result = RunCommand('closeSequence', properties)
+    Log(result['msg'])
+end
+local end_time = os.clock() -- End timing	
+Log(string.format("Render Elapsed time: %.4f seconds", end_time - start_time))

--- a/xLights/automation/xLightsAutomations.cpp
+++ b/xLights/automation/xLightsAutomations.cpp
@@ -158,9 +158,12 @@ bool xLightsFrame::ProcessAutomation(std::vector<std::string> &paths,
                 return sendResponse("Sequence already open.", "msg", 503, false);
             }
             auto oldPrompt = _promptBatchRenderIssues;
+            auto oldRenderMode = _renderMode;
+            if (!prompt) _renderMode = true;
             _promptBatchRenderIssues = prompt; // off by default
             OpenSequence(seq, nullptr);
             _promptBatchRenderIssues = oldPrompt;
+            _renderMode = oldRenderMode;
             std::string response = wxString::Format("{\"seq\":\"%s\",\"fullseq\":\"%s\",\"media\":\"%s\",\"len\":%u,\"framems\":%u}",
                                                     JSONSafe(CurrentSeqXmlFile->GetName()),
                                                     JSONSafe(CurrentSeqXmlFile->GetFullPath()),


### PR DESCRIPTION
Also a small change to honor the promptIssues flag. This is a script I use to batch render multiple sequences and then I can compare the render times and total elapsed time.