### PR TITLE
Handle crash when creating multiple strings in visualizer #5921

### DIFF
--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -400,7 +400,7 @@ void CustomModel::SetStringStartChannels(int NumberOfStrings, int StartChannel, 
         stringStartChan.clear();
         stringStartChan.resize(_strings);
         for (int i = 0; i < _strings; i++) {
-            int node = _indivStartNodes[i];
+            int node = (i < (int)_indivStartNodes.size()) ? _indivStartNodes[i] : 0;
             if (node == 0) {
                 node = ((ChannelsPerString * i) / GetNodeChannelCount(StringType)) + 1;
             }


### PR DESCRIPTION
When right-clicking a Custom Model in the Controller Visualizer and changing the string count, xLights would crash.
  This fix prevents the crash so the string count can be changed without issue.