### PR TITLE
Fix submodel effects rendering to wrong channels after parallel model loading

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2663,6 +2663,13 @@ void Model::UpdateChannels()
     Nodes.clear();
     InitModel();
 
+    // Submodels clone parent nodes during Setup, so when parent channels
+    // change (e.g. after RecalcStartChannels resolves chain dependencies),
+    // submodels must be re-setup to pick up the new ActChan values.
+    for (auto& sm : subModels) {
+        sm->Setup();
+    }
+
     IncrementChangeCount();
 }
 

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -271,8 +271,13 @@ void ModelManager::LoadModels(wxXmlNode* modelNode, int previewW, int previewH)
         }
     }
 
+    // Must recalculate start channels synchronously after parallel loading.
+    // During parallel_for, models with chained start channels (>ModelName:1)
+    // cannot resolve correctly because their dependency may not be loaded yet.
+    // RecalcStartChannels resolves chains in topological order now that all
+    // models are loaded.
+    RecalcStartChannels();
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ModelManager::LoadModels");
-    // RecalcStartChannels();
 }
 
 uint32_t ModelManager::GetLastChannel() const


### PR DESCRIPTION
## Problem

When models with chained start channels (`>ModelName:1`) have submodels (e.g. singing face props with mouth/eye submodels), the submodel effects render to the wrong channels — typically channel 0/1. This causes:

1. **Submodel effects don't appear on the correct model** — singing face effects (fire, shimmer, on, etc. on mouth/eye submodels) are missing from their parent model
2. **Ghost effects appear on unrelated models** — the misdirected pixel data shows up on whatever model occupies absolute channel 1 (e.g. a matrix)

This affects any model whose start channel is resolved via chaining (`>ModelName:1`) and has submodels with effects.

## Root Cause

Models are loaded in parallel via `parallel_for` in `ModelManager::LoadModels`. During parallel loading, each model's `Setup()` calls `UpdateChannels()`, which tries to resolve chained start channels. However, the dependency model may not be loaded yet, so `GetNumberFromChannelString` returns 1 (the default fallback). This gives the parent model `ActChan` values starting at 0.

Submodels are initialized during `Setup()` by cloning parent nodes — picking up these incorrect `ActChan=0` values.

`RecalcStartChannels()` later resolves the chains correctly in topological order and calls `UpdateChannels()` to rebuild parent nodes with correct `ActChan` values. **But `UpdateChannels()` did not re-setup submodels.** The submodels retained their stale `ActChan` values from the initial parallel load, causing rendered effects to write to channel 0 instead of the correct channels.

## Fix

Two changes:

1. **`Model::UpdateChannels()` now re-setups submodels** after rebuilding parent nodes. This ensures submodels always pick up current `ActChan` values whenever the parent's channels are recalculated.

2. **Restore synchronous `RecalcStartChannels()` call** in `ModelManager::LoadModels` after parallel loading completes. This was previously commented out, leaving only a deferred async work item. The synchronous call ensures all chain dependencies are resolved immediately while all models are available.

## Test plan

- [ ] Open a layout with models using chained start channels (`>ModelName:1`) that have submodels (e.g. singing face custom models with mouth/eye submodel ranges)
- [ ] Put effects on submodels (e.g. fire, shimmer, on effects on face submodels)  
- [ ] Render All — verify effects appear on the correct model, not on an unrelated model at channel 1
- [ ] Verify no performance regression from the synchronous `RecalcStartChannels()` call during model loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)