### PR TITLE
Fix #5442: Improve red text readability in dark mode

### DIFF
--- a/xLights/SaveChangesDialog.cpp
+++ b/xLights/SaveChangesDialog.cpp
@@ -9,6 +9,7 @@
  **************************************************************/
 
 #include "SaveChangesDialog.h"
+#include "UtilFunctions.h"
 
 //(*InternalHeaders(SaveChangesDialog)
 #include <wx/font.h>
@@ -41,7 +42,7 @@ SaveChangesDialog::SaveChangesDialog(wxWindow* parent)
 	FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
 	FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
 	StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _("*** The sequence you are closing has unsaved changes. ***"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
-	StaticText2->SetForegroundColour(wxColour(255,0,0));
+	StaticText2->SetForegroundColour(RedOrLightRed());
 	wxFont StaticText2Font(12,wxFONTFAMILY_SWISS,wxFONTSTYLE_NORMAL,wxFONTWEIGHT_NORMAL,false,_T("Arial"),wxFONTENCODING_DEFAULT);
 	StaticText2->SetFont(StaticText2Font);
 	FlexGridSizer2->Add(StaticText2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);

--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -405,7 +405,7 @@ SeqSettingsDialog::SeqSettingsDialog(wxWindow* parent, xLightsXmlFile* file_to_h
     FlexGridSizer1->Add(Notebook_Seq_Settings, 1, wxTOP|wxLEFT|wxRIGHT|wxEXPAND, 5);
     StaticText_Warning = new wxStaticText(this, ID_STATICTEXT_Warning, _("Show Warning Here"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Warning"));
     StaticText_Warning->Hide();
-    StaticText_Warning->SetForegroundColour(wxColour(255,0,0));
+    StaticText_Warning->SetForegroundColour(RedOrLightRed());
     wxFont StaticText_WarningFont(wxDEFAULT,wxFONTFAMILY_DEFAULT,wxFONTSTYLE_NORMAL,wxFONTWEIGHT_BOLD,false,wxEmptyString,wxFONTENCODING_DEFAULT);
     StaticText_Warning->SetFont(StaticText_WarningFont);
     FlexGridSizer1->Add(StaticText_Warning, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -417,7 +417,7 @@ SeqSettingsDialog::SeqSettingsDialog(wxWindow* parent, xLightsXmlFile* file_to_h
     FlexGridSizer1->Add(StaticText_Info, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     StaticText_Warn_No_Media = new wxStaticText(this, ID_STATICTEXT_Warn_No_Media, _("Media File must be selected or change to animation!"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Warn_No_Media"));
     StaticText_Warn_No_Media->Hide();
-    StaticText_Warn_No_Media->SetForegroundColour(wxColour(255,0,0));
+    StaticText_Warn_No_Media->SetForegroundColour(RedOrLightRed());
     wxFont StaticText_Warn_No_MediaFont(20,wxFONTFAMILY_DEFAULT,wxFONTSTYLE_NORMAL,wxFONTWEIGHT_BOLD,false,wxEmptyString,wxFONTENCODING_DEFAULT);
     StaticText_Warn_No_Media->SetFont(StaticText_Warn_No_MediaFont);
     FlexGridSizer1->Add(StaticText_Warn_No_Media, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);

--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -284,10 +284,10 @@ wxImage ApplyOrientation(const wxImage& img, int orient) {
     case 2: return res.Mirror(true);  // horizontal flip
     case 3: return res.Rotate180();
     case 4: return res.Mirror(false); // vertical flip
-    case 5: return res.Mirror(true).Rotate90(false); // horizontal flip + 90° CCW
-    case 6: return res.Rotate90(true);  // 90° CW
-    case 7: return res.Mirror(true).Rotate90(true);  // horizontal flip + 90° CW
-    case 8: return res.Rotate90(false); // 90° CCW
+    case 5: return res.Mirror(true).Rotate90(false); // horizontal flip + 90ï¿½ CCW
+    case 6: return res.Rotate90(true);  // 90ï¿½ CW
+    case 7: return res.Mirror(true).Rotate90(true);  // horizontal flip + 90ï¿½ CW
+    case 8: return res.Rotate90(false); // 90ï¿½ CCW
     default: return res;
     }
 }
@@ -1446,6 +1446,15 @@ wxColor LightOrMediumGrey() {
         return medGray;
     } else {
         return *wxLIGHT_GREY;
+    }
+}
+wxColor RedOrLightRed() {
+    if (IsDarkMode()) {
+        // In Dark Mode pure red is hard to read on grey, use a lighter salmon/coral red
+        static const wxColor lightRed(0xFF, 0x6B, 0x6B);
+        return lightRed;
+    } else {
+        return *wxRED;
     }
 }
 void CleanupIpAddress(wxString& IpAddr) {

--- a/xLights/UtilFunctions.h
+++ b/xLights/UtilFunctions.h
@@ -185,6 +185,7 @@ void DumpBinary(uint8_t* buffer, size_t read);
 wxColor CyanOrBlue();
 wxColor LightOrMediumGrey();
 wxColor BlueOrLightBlue();
+wxColor RedOrLightRed();
 bool IsFloat(const std::string& number);
 bool IsDarkMode();
 void SetSuppressDarkMode(bool suppress);


### PR DESCRIPTION
## Summary

Red warning text on grey backgrounds is difficult to read in macOS dark mode. This adds a `RedOrLightRed()` helper function (following the existing pattern of `CyanOrBlue()`, `BlueOrLightBlue()`, etc.) that returns a lighter salmon/coral red in dark mode for better contrast.

Fixes #5442

## Changes

- Added `RedOrLightRed()` to UtilFunctions.h/cpp
  - Returns `wxRED` (255, 0, 0) in light mode  
  - Returns lighter red (255, 107, 107) in dark mode
- Applied to SaveChangesDialog "unsaved changes" warning
- Applied to SeqSettingsDialog warning text

## Testing

- [x] Built and verified on macOS
- [x] Light mode: displays standard red
- [x] Dark mode: displays lighter, more readable red

## Screenshots

The fix addresses the exact dialog shown in the issue - the "unsaved changes" warning when closing a sequence.