### PR TITLE
Fix Media Manager on Windows

### DIFF
--- a/xLights/ManageMediaPanel.cpp
+++ b/xLights/ManageMediaPanel.cpp
@@ -379,6 +379,8 @@ void ManageMediaPanel::Populate(const std::string& selectPath)
             _mediaTree->EnsureVisible(item);
             UpdatePreview(selectPath);
             UpdateButtons();
+            wxDataViewEvent evt(wxEVT_DATAVIEW_SELECTION_CHANGED, _mediaTree, item);
+            wxPostEvent(_mediaTree, evt);
         }
     }
 }
@@ -1053,7 +1055,7 @@ SelectMediaDialog::SelectMediaDialog(wxWindow* parent, SequenceMedia* sequenceMe
 
     // Enable OK when a single leaf item is selected in the panel's tree
     _panel->_mediaTree->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
-                             &SelectMediaDialog::OnSelectionChanged, this);
+        &SelectMediaDialog::OnSelectionChanged, this);
 
     _okButton->Bind(wxEVT_BUTTON, &SelectMediaDialog::OnOK, this);
 }

--- a/xLights/effects/PicturesPanel.cpp
+++ b/xLights/effects/PicturesPanel.cpp
@@ -342,7 +342,6 @@ PicturesPanel::PicturesPanel(wxWindow* parent) : xlEffectPanel(parent)
     BitmapButton_PicturesYC->GetValue()->SetLimits(PICTURES_YC_MIN, PICTURES_YC_MAX);
 
     SetName("ID_PANEL_PICTURES");
-    BitmapPreview->SetScaleMode(wxStaticBitmap::Scale_AspectFill);
     BitmapPreview->SetMaxSize(wxDLG_UNIT(this,wxSize(0,50)));
     
 	ValidateWindow();
@@ -440,7 +439,13 @@ void PicturesPanel::UpdatePreviewBitmap(const wxString& filename)
         refreshPreview(makeRedBitmap(), false);
         return;
     }
-    refreshPreview(wxBitmap(*img), !entry->IsFrameBasedAnimation());
+	wxSize previewSz = BitmapPreview->GetSize();
+	int pw = std::max(1, previewSz.x);
+	int ph = std::max(1, previewSz.y);
+	double scale = std::min((double)pw / img->GetWidth(), (double)ph / img->GetHeight());
+	int sw = std::max(1, (int)(img->GetWidth() * scale));
+	int sh = std::max(1, (int)(img->GetHeight() * scale));
+	refreshPreview(wxBitmap(img->Scale(sw, sh)), !entry->IsFrameBasedAnimation());
 }
 
 void PicturesPanel::OnAIGenerateButtonClick(wxCommandEvent& event)


### PR DESCRIPTION
Fix two issues in the Pictures effect image selector: the OK button in the Select Image dialog now activates after adding initial image and the image preview thumbnail now scales properly on Windows and Linux(?).