### PR TITLE
Fix #5656: Keyboard shortcut effects now use default settings

### DIFF
--- a/xLights/sequencer/MainSequencer.cpp
+++ b/xLights/sequencer/MainSequencer.cpp
@@ -611,7 +611,15 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                         mSequenceElements->GetXLightsFrame()->ResetPanelDefaultSettings(binding->GetEffectName(), nullptr, true);
                     }
 
-                    Effect* ef = PanelEffectGrid->Paste(binding->GetEffectName() + "\t" + binding->GetEffectString() + _("\t\n"), binding->GetEffectDataVersion());
+                    // If the binding has no effect string, get the default settings from the panel
+                    // This ensures effects added via keyboard shortcut get proper defaults (like Scale to Buffer)
+                    std::string effectSettings = binding->GetEffectString();
+                    if (effectSettings.empty()) {
+                        std::string palette;
+                        effectSettings = mSequenceElements->GetXLightsFrame()->GetEffectTextFromWindows(palette);
+                    }
+
+                    Effect* ef = PanelEffectGrid->Paste(binding->GetEffectName() + "\t" + effectSettings + _("\t\n"), binding->GetEffectDataVersion());
                     if (ef != nullptr) {
                         SelectEffect(ef);
                     }


### PR DESCRIPTION
## Summary
- When adding effects via keyboard shortcut (not preset), if the binding has no stored effect string, the code now retrieves default settings from the effect panel
- This ensures effects like Shockwave get their proper defaults (e.g., "Scale to Buffer" = true) rather than empty settings
- The fix mirrors the behavior of drag-drop effect creation which already uses `GetEffectTextFromWindows()` to get panel defaults

## Root Cause
The keyboard shortcut handler was using `binding->GetEffectString()` directly, which is empty for simple effect bindings. Meanwhile, the drag-drop path in `EffectDroppedOnGrid` calls `GetEffectTextFromWindows()` to retrieve current panel defaults after calling `ResetPanelDefaultSettings()`.

## Test Plan
- [x] Build and run xLights
- [x] Create a keyboard shortcut for Shockwave effect (Settings → Key Bindings)
- [x] Add a Shockwave effect using the keyboard shortcut
- [x] Verify "Scale to Buffer" checkbox is checked in effect Options tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)