### PR TITLE
Fix #5707: Improve group text contrast in Import Effects dark mode

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -189,7 +189,7 @@ bool xLightsImportTreeModel::GetAttr(const wxDataViewItem &item, unsigned int co
     }
 
     if (node->IsGroup()) {
-        attr.SetColour(ColorManager::instance()->CyanOrBlueOverride());
+        attr.SetColour(CyanOrBlue());
         set = true;
     }
 
@@ -1151,7 +1151,7 @@ void xLightsImportChannelMapDialog::PopulateAvailable(bool ccr)
 
             // If importing from xsqPkg flag known groups by color like is currently done in mapped list
             if (m->type == "ModelGroup") {
-                ListCtrl_Available->SetItemTextColour(j, ColorManager::instance()->CyanOrBlueOverride());
+                ListCtrl_Available->SetItemTextColour(j, CyanOrBlue());
             }
             j++;
         }
@@ -2562,7 +2562,7 @@ void xLightsImportChannelMapDialog::MarkUsed()
             // not used
             ImportChannel* im = GetImportChannel(ListCtrl_Available->GetItemText(i).ToStdString());
             if (im != nullptr && im->type == "ModelGroup") {
-                ListCtrl_Available->SetItemTextColour(i, ColorManager::instance()->CyanOrBlueOverride());
+                ListCtrl_Available->SetItemTextColour(i, CyanOrBlue());
             } else {
                 ListCtrl_Available->SetItemTextColour(i, wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
             }


### PR DESCRIPTION
## Summary
- Groups in the Import Effects dialog were displayed in dark blue text on a dark background in macOS dark mode
- Changed from `CyanOrBlueOverride()` to `CyanOrBlue()` which directly checks dark mode and returns cyan for better contrast

## Root Cause
`CyanOrBlueOverride()` checks if `COLOR_TEXT_HIGHLIGHTED` is set to black before falling back to `CyanOrBlue()`. This additional logic could result in a less visible color. Using `CyanOrBlue()` directly ensures proper dark mode handling.

## Test Plan
- [x] Build and run xLights on macOS in dark mode
- [x] Open File → Import → Import Effects
- [x] Select a sequence file with model groups
- [x] Verify groups now display in cyan (readable) instead of dark blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)