### PR TITLE
Adding console_logger to special.options

### DIFF
--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -67,6 +67,8 @@
 
 #include <log.h>
 
+void ApplyLoggingSpecialOptions();
+
 // Thread class to ping a single controller
 class ControllerPingThread : public wxThread {
 public:
@@ -323,6 +325,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     SetFixFileShowDir(CurrentDir);
     SpecialOptions::StashShowDir(CurrentDir.ToStdString());
     SpecialOptions::GetOption("", ""); // resets special options
+    ApplyLoggingSpecialOptions();
 
     
     spdlog::debug("Show directory set to : {}.", (const char*)showDirectory.c_str());

--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -47,6 +47,7 @@
 
 #include <log.h>
 #include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/common.h"
 
 #ifdef LINUX
@@ -197,6 +198,22 @@ void InitialiseLogging(bool fromMain)
         spdlog::info("Start Time: {}.", ts.ToStdString());
         spdlog::info("Current working directory {}.", wxGetCwd().ToStdString());
     }
+}
+
+void ApplyLoggingSpecialOptions()
+{
+    if (SpecialOptions::GetOption("console_logger", "false") != "true") return;
+
+    static bool consoleApplied = false;
+    if (consoleApplied) return;
+    consoleApplied = true;
+
+    auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    // Called from SetDir on the main thread before rendering is active, so
+    // mutating sinks() here does not race with concurrent log calls.
+    spdlog::apply_all([&](std::shared_ptr<spdlog::logger> logger) {
+        logger->sinks().push_back(stdout_sink);
+    });
 }
 
 std::string DecodeOS(wxOperatingSystemId o)


### PR DESCRIPTION
Allows for sending the log output directly to the IDE console for those that wish to enable it. 

Example:
```
  <SpecialOptions>
      <Option name="console_logger" value="true"/>
  </SpecialOptions>
```