### PR TITLE
Fix accidental effect/timing shift on click

### DIFF
--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -337,6 +337,7 @@ private:
     int mStartResizeTimeMS;
     bool mResizing;
     bool mDragging;
+    bool mDragThresholdExceeded;
     int mDragStartRow;
     int mDragStartX;
     int mDragStartY;


### PR DESCRIPTION
When clicking on effects or timing marks in the sequencer, even tiny mouse movements (1-2 pixels) would trigger the drag/resize logic, causing unwanted shifts in effect timing. Added a 3-pixel drag threshold that distinguishes between intentional drags and simple clicks, preventing accidental timing changes while keeping edge resizing responsive.

Before:

https://github.com/user-attachments/assets/54941d20-6834-4c62-9f92-6f9fd1e61118

After:

https://github.com/user-attachments/assets/2fb5352e-f157-45da-b560-070940f1f88a

