### PR TITLE
Fix #5721: Face with node range generates file not found error

### DIFF
--- a/xLights/ModelFaceDialog.cpp
+++ b/xLights/ModelFaceDialog.cpp
@@ -428,11 +428,15 @@ void ModelFaceDialog::SetFaceInfo(Model *cls, std::map< std::string, std::map<st
             }
         }
 
-		for (std::map<std::string, std::string>::iterator it2 = info.begin(); it2 != info.end(); ++it2)
-		{
-			if (it2->first.substr(0, 5) == "Mouth" || it2->first.substr(0, 4) == "Eyes")
+		// Only call FixFile for Matrix faces - NodeRange and SingleNode faces
+		// store node numbers, not file paths
+		if (info["Type"] == "Matrix") {
+			for (std::map<std::string, std::string>::iterator it2 = info.begin(); it2 != info.end(); ++it2)
 			{
-				it2->second = FixFile("", it2->second);
+				if (it2->first.substr(0, 5) == "Mouth" || it2->first.substr(0, 4) == "Eyes")
+				{
+					it2->second = FixFile("", it2->second);
+				}
 			}
 		}
 


### PR DESCRIPTION
## What

Stop spurious "File not found" log errors when loading NodeRange or SingleNode face definitions.

## Why

NodeRange faces store node numbers like `203-205,208-210` in their Mouth/Eyes fields. The code was calling `FixFile()` on these values, which then tried to find a file named "203-205,208-210" and logged errors when it couldn't.

Fixes #5721

## How

Only call `FixFile()` for Matrix type faces, which actually use image file paths. NodeRange and SingleNode faces just store node numbers.

## Testing

- [x] Logic matches the face type handling elsewhere in the file
- [x] Matrix faces still get `FixFile()` for their image paths