### PR TITLE
Add SM16825 RGBCW LED support for WLED controllers

### DIFF
--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -21,6 +21,7 @@
             <Protocol>tm1829</Protocol>
             <Protocol>ucs8903</Protocol>
             <Protocol>ucs8904</Protocol>
+            <Protocol>sm16825</Protocol>
             <Protocol>ws2801</Protocol>
             <Protocol>apa102</Protocol>
             <Protocol>lpd8806</Protocol>

--- a/xLights/controllers/WLED.cpp
+++ b/xLights/controllers/WLED.cpp
@@ -367,6 +367,7 @@ int WLED::EncodeStringPortProtocol(const std::string& protocol) const {
     if (p == "sk6812rgbw") return 30;
     if (p == "apa109") return 30;//same
     if (p == "tm1814") return 31;
+    if (p == "sm16825") return 34;
 
     //4-wire
     if (p == "ws2801") return 50;


### PR DESCRIPTION
## Summary
Adds support for SM16825 RGBCW (5-channel) LEDs to WLED controller configurations in xLights.

## Changes
- Added `sm16825` protocol to the list of supported pixel protocols in `wled.xcontroller`
- Added protocol encoding mapping (sm16825 → type 34) in `WLED.cpp` `EncodeStringPortProtocol` function

## Motivation
The SM16825 chip is becoming increasingly common in LED products (such as Govee Outdoor Permanent Lights Pro H706A). This change enables xLights to properly configure WLED controllers to use SM16825 LEDs.

## Technical Details
- **Protocol type**: 34 (TYPE_SM16825 in WLED firmware)
- **Characteristics**: RGBCW (RGB + Warm White + Cold White), 16-bit
- **Compatible with**: WLED firmware 0.15.0-b5 and later

## Test Plan
- [x] Verify sm16825 appears in LED protocol dropdown for WLED controllers
- [ ] Verify xLights correctly configures WLED controller with sm16825 protocol
- [ ] Verify WLED controller properly controls SM16825 LEDs after upload