### PR TITLE
Import Dialog - drag n drop error #5626

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -2219,7 +2219,7 @@ void xLightsImportChannelMapDialog::OnBeginDrag(wxDataViewEvent& event)
     if (event.GetItem().IsOk()) {
         _dragItem = event.GetItem();
         wxVariant vvalue;
-        event.GetModel()->GetValue(vvalue, event.GetItem(), 1);
+        event.GetModel()->GetValue(vvalue, event.GetItem(), 2);
         std::string mapped = vvalue.GetString().ToStdString();
 
         if (mapped != "") {


### PR DESCRIPTION
When you drag n drop an item in the import dialog, it would paste the wrong value into the model field. #5626 