### PR TITLE
Add new kaleidoscope types: Square 2, 6-Fold, 8-Fold, 12-Fold, Radial

### DIFF
--- a/xLights/effects/KaleidoscopeEffect.h
+++ b/xLights/effects/KaleidoscopeEffect.h
@@ -33,6 +33,21 @@ struct KaleidoscopeEdge
     KaleidoscopeEdge(const wxPoint &p1, const wxPoint& p2) { _p1 = p1; _p2 = p2; }
 };
 
+struct KaleidoscopeVertex {
+    double x;
+    double y;
+    KaleidoscopeVertex() :
+        x(0), y(0) {
+    }
+    KaleidoscopeVertex(double x_, double y_) :
+        x(x_), y(y_) {
+    }
+};
+
+struct KaleidoscopeTriangle {
+    KaleidoscopeVertex v[3];
+};
+
 class KaleidoscopeEffect : public RenderableEffect
 {
     public:
@@ -74,4 +89,11 @@ class KaleidoscopeEffect : public RenderableEffect
         virtual xlEffectPanel *CreatePanel(wxWindow *parent) override;
         bool KaleidoscopeDone(const std::vector<std::vector<bool>>& current);
         std::pair<int, int> GetSourceLocation(int x, int y, const KaleidoscopeEdge& edge, int width, int height);
+        void RenderNew(const std::string& type, int xCentre, int yCentre, int size, int rotation, RenderBuffer& buffer);
+        static KaleidoscopeTriangle ComputeTriangle(const std::string& type, double cx, double cy, double size, double rotRad);
+        static std::pair<int, int> MapToSourceTriangle(double px, double py, const KaleidoscopeTriangle& tri, int maxIter);
+        static std::pair<int, int> MapToSourceNewSquare(double px, double py, double cx, double cy, double halfSize, double rotRad);
+        static void ReflectPointAcrossLine(double& px, double& py, double lx1, double ly1, double lx2, double ly2);
+        static double SignedDist(double px, double py, double lx1, double ly1, double lx2, double ly2);
+        static double ReflectCoord(double v, double halfSize);
 };

--- a/xLights/effects/KaleidoscopePanel.cpp
+++ b/xLights/effects/KaleidoscopePanel.cpp
@@ -140,7 +140,11 @@ KaleidoscopePanel::KaleidoscopePanel(wxWindow* parent,wxWindowID id,const wxPoin
 
     Choice_Kaleidoscope_Type->Append(_("Triangle"));
     Choice_Kaleidoscope_Type->Append(_("Square"));
-    //Choice_Kaleidoscope_Type->Append(_("Hexagon"));
+    Choice_Kaleidoscope_Type->Append(_("Square 2"));
+    Choice_Kaleidoscope_Type->Append(_("6-Fold"));
+    Choice_Kaleidoscope_Type->Append(_("8-Fold"));
+    Choice_Kaleidoscope_Type->Append(_("12-Fold"));
+    Choice_Kaleidoscope_Type->Append(_("Radial"));
     Choice_Kaleidoscope_Type->SetSelection(0);
 
 	Connect( wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&KaleidoscopePanel::OnVCChanged, 0, this );


### PR DESCRIPTION
New kaleidoscope types using per-pixel reverse mapping instead of the iterative edge-reflection approach. 
Each pixel independently maps back to the source region, eliminating thread safety issues with the parallel renderer and providing correct rotation support via value curves.

- Square 2: closed-form coordinate folding, no iteration needed
- 6-Fold: equilateral triangle tiling
- 8-Fold: right isosceles triangle tiling
- 12-Fold: 30-60-90 triangle tiling
- Radial: polar wedge reflection with rotational symmetry

Original square and triangle types I left for existing sequences (except for I believe a small bug where it had -= -.1  , looks like it should have been   -= 0.1

![example](https://github.com/user-attachments/assets/3352414d-e725-4079-84ee-fa1eef3e665b)

<img width="875" height="303" alt="image" src="https://github.com/user-attachments/assets/a6d84d1a-b149-4f8d-b284-6f8df33bfb82" />

<img width="955" height="397" alt="image" src="https://github.com/user-attachments/assets/7e6803f1-2bc0-4a97-a947-a1a09e8ecf4d" />

