### PR TITLE
Add keyboard shortcuts for dividing timing marks

### DIFF
--- a/xLights/KeyBindings.cpp
+++ b/xLights/KeyBindings.cpp
@@ -26,6 +26,13 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
 {
     { "TIMING_ADD", KBSCOPE::Sequence },
     { "TIMING_SPLIT", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_2", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_3", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_4", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_6", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_8", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_12", KBSCOPE::Sequence },
+    { "TIMING_DIVIDE_16", KBSCOPE::Sequence },
     { "ZOOM_IN", KBSCOPE::Sequence },
     { "ZOOM_OUT", KBSCOPE::Sequence },
     { "ZOOM_SEL", KBSCOPE::Sequence },

--- a/xLights/sequencer/MainSequencer.cpp
+++ b/xLights/sequencer/MainSequencer.cpp
@@ -548,6 +548,27 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
             }
             else if (type == "TIMING_SPLIT") {
                 SplitTimingMark();
+            }
+            else if (type == "TIMING_DIVIDE_2") {
+                DivideTimingTrack(2);
+            }
+            else if (type == "TIMING_DIVIDE_3") {
+                DivideTimingTrack(3);
+            }
+            else if (type == "TIMING_DIVIDE_4") {
+                DivideTimingTrack(4);
+            }
+            else if (type == "TIMING_DIVIDE_6") {
+                DivideTimingTrack(6);
+            }
+            else if (type == "TIMING_DIVIDE_8") {
+                DivideTimingTrack(8);
+            }
+            else if (type == "TIMING_DIVIDE_12") {
+                DivideTimingTrack(12);
+            }
+            else if (type == "TIMING_DIVIDE_16") {
+                DivideTimingTrack(16);
             } else if (type == "EFFECTS_TO_TIMING") {
                 PanelEffectGrid->CreateTimingFromSelectedEffects();
             } else if (type == "SELECT_TIMING_1") {
@@ -1854,6 +1875,66 @@ void MainSequencer::SplitTimingMark()
                 DisplayError("Timing placement error: Timing cannot be split across timing marks.");
             }
         }
+    }
+}
+
+void MainSequencer::DivideTimingTrack(int divisor)
+{
+    log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    int selectedTiming = mSequenceElements->GetSelectedTimingRow();
+    if (selectedTiming >= 0)
+    {
+        Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
+        EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
+
+        if (el == nullptr)
+        {
+            logger_base.crit("MainSequencer::DivideTimingTrack el is nullptr ... this is going to crash.");
+            return;
+        }
+
+        if (el->IsFixedTimingLayer())
+        {
+            logger_base.warn("MainSequencer::DivideTimingTrack Cannot divide fixed timing layer.");
+            return;
+        }
+
+        mSequenceElements->get_undo_mgr().CreateUndoStep();
+        auto frequency = PanelTimeLine->GetTimeFrequency();
+        int base_timing = 1000.0 / frequency;
+
+        for (int i = 0; i < el->GetEffectCount(); i++) {
+            auto ef = el->GetEffect(i);
+            if (ef->GetSelected()) {
+                long s = ef->GetStartTimeMS();
+                long e_time = ef->GetEndTimeMS();
+                if (e_time - s > base_timing) {
+                    float splitf = (float)(e_time - s) / (float)divisor;
+                    mSequenceElements->get_undo_mgr().CaptureModifiedEffect(el->GetParentElement()->GetModelName(), el->GetIndex(), ef->GetID(), ef->GetSettingsAsString(), ef->GetPaletteAsString());
+                    mSequenceElements->get_undo_mgr().CaptureEffectToBeMoved(el->GetParentElement()->GetModelName(), el->GetIndex(), ef->GetID(), ef->GetStartTimeMS(), ef->GetEndTimeMS());
+                    long newend = TimeLine::RoundToMultipleOfPeriod((float)s + splitf, frequency);
+                    ef->SetEndTimeMS(newend);
+
+                    for (int j = 1; j < divisor; j++) {
+                        long newstart = newend;
+                        if (j == divisor - 1) {
+                            newend = e_time;
+                        } else {
+                            newend = TimeLine::RoundToMultipleOfPeriod((long)((float)s + splitf * (float)(j + 1)), frequency);
+                        }
+
+                        if (newstart != newend) {
+                            Effect* newef = el->AddEffect(0, "", "", "", newstart, newend, EFFECT_SELECTED, false);
+                            mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetName(), el->GetIndex(), newef->GetID());
+                            ++i; // jump over the one we just inserted
+                        }
+                    }
+                    ef->SetSelected(EFFECT_SELECTED);
+                }
+            }
+        }
+        PanelEffectGrid->ForceRefresh();
     }
 }
 

--- a/xLights/sequencer/MainSequencer.h
+++ b/xLights/sequencer/MainSequencer.h
@@ -144,6 +144,7 @@ class MainSequencer: public wxPanel
         void TimeLineSelectionChanged(wxCommandEvent& event);
         void InsertTimingMarkFromRange();
         void SplitTimingMark();
+        void DivideTimingTrack(int divisor);
         void SetHandlers(wxWindow *);
 
         void ScrollRight( wxCommandEvent& event);


### PR DESCRIPTION
Adds keyboard shortcuts to divide selected timing marks into equal parts (2, 3, 4, 6, 8, 12, or 16 divisions).

Users working with timing tracks often need to divide timing marks into smaller intervals. The existing feature requires right-clicking and using a dialog, which slows down the workflow. This adds 7 new keyboard shortcuts (unassigned by default) that allow instant division without dialog boxes.

This is particularly useful when mapped to external devices like Stream Deck - users can create timing tracks extremely quickly by placing rough timing marks and then rapidly subdividing them with physical buttons. Anyone working with singing faces, music timing, or choreography would benefit from this workflow improvement.

New keyboard shortcuts (unassigned by default):
- TIMING_DIVIDE_2 through TIMING_DIVIDE_16

Usage: Select timing marks, press assigned shortcut, marks are divided instantly. Supports undo/redo.

Example Video:
https://github.com/user-attachments/assets/178d5ab6-009d-4a66-9d8d-8e9c2ba13f1f

Stream Deck mapped to timing division shortcuts:
![IMG_4155](https://github.com/user-attachments/assets/5d47bdb6-3015-4709-a52c-c2971e024825)
