### PR TITLE
Fix #5323: Meteor effect speed=1 now works at high frame rates

### DIFF
--- a/xLights/effects/MeteorsEffect.cpp
+++ b/xLights/effects/MeteorsEffect.cpp
@@ -197,7 +197,7 @@ void MeteorsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
         buffer.needToInit = false;
         cache->meteors.clear();
         cache->meteorsRadial.clear();
-        cache->effectState = mSpeed * buffer.frameTimeInMs / 50;
+        cache->effectState = std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     }
 
     switch (MeteorsEffect) {
@@ -302,7 +302,7 @@ void MeteorsEffect::RenderMeteorsHorizontal(RenderBuffer& buffer, int ColorSchem
 
     if (buffer.curPeriod == buffer.curEffStartPer) {
         for (int i = 0; i < warmupFrames; ++i) {
-            cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+            cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
             int mspeed = cache->effectState / 4;
             cache->effectState -= mspeed * 4;
 
@@ -312,7 +312,7 @@ void MeteorsEffect::RenderMeteorsHorizontal(RenderBuffer& buffer, int ColorSchem
         }
     }
 
-    cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+    cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     int speed = cache->effectState / 4;
     cache->effectState -= speed * 4;
 
@@ -445,7 +445,7 @@ void MeteorsEffect::RenderMeteorsVertical(RenderBuffer& buffer, int ColorScheme,
 
     if (buffer.curPeriod == buffer.curEffStartPer) {
         for (int i = 0; i < warmupFrames; ++i) {
-            cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+            cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
             int mspeed = cache->effectState / 4;
             cache->effectState -= mspeed * 4;
 
@@ -455,7 +455,7 @@ void MeteorsEffect::RenderMeteorsVertical(RenderBuffer& buffer, int ColorScheme,
         }
     }
 
-    cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+    cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     int speed = cache->effectState / 4;
     cache->effectState -= speed * 4;
 
@@ -583,7 +583,7 @@ void MeteorsEffect::RenderIcicleDrip(RenderBuffer& buffer, int ColorScheme, int 
 
     if (buffer.curPeriod == buffer.curEffStartPer) {
         for (int i = 0; i < warmupFrames; ++i) {
-            cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+            cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
             int mspeed = cache->effectState / 4;
             cache->effectState -= mspeed * 4;
 
@@ -593,7 +593,7 @@ void MeteorsEffect::RenderIcicleDrip(RenderBuffer& buffer, int ColorScheme, int 
         }
     }
 
-    cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+    cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     int speed = cache->effectState / 4;
     cache->effectState -= speed * 4;
 
@@ -783,7 +783,7 @@ void MeteorsEffect::RenderMeteorsImplode(RenderBuffer& buffer, int ColorScheme, 
 
     if (buffer.curPeriod == buffer.curEffStartPer) {
         for (int i = 0; i < warmupFrames; ++i) {
-            cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+            cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
             int mspeed = cache->effectState / 4;
             cache->effectState -= mspeed * 4;
 
@@ -793,7 +793,7 @@ void MeteorsEffect::RenderMeteorsImplode(RenderBuffer& buffer, int ColorScheme, 
         }
     }
 
-    cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+    cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     int speed = cache->effectState / 4;
     cache->effectState -= speed * 4;
 
@@ -978,7 +978,7 @@ void MeteorsEffect::RenderMeteorsExplode(RenderBuffer& buffer, int ColorScheme, 
 
     if (buffer.curPeriod == buffer.curEffStartPer) {
         for (int i = 0; i < warmupFrames; ++i) {
-            cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+            cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
             int mspeed = cache->effectState / 4;
             cache->effectState -= mspeed * 4;
 
@@ -988,7 +988,7 @@ void MeteorsEffect::RenderMeteorsExplode(RenderBuffer& buffer, int ColorScheme, 
         }
     }
 
-    cache->effectState += mSpeed * buffer.frameTimeInMs / 50;
+    cache->effectState += std::max(mSpeed * buffer.frameTimeInMs / 50, 1);
     int speed = cache->effectState / 4;
     cache->effectState -= speed * 4;
 


### PR DESCRIPTION
## Summary

The Meteor effect with speed=1 would freeze at frame rates above 20fps (e.g., 40fps, 100fps) because the speed calculation resulted in 0 due to integer division.

Fixes #5323

## Root Cause

The speed calculation `mSpeed * buffer.frameTimeInMs / 50` uses integer math:
- At 20fps (50ms): `1 * 50 / 50 = 1` ✓
- At 40fps (25ms): `1 * 25 / 50 = 0` ✗
- At 100fps (10ms): `1 * 10 / 50 = 0` ✗

When the result is 0, `effectState` never increments and meteors don't move.

## Changes

Applied `std::max(..., 1)` to ensure the speed increment is at least 1, allowing the effect to work at any frame rate.

## Testing

- [x] Built and verified on macOS
- [x] Meteor effect with speed=1 now animates at 40fps and higher frame rates