### PR TITLE
Change Layout Model Icons to resize on 4K/HiDPI monitors

### DIFF
--- a/xLights/ui/layout/LayoutPanel.cpp
+++ b/xLights/ui/layout/LayoutPanel.cpp
@@ -786,9 +786,10 @@ NewModelBitmapButton* LayoutPanel::AddModelButton(const std::string &type, const
     wxImage disImage = image.ConvertToDisabled();
     wxImage presImage = image.ConvertToDisabled(128);
 
-    wxImage img24 = image.Scale(24, 24, RESCALE_MODEL_BUTTON_QUALITY);
-    wxImage disImg24 = disImage.Scale(24, 24, RESCALE_MODEL_BUTTON_QUALITY);
-    wxImage presImg24 = presImage.Scale(24, 24, RESCALE_MODEL_BUTTON_QUALITY);
+   int iconSize = PreviewGLPanel->FromDIP(24);
+    wxImage img24 = image.Scale(iconSize, iconSize, RESCALE_MODEL_BUTTON_QUALITY);
+    wxImage disImg24 = disImage.Scale(iconSize, iconSize, RESCALE_MODEL_BUTTON_QUALITY);
+    wxImage presImg24 = presImage.Scale(iconSize, iconSize, RESCALE_MODEL_BUTTON_QUALITY);
 
     wxBitmapBundle bmp = wxBitmapBundle::FromBitmaps(img24, image);
     wxBitmapBundle disBmp = wxBitmapBundle::FromBitmaps(disImg24, disImage);


### PR DESCRIPTION
Changes model icons to resize icons to higher definition 4K and HiDPI resolution monitors. Buttons are really small on HiRES monitors.
<img width="916" height="488" alt="Screenshot 2026-04-03 171052" src="https://github.com/user-attachments/assets/e58d14ac-9259-48da-adf0-72fc52ad7ffb" />
<img width="1401" height="427" alt="Screenshot 2026-04-03 172143" src="https://github.com/user-attachments/assets/d8dbce74-54f1-46e8-99dd-ebffb25fb188" />
