### PR TITLE
Add AI Image Generation

### DIFF
--- a/prompts/AI_Generate_Image.txt
+++ b/prompts/AI_Generate_Image.txt
@@ -1,0 +1,5 @@
+MANDATORY OUTPUT REQUIREMENTS: Background: Pure Black background (#000000) with no watermarks or border. 
+Design: 2D Vector Style, Colors aligned to the character design. 
+The design features bold, clean outlines, simple cel-shading, and a limited vibrant color palette with clean edges and no gradients. 
+Ensure the lines are perfectly horizontal and vertical with no diagonal smoothing.
+A minimalist, flat 2D pixel art illustration using a 16-bit kawaii style. 

--- a/xLights/UtilFunctions.h
+++ b/xLights/UtilFunctions.h
@@ -83,6 +83,8 @@ void ReverseNodes(std::map<std::string, std::string> & nodes, int max);
 wxImage ApplyOrientation(const wxImage& img, int orient);
 int GetExifOrientation(const wxString& filename);
 
+std::string GetAIPrompt(const std::string& promptType, const std::string& showDir);
+
 std::string GetResourcesDirectory();
 
 inline long roundTo4(long i) {

--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -500,7 +500,9 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClCompile Include="AboutDialog.cpp" />
     <ClCompile Include="ai\AIColorPaletteDialog.cpp" />
     <ClCompile Include="ai\aiBase.cpp" />
+    <ClCompile Include="ai\AIImageDialog.cpp" />
     <ClCompile Include="ai\chatGPT.cpp" />
+    <ClCompile Include="ai\gemini.cpp" />
     <ClCompile Include="ai\ollama.cpp" />
     <ClCompile Include="ai\ServiceManager.cpp" />
     <ClCompile Include="AlignmentDialog.cpp" />
@@ -1024,8 +1026,10 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClInclude Include="AboutDialog.h" />
     <ClCompile Include="ai\AIColorPaletteDialog.h" />
     <ClInclude Include="ai\aiBase.h" />
+    <ClInclude Include="ai\AIImageDialog.h" />
     <ClInclude Include="ai\aiType.h" />
     <ClInclude Include="ai\chatGPT.h" />
+    <ClInclude Include="ai\gemini.h" />
     <ClInclude Include="ai\ollama.h" />
     <ClInclude Include="ai\ServiceManager.h" />
     <ClInclude Include="AlignmentDialog.h" />
@@ -1558,6 +1562,7 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\documentation\xlDo Commands.txt" />
+    <Text Include="..\prompts\AI_Generate_Image.txt" />
     <Text Include="..\prompts\AI_Model_AutoMap.txt" />
     <Text Include="..\prompts\AI_Node_AutoMap.txt" />
     <Text Include="..\prompts\AI_Strand_AutoMap.txt" />

--- a/xLights/Xlights.vcxproj.filters
+++ b/xLights/Xlights.vcxproj.filters
@@ -1118,6 +1118,8 @@
     <ClCompile Include="..\xSchedule\wxJSON\jsonreader.cpp" />
     <ClCompile Include="..\xSchedule\wxJSON\jsonval.cpp" />
     <ClCompile Include="..\xSchedule\wxJSON\jsonwriter.cpp" />
+    <ClCompile Include="ai\AIImageDialog.cpp" />
+    <ClCompile Include="ai\gemini.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BatchRenderDialog.h" />
@@ -2248,6 +2250,8 @@
     <ClInclude Include="..\xSchedule\wxJSON\jsonreader.h" />
     <ClInclude Include="..\xSchedule\wxJSON\jsonval.h" />
     <ClInclude Include="..\xSchedule\wxJSON\jsonwriter.h" />
+    <ClInclude Include="ai\AIImageDialog.h" />
+    <ClInclude Include="ai\gemini.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Models">
@@ -2324,6 +2328,7 @@
     <Text Include="..\prompts\AI_SubModel_AutoMap.txt">
       <Filter>Prompts</Filter>
     </Text>
+    <Text Include="..\prompts\AI_Generate_Image.txt" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="effects\ispc\LayerBlendingFunctions.ispc" />

--- a/xLights/ai/AIImageDialog.cpp
+++ b/xLights/ai/AIImageDialog.cpp
@@ -1,0 +1,547 @@
+#include "AIImageDialog.h"
+
+//(*InternalHeaders(AIImageDialog)
+#include <wx/string.h>
+//*)
+#include <wx/mstream.h>
+
+//#define BYPASS_GEMINI // set this to use a local image for testing local functions
+
+//(*IdInit(AIImageDialog)
+const wxWindowID AIImageDialog::ID_STATICTEXT1 = wxNewId();
+const wxWindowID AIImageDialog::ID_PROMPT = wxNewId();
+const wxWindowID AIImageDialog::ID_STATICTEXT3 = wxNewId();
+const wxWindowID AIImageDialog::ID_DIRBUTTON = wxNewId();
+const wxWindowID AIImageDialog::ID_DIRECTORY = wxNewId();
+const wxWindowID AIImageDialog::ID_STATICTEXT6 = wxNewId();
+const wxWindowID AIImageDialog::ID_FNAMEBUTTON = wxNewId();
+const wxWindowID AIImageDialog::ID_FILENAME = wxNewId();
+const wxWindowID AIImageDialog::ID_STATICTEXT2 = wxNewId();
+const wxWindowID AIImageDialog::ID_AIPROMPT = wxNewId();
+const wxWindowID AIImageDialog::ID_HTMLWINDOW1 = wxNewId();
+const wxWindowID AIImageDialog::ID_GENERATE = wxNewId();
+const wxWindowID AIImageDialog::ID_OK = wxNewId();
+const wxWindowID AIImageDialog::ID_CANCEL = wxNewId();
+//*)
+
+BEGIN_EVENT_TABLE(AIImageDialog,wxDialog)
+    //(*EventTable(AIImageDialog)
+    //*)
+END_EVENT_TABLE()
+
+#include "../utils/CurlManager.h"
+#include "../xLightsMain.h"
+#include "../xLightsApp.h"
+#include "../sequencer/MainSequencer.h"
+#include "../ai/aiBase.h"
+#include "../ai/gemini.h"
+#include "ServiceManager.h"
+#include "TempFileManager.h"
+#include "UtilFunctions.h"
+
+#include <log4cpp/Category.hh>
+
+
+AIImageDialog::AIImageDialog(wxWindow* parent, ServiceManager* sm, const wxString& defaultPrompt,  const wxString& AIPrompt, wxWindowID id)
+    : wxDialog()
+    , _serviceManager(sm)
+{
+    //(*Initialize(AIImageDialog)
+    wxBoxSizer* BoxSizer1;
+    wxBoxSizer* BoxSizer2;
+    wxFlexGridSizer* FlexGridSizer1;
+    wxFlexGridSizer* FlexGridSizer2;
+    wxFlexGridSizer* FlexGridSizer3;
+    wxStaticBoxSizer* StaticBoxSizer1;
+    wxStaticBoxSizer* StaticBoxSizer2;
+
+    Create(parent, id, _T("Generate Image"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxCLOSE_BOX|wxFULL_REPAINT_ON_RESIZE, _T("id"));
+    SetClientSize(wxDefaultSize);
+    Move(wxDefaultPosition);
+    FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
+    FlexGridSizer1->AddGrowableCol(0);
+    StaticBoxSizer1 = new wxStaticBoxSizer(wxHORIZONTAL, this, _T("Parameters"));
+    FlexGridSizer2 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer2->AddGrowableCol(1);
+    StaticText1 = new wxStaticText(this, ID_STATICTEXT1, _T("Prompt"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
+    FlexGridSizer2->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FreeFormText = new wxTextCtrl(this, ID_PROMPT, wxEmptyString, wxDefaultPosition, wxSize(400,50), wxTE_MULTILINE|wxVSCROLL, wxDefaultValidator, _T("ID_PROMPT"));
+    FreeFormText->SetFocus();
+    FreeFormText->SetHelpText(_T("Enter a prompt"));
+    FlexGridSizer2->Add(FreeFormText, 1, wxALL|wxEXPAND, 2);
+    StaticText3 = new wxStaticText(this, ID_STATICTEXT3, _T("Directory"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT3"));
+    FlexGridSizer2->Add(StaticText3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    BoxSizer1 = new wxBoxSizer(wxHORIZONTAL);
+    DirButton = new wxButton(this, ID_DIRBUTTON, _T("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_DIRBUTTON"));
+    BoxSizer1->Add(DirButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 2);
+    DirectoryCtrl = new wxTextCtrl(this, ID_DIRECTORY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_DIRECTORY"));
+    BoxSizer1->Add(DirectoryCtrl, 1, wxALL|wxEXPAND, 2);
+    FlexGridSizer2->Add(BoxSizer1, 0, wxEXPAND, 5);
+    StaticText6 = new wxStaticText(this, ID_STATICTEXT6, _T("Filename"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
+    FlexGridSizer2->Add(StaticText6, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    BoxSizer2 = new wxBoxSizer(wxHORIZONTAL);
+    FilenameButton = new wxButton(this, ID_FNAMEBUTTON, _T("Select"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_FNAMEBUTTON"));
+    BoxSizer2->Add(FilenameButton, 0, wxALL|wxALIGN_CENTER_VERTICAL, 2);
+    FilenameCtrl = new wxTextCtrl(this, ID_FILENAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_FILENAME"));
+    BoxSizer2->Add(FilenameCtrl, 1, wxALL|wxEXPAND, 2);
+    FlexGridSizer2->Add(BoxSizer2, 0, wxEXPAND, 5);
+    StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _T("AI Prompt"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
+    FlexGridSizer2->Add(StaticText2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    TextCtrl1 = new wxTextCtrl(this, ID_AIPROMPT, wxEmptyString, wxDefaultPosition, wxSize(400,100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL, wxDefaultValidator, _T("ID_AIPROMPT"));
+    TextCtrl1->SetHelpText(_T("Default system prompt"));
+    FlexGridSizer2->Add(TextCtrl1, 1, wxALL|wxEXPAND, 2);
+    StaticBoxSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer1->Add(StaticBoxSizer1, 0, wxALL|wxEXPAND, 5);
+    StaticBoxSizer2 = new wxStaticBoxSizer(wxHORIZONTAL, this, _T("Results"));
+    ResultHTMLCtrl = new wxHtmlWindow(this, ID_HTMLWINDOW1, wxDefaultPosition, wxSize(-1,260), wxHW_SCROLLBAR_AUTO, _T("ID_HTMLWINDOW1"));
+    StaticBoxSizer2->Add(ResultHTMLCtrl, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer1->Add(StaticBoxSizer2, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer3 = new wxFlexGridSizer(0, 3, 0, 0);
+    GenerateButton = new wxButton(this, ID_GENERATE, _T("Generate"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_GENERATE"));
+    GenerateButton->SetDefault();
+    FlexGridSizer3->Add(GenerateButton, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    OkButton = new wxButton(this, ID_OK, _T("OK"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_OK"));
+    FlexGridSizer3->Add(OkButton, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    CancelButton = new wxButton(this, ID_CANCEL, _T("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CANCEL"));
+    FlexGridSizer3->Add(CancelButton, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer1->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+    SetSizer(FlexGridSizer1);
+    FlexGridSizer1->SetSizeHints(this);
+    Center();
+
+    Connect(ID_DIRBUTTON, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&AIImageDialog::OnDirectoryButtonClick);
+    Connect(ID_FNAMEBUTTON, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&AIImageDialog::OnFilenameButtonClick);
+    Connect(ID_GENERATE, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&AIImageDialog::OnGenerateButtonClick);
+    Connect(ID_OK, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&AIImageDialog::OnOkButtonClick);
+    Connect(ID_CANCEL, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&AIImageDialog::OnCancelButtonClick);
+    Connect(wxEVT_SIZE, (wxObjectEventFunction)&AIImageDialog::OnResize);
+    //*)
+
+    FreeFormText->SetValue(defaultPrompt);
+    FreeFormText->SetFocus();
+    FreeFormText->SetSelection(-1, -1);
+
+    wxString showDir = xLightsFrame::CurrentDir;
+    wxConfigBase* config = wxConfigBase::Get();
+    wxString imageDir = "";
+    if (config != nullptr) {
+        config->Read("xLightsAIImageDir", &imageDir, showDir);
+    }
+    if (imageDir.empty()) {
+        imageDir = showDir;
+    }
+
+    DirectoryCtrl->SetValue(imageDir);
+    TextCtrl1->SetValue(AIPrompt);
+
+    wxDateTime now = wxDateTime::Now();
+    wxString filename = wxString::Format("image-%04d-%02d-%02d-%02d%02d.png",
+        now.GetYear(), now.GetMonth() + 1, now.GetDay(),
+        now.GetHour(), now.GetMinute());
+
+    FilenameCtrl->SetValue(filename);
+
+    // MANDATORY OUTPUT REQUIREMENTS: Background: Pure Black background (#000000) with no watermarks or border.
+    // Design: 2D Vector Style, Colors aligned to the character design.
+    // The design features bold, clean outlines, simple cel-shading, and a limited vibrant color palette with clean edges and no gradients.
+    // Character features should be simplified with large blocky shapes, a large head, and a small body (Chibi proportions).
+    // Ensure the lines are perfectly horizontal and vertical with no diagonal smoothing.  A minimalist, flat 2D pixel art illustration using a 32-bit kawaii style.
+}
+
+AIImageDialog::~AIImageDialog()
+{
+    //(*Destroy(AIImageDialog)
+    //*)
+}
+
+struct Point {
+    int y, x;
+    Point(int y, int x) : y(y), x(x) {}
+};
+
+wxImage RemoveBlackBackground(const wxImage& src)
+{
+    if (!src.IsOk()) {
+        return src;  // Return invalid image as-is
+    }
+
+    wxImage result = src.Copy();
+
+    // Ensure we have an alpha channel
+    if (!result.HasAlpha()) {
+        result.InitAlpha();
+        // Initialize alpha to fully opaque by default
+        memset(result.GetAlpha(), 255, result.GetWidth() * result.GetHeight());
+    }
+
+    int width = result.GetWidth();
+    int height = result.GetHeight();
+
+    std::vector<bool> visited(width * height, false);
+    std::queue<std::pair<int, int>> q;
+
+    // 4-directional neighbors
+    const int dx[4] = {0, 0, -1, 1};
+    const int dy[4] = {-1, 1, 0, 0};
+
+    auto isBlack = [&](int x, int y) -> bool {
+        unsigned char r = result.GetRed(x, y);
+        unsigned char g = result.GetGreen(x, y);
+        unsigned char b = result.GetBlue(x, y);
+
+        const unsigned char tolerance = 25;
+
+        return r <= tolerance && g <= tolerance && b <= tolerance;
+        };
+
+    // Seed flood fill from all black pixels on the image borders
+    for (int x = 0; x < width; ++x) {
+        if (isBlack(x, 0)) {               // Top row
+            q.push({x, 0});
+            visited[x] = true;
+            result.SetAlpha(x, 0, 0);
+        }
+        if (isBlack(x, height - 1)) {      // Bottom row
+            q.push({x, height - 1});
+            visited[x + (height - 1) * width] = true;
+            result.SetAlpha(x, height - 1, 0);
+        }
+    }
+    for (int y = 0; y < height; ++y) {
+        if (isBlack(0, y)) {               // Left column
+            q.push({0, y});
+            visited[y * width] = true;
+            result.SetAlpha(0, y, 0);
+        }
+        if (isBlack(width - 1, y)) {       // Right column
+            q.push({width - 1, y});
+            visited[(width - 1) + y * width] = true;
+            result.SetAlpha(width - 1, y, 0);
+        }
+    }
+
+    while (!q.empty()) {
+        auto [cx, cy] = q.front();
+        q.pop();
+
+        for (int d = 0; d < 4; ++d) {
+            int nx = cx + dx[d];
+            int ny = cy + dy[d];
+
+            if (nx >= 0 && nx < width && ny >= 0 && ny < height) {
+                int idx = nx + ny * width;
+                if (!visited[idx] && isBlack(nx, ny)) {
+                    visited[idx] = true;
+                    result.SetAlpha(nx, ny, 0);
+                    q.push({nx, ny});
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+void AIImageDialog::OnGenerateButtonClick(wxCommandEvent& event)
+{
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    wxString prompt = FreeFormText->GetValue().Trim();
+    if (prompt.IsEmpty()) {
+        ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> Prompt cannot be empty.</body></html>");
+        return;
+    }
+    wxString AIPrompt = TextCtrl1->GetValue().Trim();
+    if (AIPrompt.IsEmpty()) {
+        ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> System Prompt cannot be empty.</body></html>");
+        return;
+    }
+    gemini* geminiService = dynamic_cast<gemini*>(_serviceManager->getService("Gemini"));
+    if (!geminiService || !geminiService->IsAvailable()) {
+        ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> Gemini service is not available or not configured.</body></html>");
+        return;
+    }
+    std::string actualKey = _serviceManager->getSecretServiceToken("GeminiApiKey");
+
+    if (actualKey.empty()) {
+        ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> Gemini API key is not set. Go to Preferences Services to configure it.</body></html>");
+        return;
+    }
+
+#ifdef BYPASS_GEMINI
+    // === TEST MODE: Load local image file instead of calling Gemini ===
+    std::vector<uint8_t> imageData;
+    std::string localFile = "F:\\ShowFolderQA\\image-2026-01-04-1848.png";
+    wxFile localImageFile(localFile, wxFile::read);
+    if (localImageFile.IsOpened()) {
+        size_t len = localImageFile.Length();
+        imageData.resize(len);
+        localImageFile.Read(imageData.data(), len);
+        localImageFile.Close();
+        logger_base.debug("Loaded local test image: %s (%zu bytes)", localFile.c_str(), len);
+    } else {
+        logger_base.error("Failed to open local test image: %s", localFile.c_str());
+    }
+
+    std::string html = "<html><body>";
+    if (imageData.empty()) {
+        html += "<b>Failed to load local test image.</b>";
+    } else {
+        html += "<b>Test Mode:</b> Loaded local image successfully.<br>";
+
+        wxMemoryInputStream stream(imageData.data(), imageData.size());
+        wxImage originalImage(stream, wxBITMAP_TYPE_PNG);
+
+        if (!originalImage.IsOk()) {
+            html += "<b>Invalid PNG data received.</b>";
+        } else {
+            wxImage processedImage = ::RemoveBlackBackground(originalImage);
+
+            wxString filename = FilenameCtrl->GetValue();
+            if(filename.empty()) {
+                ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> Filename cannot be empty.</body></html>");
+                return;
+            }
+
+            wxString imageDir = DirectoryCtrl->GetValue();
+            if(imageDir.empty()) {
+                imageDir = xLightsFrame::CurrentDir;
+            } else {
+                wxConfigBase* config = wxConfigBase::Get();
+                if (config != nullptr) {
+                    config->Write("xLightsAIImageDir", imageDir);
+                }
+            }
+
+            wxFileName fullPath(imageDir, filename);
+            generatedImagePath = fullPath.GetFullPath();
+
+            if (processedImage.SaveFile(generatedImagePath, wxBITMAP_TYPE_PNG)) {
+                html += "<b>Success!</b> Image saved!<br><br>";
+
+                wxImage thumbnail = processedImage.Copy();
+                thumbnail.Rescale(128, 128);
+
+                wxString thumbFilename = filename.BeforeLast('.') + "_thumb.png";
+
+                wxFileName thumbPath(imageDir, thumbFilename);
+                wxString thumbFullPath = thumbPath.GetFullPath();
+                TempFileManager::GetTempFileManager().AddTempFile(thumbFullPath);
+
+                if (thumbnail.SaveFile(thumbFullPath, wxBITMAP_TYPE_PNG)) {
+                    html += "<img src='file:///" + thumbFullPath.ToStdString() +
+                        "' style='border:3px solid #0f0; border-radius:5px;'><br>";
+                    html += "<small><i>128x128 thumbnail shown above. Full PNG saved.</i></small><br><br>";
+                }
+
+                html += "<small><b>File:</b> " + filename.ToStdString() + "<br>";
+                html += "<b>Path:</b> " + generatedImagePath.ToStdString() + "</small>";
+            } else {
+                html += "<b>Failed to save PNG file.</b>";
+                generatedImagePath = "";
+            }
+        }
+    }
+    html += "</body></html>";
+    ResultHTMLCtrl->SetPage(html);
+
+#else
+    // === NORMAL MODE: Call Gemini API ===
+
+    prompt = AIPrompt + " " + prompt;
+
+    ResultHTMLCtrl->SetPage("<html><body><i>Generating image with Gemini...<br>This may take 10-30 seconds.</i></body></html>");
+    ResultHTMLCtrl->Refresh();
+    wxYield();
+
+    std::string model = "gemini-2.5-flash-image";
+    model = _serviceManager->getServiceSetting("GeminiModel", model);
+    std::string url = "https://generativelanguage.googleapis.com/v1beta/models/" + model + ":generateContent?key=" + actualKey;
+
+    wxString jsonPayload = wxString::Format(
+        "{"
+        "  \"contents\": [{"
+        "    \"parts\": [{"
+        "      \"text\": \"%s\""
+        "    }]"
+        "  }],"
+        "  \"generationConfig\": {"
+        "    \"responseModalities\": [\"IMAGE\"]"
+        "  }"
+        "}", prompt);
+
+    std::string postData = jsonPayload.ToStdString();
+
+    CurlManager::INSTANCE.addPost(
+        url,
+        postData,
+        "application/json",
+        [this](int rc, const std::string& resp)
+        {
+            static log4cpp::Category& logger_base = log4cpp::Category::getInstance("log_base");
+            std::string html = "<html><body>";
+            std::vector<unsigned char> imageData;
+
+            if (rc != 200) {
+                html += wxString::Format("<b>HTTP Error %d</b><br><pre>%s</pre>", rc, resp.c_str());
+            } else {
+                std::string base64Data;
+                try {
+                    auto jsonResp = nlohmann::json::parse(resp);
+                    logger_base.debug("Gemini Response: %s", resp.c_str());
+
+                    if (jsonResp.contains("candidates") && jsonResp["candidates"].is_array() && !jsonResp["candidates"].empty()) {
+                        auto parts = jsonResp["candidates"][0]["content"]["parts"];
+                        for (const auto& part : parts) {
+                            if (part.contains("inlineData") && part["inlineData"].contains("data")) {
+                                base64Data = part["inlineData"]["data"].get<std::string>();
+                                break;
+                            }
+                        }
+                    }
+                } catch (const std::exception& e) {
+                    html += wxString::Format("<b>JSON Parse Error:</b> %s<br><pre>%s</pre>", e.what(), resp.c_str());
+                }
+
+                if (base64Data.empty()) {
+                    html += "<b>No image data found in response.</b>";
+                } else {
+                    base64Data.erase(std::remove_if(base64Data.begin(), base64Data.end(), ::isspace), base64Data.end());
+
+                    wxMemoryBuffer decoded = wxBase64Decode(base64Data.c_str(), base64Data.length());
+                    if (decoded.GetDataLen() > 0) {
+                        imageData.resize(decoded.GetDataLen());
+                        memcpy(imageData.data(), decoded.GetData(), decoded.GetDataLen());
+                    }
+                }
+            }
+
+            if (imageData.empty()) {
+                html += "<b>Failed to obtain image data.</b>";
+            } else {
+                wxMemoryInputStream stream(imageData.data(), imageData.size());
+                wxImage originalImage(stream, wxBITMAP_TYPE_PNG);
+
+                if (!originalImage.IsOk()) {
+                    html += "<b>Invalid PNG data received.</b>";
+                } else {
+                    wxImage processedImage = ::RemoveBlackBackground(originalImage);
+
+                    wxString filename = FilenameCtrl->GetValue();
+                    if(filename.empty()) {
+                        ResultHTMLCtrl->SetPage("<html><body><b>Error:</b> Filename cannot be empty.</body></html>");
+                        return;
+                    }
+
+                    wxString imageDir = DirectoryCtrl->GetValue();
+                    if(imageDir.empty()) {
+                        imageDir = xLightsFrame::CurrentDir;
+                    } else {
+                        wxConfigBase* config = wxConfigBase::Get();
+                        if (config != nullptr) {
+                            config->Write("xLightsAIImageDir", imageDir);
+                        }
+                    }
+
+                    wxFileName fullPath(imageDir, filename);
+                    generatedImagePath = fullPath.GetFullPath();
+
+                    if (processedImage.SaveFile(generatedImagePath, wxBITMAP_TYPE_PNG)) {
+                        html += "<b>Success!</b> Image saved!<br><br>";
+
+                        wxImage thumbnail = processedImage.Copy();
+                        thumbnail.Rescale(128, 128);
+
+                        wxString thumbFilename = filename.BeforeLast('.') + "_thumb.png";
+                        wxFileName thumbPath(imageDir, thumbFilename);
+                        wxString thumbFullPath = thumbPath.GetFullPath();
+                        TempFileManager::GetTempFileManager().AddTempFile(thumbFullPath);
+
+                        if (thumbnail.SaveFile(thumbFullPath, wxBITMAP_TYPE_PNG)) {
+                            html += "<img src='file:///" + thumbFullPath.ToStdString() +
+                                "' style='border:3px solid #0f0; border-radius:5px;'><br>";
+                            html += "<small><i>128x128 thumbnail shown above. Full PNG saved.</i></small><br><br>";
+                        }
+
+                        html += "<small><b>File:</b> " + filename.ToStdString() + "<br>";
+                        html += "<b>Path:</b> " + generatedImagePath.ToStdString() + "</small>";
+                    } else {
+                        html += "<b>Failed to save PNG file.</b>";
+                        generatedImagePath = "";
+                    }
+                }
+            }
+
+            html += "</body></html>";
+            wxTheApp->CallAfter([this, html]() {
+                ResultHTMLCtrl->SetPage(html);
+                });
+        }
+    );
+#endif
+}
+
+void AIImageDialog::OnOkButtonClick(wxCommandEvent& event)
+{
+    EndModal(wxID_OK);
+}
+
+void AIImageDialog::OnCancelButtonClick(wxCommandEvent& event)
+{
+    EndModal(wxID_CANCEL);
+}
+
+
+void AIImageDialog::OnResize(wxSizeEvent& event) {
+    OnSize(event);
+    Refresh();
+}
+
+void AIImageDialog::OnDirectoryButtonClick(wxCommandEvent& event) {
+    wxDirDialog dirDialog(this, _("Select Image Directory"), generatedImagePath,
+                          wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+
+    if (dirDialog.ShowModal() == wxID_OK) {
+        wxString selectedPath = dirDialog.GetPath();
+        wxLogMessage(wxString::Format("Selected directory: %s", selectedPath));
+        DirectoryCtrl->SetValue(selectedPath);
+    }
+}
+
+void AIImageDialog::OnFilenameButtonClick(wxCommandEvent& event) {
+    wxLogMessage("fname");
+    wxString directory = DirectoryCtrl->GetValue();
+    wxString defaultFilename = FilenameCtrl->GetValue();
+
+    if (defaultFilename.IsEmpty()) {
+        wxDateTime now = wxDateTime::Now();
+        wxString filename = wxString::Format("image-%04d-%02d-%02d-%02d%02d.png",
+                                             now.GetYear(), now.GetMonth() + 1, now.GetDay(),
+                                             now.GetHour(), now.GetMinute());
+    }
+
+    wxString wildcard = _("PNG files (*.png)|*.png|All files (*.*)|*.*");
+
+    wxFileDialog saveDialog(this,
+                            _("Enter filename to save"),
+                            directory,
+                            defaultFilename,
+                            wildcard,
+                            wxFD_SAVE);
+
+    if (saveDialog.ShowModal() == wxID_OK) {
+        wxString fullPath = saveDialog.GetPath();
+
+        if (wxFileExists(fullPath)) {
+            wxMessageDialog confirm(this,
+                                    wxString::Format(_("%s already exists.\nDo you want to overwrite it?"), fullPath),
+                                    _("Confirm Overwrite"),
+                                    wxYES_NO | wxICON_QUESTION);
+
+            if (confirm.ShowModal() != wxID_YES)
+                return; // user cancelled
+        }
+
+        FilenameCtrl->SetValue(saveDialog.GetFilename()); // or fullPath as needed
+    }
+}

--- a/xLights/ai/AIImageDialog.h
+++ b/xLights/ai/AIImageDialog.h
@@ -1,0 +1,80 @@
+#ifndef HEADER_85D1CC366A7F7DAE
+#define HEADER_85D1CC366A7F7DAE
+
+#pragma once
+
+class ServiceManager;
+
+//(*Headers(AIImageDialog)
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/html/htmlwin.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+//*)
+
+class AIImageDialog: public wxDialog
+{
+    public:
+
+        AIImageDialog(wxWindow* parent, ServiceManager* sm, const wxString& topic, const wxString& AIPrompt, wxWindowID id = wxID_ANY);
+        virtual ~AIImageDialog();
+
+        wxString GetGeneratedImagePath() const { return generatedImagePath; }
+
+        //(*Declarations(AIImageDialog)
+        wxButton* CancelButton;
+        wxButton* DirButton;
+        wxButton* FilenameButton;
+        wxButton* GenerateButton;
+        wxButton* OkButton;
+        wxHtmlWindow* ResultHTMLCtrl;
+        wxStaticText* StaticText1;
+        wxStaticText* StaticText2;
+        wxStaticText* StaticText3;
+        wxStaticText* StaticText6;
+        wxTextCtrl* DirectoryCtrl;
+        wxTextCtrl* FilenameCtrl;
+        wxTextCtrl* FreeFormText;
+        wxTextCtrl* TextCtrl1;
+        //*)
+
+
+    protected:
+
+        //(*Identifiers(AIImageDialog)
+        static const wxWindowID ID_STATICTEXT1;
+        static const wxWindowID ID_PROMPT;
+        static const wxWindowID ID_STATICTEXT3;
+        static const wxWindowID ID_DIRBUTTON;
+        static const wxWindowID ID_DIRECTORY;
+        static const wxWindowID ID_STATICTEXT6;
+        static const wxWindowID ID_FNAMEBUTTON;
+        static const wxWindowID ID_FILENAME;
+        static const wxWindowID ID_STATICTEXT2;
+        static const wxWindowID ID_AIPROMPT;
+        static const wxWindowID ID_HTMLWINDOW1;
+        static const wxWindowID ID_GENERATE;
+        static const wxWindowID ID_OK;
+        static const wxWindowID ID_CANCEL;
+        //*)
+
+    private:
+
+        //(*Handlers(AIImageDialog)
+        void OnGenerateButtonClick(wxCommandEvent& event);
+        void OnOkButtonClick(wxCommandEvent& event);
+        void OnCancelButtonClick(wxCommandEvent& event);
+        void OnResize(wxSizeEvent& event);
+        void OnDirectoryButtonClick(wxCommandEvent& event);
+        void OnFilenameButtonClick(wxCommandEvent& event);
+        //*)
+
+        DECLARE_EVENT_TABLE()
+
+        ServiceManager* _serviceManager;
+        wxString generatedImagePath;
+};
+#endif // header guard 
+

--- a/xLights/ai/ServiceManager.cpp
+++ b/xLights/ai/ServiceManager.cpp
@@ -1,6 +1,7 @@
 #include "ServiceManager.h"
 #include "aiBase.h"
 #include "chatGPT.h"
+#include "gemini.h"
 #include "ollama.h"
 
 #ifdef __WXOSX__
@@ -28,6 +29,7 @@ ServiceManager::ServiceManager(xLightsFrame* xl)
 #endif
     m_services.push_back(std::make_unique<chatGPT>(this));
     m_services.push_back(std::make_unique<ollama>(this));
+    m_services.push_back(std::make_unique<gemini>(this));
     for (auto& service : m_services) {
         service->LoadSettings();
     }

--- a/xLights/ai/gemini.cpp
+++ b/xLights/ai/gemini.cpp
@@ -1,0 +1,110 @@
+#include "gemini.h"
+#include <nlohmann/json.hpp>
+#include "ServiceManager.h"
+#include "utils/Curl.h"
+#include "UtilFunctions.h"
+
+#include <wx/propgrid/propgrid.h>
+
+#include <vector>
+#include <string>
+
+#include <log4cpp/Category.hh>
+
+bool gemini::IsAvailable() const {
+    return !api_key.empty() && _enabled;
+}
+
+void gemini::SaveSettings() const {
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    _sm->setServiceSetting("GeminiModel", model);
+    _sm->setServiceSetting("GeminiEnable", _enabled);
+    _sm->setSecretServiceToken("GeminiApiKey", api_key);
+    logger_base.info("Gemini settings saved successfully");
+}
+
+void gemini::LoadSettings() {
+    model = _sm->getServiceSetting("GeminiModel", model);
+    _enabled = _sm->getServiceSetting("GeminiEnable", _enabled);
+    api_key = _sm->getSecretServiceToken("GeminiApiKey");
+}
+
+void gemini::PopulateLLMSettings(wxPropertyGrid* page) {
+    page->Append(new wxPropertyCategory("Gemini"));
+    auto p = page->Append(new wxBoolProperty("Enabled", "Gemini.Enabled", _enabled));
+    p->SetEditor("CheckBox");
+    page->Append(new wxStringProperty("API Key", "Gemini.Key", api_key));
+    page->Append(new wxStringProperty("Model", "Gemini.Model", model));
+}
+
+void gemini::SetSetting(const std::string& key, const wxVariant& value) {
+    if (key == "Gemini.Enabled") {
+        _enabled = value.GetBool();
+    } else if (key == "Gemini.Key") {
+        api_key = value.GetString();
+    } else if (key == "Gemini.Model") {
+        model = value.GetString();
+    }
+}
+
+std::pair<std::string, bool> gemini::CallLLM(const std::string& prompt) const {
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    std::string apiKey = api_key;
+
+    if (apiKey.empty()) {
+        apiKey = _sm->getSecretServiceToken("GeminiApiKey");
+    }
+
+    if (api_key.empty() && apiKey.empty()) {
+        wxMessageBox("You must set a Gemini API Key in the Preferences on the Services Panel", "Error", wxICON_ERROR);
+        return { "Gemini: API Key is empty", false };
+    }
+
+    std::string p = prompt;
+    Replace(p, std::string("\t"), std::string(" "));
+    Replace(p, std::string("\r"), std::string(""));
+
+    std::string const request = "{ \"model\": \"" + model + "\", \"messages\": [ { \"role\": \"user\",\"content\": \"" + JSONSafe(p) + "\" } ] }";
+
+    std::vector<std::pair<std::string, std::string>> customHeaders = {
+        { "Authorization", "Bearer " + apiKey }
+    };
+
+    logger_base.debug("Gemini: %s", request.c_str());
+
+    int responseCode = 0;	
+    std::string response = Curl::HTTPSPost(url, request, "", "", "JSON", 60, customHeaders, &responseCode);
+
+    logger_base.debug("Gemini Response %d: %s", responseCode, response.c_str());
+
+    if (responseCode != 200) {
+        return { response, false };
+    }
+
+    nlohmann::json root;
+    try {
+        root = nlohmann::json::parse(response);
+    } catch (const std::exception&) {
+        logger_base.error("Gemini: Invalid JSON response: %s", response.c_str());
+        return { "Gemini: Invalid JSON response", false };
+    }
+
+    auto choices = root["choices"];
+    if (choices.is_null() || choices.size() == 0) {
+        logger_base.error("Gemini: No choices in response");
+        return { "Gemini: No choices in response", false };
+    }
+
+    auto choice = choices[0];
+    auto text = choice["message"]["content"];
+    if (text.is_null()) {
+        logger_base.error("Gemini: No text in response");
+        return { "Gemini: No text in response", false };
+    }
+
+    response = text.get<std::string>();
+    logger_base.debug("Gemini: %s", response.c_str());
+
+    return { response, true };
+}

--- a/xLights/ai/gemini.h
+++ b/xLights/ai/gemini.h
@@ -1,0 +1,48 @@
+#pragma once
+
+/***************************************************************
+* This source files comes from the xLights project
+* https://www.xlights.org
+* https://github.com/xLightsSequencer/xLights
+* See the github commit history for a record of contributing
+* developers.
+* Copyright claimed based on commit dates recorded in Github
+* License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+**************************************************************/
+
+#include "aiBase.h"
+#include "aiType.h"
+#include <string>
+
+// Google Gemini API documentation:
+// https://ai.google.dev/gemini-api/docs
+// OpenAI-compatible chat endpoint: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+
+class gemini : public aiBase {
+
+    std::string url = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+    std::string model = "gemini-2.5-flash";
+    std::string api_key;
+
+public:
+
+    explicit gemini(ServiceManager* sm) :
+        aiBase(sm) {
+    }
+    virtual ~gemini() {}
+
+    void SaveSettings() const override;
+    void LoadSettings() override;
+
+    void PopulateLLMSettings(wxPropertyGrid* page) override;
+    void SetSetting(const std::string& key, const wxVariant& value) override;
+
+    [[nodiscard]] std::pair<std::string, bool> CallLLM(const std::string& prompt) const override;
+    [[nodiscard]] bool IsAvailable() const override;
+    [[nodiscard]] std::string GetLLMName() const override {
+        return "Gemini";
+    }
+    [[nodiscard]] std::list<aiType::TYPE> GetTypes() const override {
+        return std::list({ aiType::TYPE::PROMPT });
+    }
+};

--- a/xLights/wxsmith/AIImageDialog.wxs
+++ b/xLights/wxsmith/AIImageDialog.wxs
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wxsmith>
+	<object class="wxDialog" name="AIImageDialog">
+		<title>Generate Image</title>
+		<centered>1</centered>
+		<pos_arg>1</pos_arg>
+		<size_arg>1</size_arg>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxCLOSE_BOX|wxFULL_REPAINT_ON_RESIZE</style>
+		<handler function="OnResize" entry="EVT_SIZE" />
+		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+			<cols>1</cols>
+			<growablecols>0</growablecols>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="StaticBoxSizer1" member="no">
+					<label>Parameters</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
+							<cols>2</cols>
+							<growablecols>1</growablecols>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT1" variable="StaticText1" member="yes">
+									<label>Prompt</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_PROMPT" variable="FreeFormText" member="yes">
+									<size>400,50</size>
+									<focused>1</focused>
+									<help>Enter a prompt</help>
+									<style>wxTE_MULTILINE|wxVSCROLL</style>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT3" variable="StaticText3" member="yes">
+									<label>Directory</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxBoxSizer" variable="BoxSizer1" member="no">
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_DIRBUTTON" variable="DirButton" member="yes">
+											<label>Select</label>
+											<handler function="OnDirectoryButtonClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>2</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxTextCtrl" name="ID_DIRECTORY" variable="DirectoryCtrl" member="yes" />
+										<flag>wxALL|wxEXPAND</flag>
+										<border>2</border>
+										<option>1</option>
+									</object>
+								</object>
+								<flag>wxEXPAND</flag>
+								<border>5</border>
+							</object>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT6" variable="StaticText6" member="yes">
+									<label>Filename</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxBoxSizer" variable="BoxSizer2" member="no">
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_FNAMEBUTTON" variable="FilenameButton" member="yes">
+											<label>Select</label>
+											<handler function="OnFilenameButtonClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>2</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxTextCtrl" name="ID_FILENAME" variable="FilenameCtrl" member="yes" />
+										<flag>wxALL|wxEXPAND</flag>
+										<border>2</border>
+										<option>1</option>
+									</object>
+								</object>
+								<flag>wxEXPAND</flag>
+								<border>5</border>
+							</object>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT2" variable="StaticText2" member="yes">
+									<label>AI Prompt</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_AIPROMPT" variable="TextCtrl1" member="yes">
+									<size>400,100</size>
+									<help>Default system prompt</help>
+									<style>wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL</style>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="StaticBoxSizer2" member="no">
+					<label>Results</label>
+					<object class="sizeritem">
+						<object class="wxHtmlWindow" name="ID_HTMLWINDOW1" variable="ResultHTMLCtrl" member="yes">
+							<size>-1,260</size>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
+					<cols>3</cols>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_GENERATE" variable="GenerateButton" member="yes">
+							<label>Generate</label>
+							<default>1</default>
+							<handler function="OnGenerateButtonClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_OK" variable="OkButton" member="yes">
+							<label>OK</label>
+							<handler function="OnOkButtonClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_CANCEL" variable="CancelButton" member="yes">
+							<label>Cancel</label>
+							<handler function="OnCancelButtonClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>2</border>
+				<option>1</option>
+			</object>
+		</object>
+	</object>
+</wxsmith>

--- a/xLights/wxsmith/xLightsframe.wxs
+++ b/xLights/wxsmith/xLightsframe.wxs
@@ -1317,6 +1317,11 @@
 					<label>Remap Custom Model</label>
 					<handler function="OnMenuItem_RemapCustomSelected" entry="EVT_MENU" />
 				</object>
+				<object class="wxMenuItem" name="ID_MENUITEM_GenerateAIImage" variable="Menu_GenerateAIImage" member="yes">
+					<label>Generate AI Image</label>
+					<help>Create images using Gemini - if configured.</help>
+					<handler function="OnMenuItem_GenerateAIImageSelected" entry="EVT_MENU" />
+				</object>
 				<object class="wxMenuItem" name="ID_MNU_GENERATELYRICS" variable="MenuItem_GenerateLyrics" member="yes">
 					<label>Generate &amp;Lyrics From Data</label>
 					<help>Generate lyric phenomes from data</help>

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -492,6 +492,8 @@
 		<Unit filename="XlightsDrawable.h" />
 		<Unit filename="ai/AIColorPaletteDialog.cpp" />
 		<Unit filename="ai/AIColorPaletteDialog.h" />
+		<Unit filename="ai/AIImageDialog.cpp" />
+		<Unit filename="ai/AIImageDialog.h" />
 		<Unit filename="ai/ServiceManager.cpp" />
 		<Unit filename="ai/ServiceManager.h" />
 		<Unit filename="ai/aiBase.cpp" />
@@ -1169,6 +1171,7 @@
 		<Unit filename="wxModelGridCellRenderer.h" />
 		<Unit filename="wx_pch.h" />
 		<Unit filename="wxsmith/AIColorPaletteDialog.wxs" />
+		<Unit filename="wxsmith/AIImageDialog.wxs" />
 		<Unit filename="wxsmith/AboutDialog.wxs" />
 		<Unit filename="wxsmith/AdjustPanel.wxs" />
 		<Unit filename="wxsmith/AlignmentDialog.wxs" />
@@ -1578,6 +1581,7 @@
 					<wxDialog wxs="wxsmith/ShowFolderSearchDialog.wxs" src="ShowFolderSearchDialog.cpp" hdr="ShowFolderSearchDialog.h" fwddecl="0" i18n="1" name="ShowFolderSearchDialog" language="CPP" />
 					<wxPanel wxs="wxsmith/ServicesPanel.wxs" src="preferences/ServicesPanel.cpp" hdr="preferences/ServicesPanel.h" fwddecl="0" i18n="1" name="ServicesPanel" language="CPP" />
 					<wxDialog wxs="wxsmith/AIColorPaletteDialog.wxs" src="ai/AIColorPaletteDialog.cpp" hdr="ai/AIColorPaletteDialog.h" fwddecl="0" i18n="0" name="AIColorPaletteDialog" language="CPP" />
+					<wxDialog wxs="wxsmith/AIImageDialog.wxs" src="ai/AIImageDialog.cpp" hdr="ai/AIImageDialog.h" fwddecl="0" i18n="0" name="AIImageDialog" language="CPP" />					
 				</resources>
 			</wxsmith>
 		</Extensions>

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -419,6 +419,8 @@ public:
     void ClearTraceMessages();
     bool ExportVideoPreview(wxString const& path);
 
+    ServiceManager* GetServiceManager() const { return serviceManager; }
+
 	void SetAudioControls();
     void ImportXLights(const wxFileName &filename, std::string const& mapFile = std::string());
     void ImportXLights(SequenceElements &se, const std::vector<Element *> &elements, const wxFileName &filename,
@@ -604,6 +606,7 @@ public:
     void OnMenuItem_ZoomSelected(wxCommandEvent& event);
     void OnMenuItem_CleanupFileLocationsSelected(wxCommandEvent& event);
     void OnMenuItem_Generate2DPathSelected(wxCommandEvent& event);
+    void OnMenuItem_GenerateAIImage(wxCommandEvent& event);
     void OnMenuItem_PrepareAudioSelected(wxCommandEvent& event);
     void OnMenuItem_UserManualSelected(wxCommandEvent& event);
     void OnMenuItem_ValueCurvesSelected(wxCommandEvent& event);
@@ -646,13 +649,12 @@ public:
     void OnButton_OpenBaseShowDirClick(wxCommandEvent& event);
     void OnMenuItemFindShowFolderSelected(wxCommandEvent& event);
     void OnMenuItemShiftEffectsAndTimingSelected(wxCommandEvent& event);
+    void OnMenuItem_GenerateAIImageSelected(wxCommandEvent& event);
     //*)
     void OnCharHook(wxKeyEvent& event);
     void OnHelp(wxHelpEvent& event);
 
 private :
-
-    //void OnMenuItem53Selected(wxCommandEvent& event);
 
     void DoMenuAction(wxMenuEvent &evt);
 	void ShowHideAllSequencerWindows(bool show);
@@ -663,6 +665,7 @@ private :
     wxTimer* _pingTimer;
     wxTimer* _statusRefreshTimer;
     bool _pingInProgress = false;
+    ServiceManager* serviceManager = nullptr;
 
 public:
 
@@ -795,6 +798,7 @@ public:
     static const wxWindowID ID_MENU_GENERATE2DPATH;
     static const wxWindowID ID_MENUITEM_GenerateCustomModel;
     static const wxWindowID ID_MNU_REMAPCUSTOM;
+    static const wxWindowID ID_MENUITEM_GenerateAIImage;
     static const wxWindowID ID_MNU_GENERATELYRICS;
     static const wxWindowID ID_MENUITEM_CONVERT;
     static const wxWindowID ID_MNU_PREPAREAUDIO;
@@ -1026,6 +1030,7 @@ public:
     wxMenuItem* MenuItem_Zoom;
     wxMenuItem* MenuItem_xScanner;
     wxMenuItem* MenuItem_xSchedule;
+    wxMenuItem* Menu_GenerateAIImage;
     wxMenuItem* Menu_GenerateCustomModel;
     wxMenuItem* Menu_Settings_Sequence;
     wxMenuItem* QuitMenuItem;


### PR DESCRIPTION
Add Gemini as a service pointing to the image model. Add Generate AI Image item to the menu.
Gemini costs 2-4cents per image but they do offer $300 90day trial as well.
Pulls the ai prompt from the txt file that is stored on your installation - similar to what was done with AI Auto map.
Ideally the user can place a very simple item in the prompt "A Christmas Tree" - and the ai prompt will do the rest.
Note that code was added to remove the black background since Gemini cannot create transparent images.
The Directory is stored as a sys variable so folks are encouraged to create their own Images directory for these images.
Also I have ifdef code in there so folks can test the dialog etc with a local image, without having the gemini api paid service.
Gemini creates a 1Kx1K image by default - cant make it smaller.
**UNTESTED ON MAC**
<img width="507" height="647" alt="image" src="https://github.com/user-attachments/assets/7528228f-c333-4290-8691-76e253719aeb" />
