### PR TITLE
Fix #4347: Twinkle effect value curve for Steps now matches slider max

### DIFF
--- a/xLights/effects/TwinkleEffect.h
+++ b/xLights/effects/TwinkleEffect.h
@@ -16,7 +16,7 @@
 #define TWINKLE_COUNT_MAX 100
 
 #define TWINKLE_STEPS_MIN 2
-#define TWINKLE_STEPS_MAX 100
+#define TWINKLE_STEPS_MAX 400
 
 class TwinkleEffect : public RenderableEffect
 {


### PR DESCRIPTION
## Summary
- Fixed the value curve for Twinkle Steps to allow values up to 400, matching the slider maximum

## Problem
The slider for "Twinkle Steps" allows values from 2 to 400, but the value curve was limited to 100 via `TWINKLE_STEPS_MAX`. This meant users couldn't ramp up to the full range when using value curves.

## Solution
Changed `TWINKLE_STEPS_MAX` from 100 to 400 to match the slider maximum.

## Test plan
- [ ] Open Twinkle effect
- [ ] Click on the value curve button for "Twinkle Steps"
- [ ] Verify the curve editor now allows values up to 400
- [ ] Apply a curve that ramps from low to 400
- [ ] Verify the effect renders correctly across the full range

Provided by llamassist.ai