### PR TITLE
Fix incomplete git submodule commands in build documentation

### DIFF
--- a/README.osx
+++ b/README.osx
@@ -4,9 +4,13 @@ To build/debug xLights on macOS, you need to checkout the macOS updates, scripts
 
 The easiest way to do that is to run:
 git submodule update --init macOS
+git submodule update --init --recursive
 
-That will checkout the code as a submodule.  There will be a README.macOS file in the macOS directory
-that explains how to build the various 3rd party dependencies that xLights needs.
+The first command checks out the macOS build system as a submodule.
+The second command recursively initializes all dependencies (like nanosvg, etc.).
+
+There will be a README.macOS file in the macOS directory that explains how to build 
+the various 3rd party dependencies that xLights needs.
 
 Once the dependencies are built, open up the xcodeproject file in Xcode and you should be able to
 build and run xLights.

--- a/README.windows
+++ b/README.windows
@@ -67,7 +67,8 @@ Here are the steps to compile xLights for Windows using the Visual Studio compil
                 b) Edit <basedir>\xLights\.git\config  and remove the section <[submodule "dependencies/log4cpp-codegit"]> and its indented lines
                 c) Run the command: git rm --cached dependencies/log4cpp-codegit
                 d) Run the command: git submodule update --init
-                e) Be sure not to submit these files in any PRs.
+                e) Run the command: git submodule update --init --recursive
+                f) Be sure not to submit these files in any PRs.
    
        3) Open the xLights project <basedir>\xLights\xLights\xLights.sln and build the project in x64 Debug mode
 


### PR DESCRIPTION
The build documentation was missing the --recursive flag for git submodule initialization, causing developers to miss nested dependencies.   Added 'git submodule update --init --recursive' command

Changes:
- README.osx: Added recursive submodule initialization step
- README.windows: Added recursive submodule initialization step