### PR TITLE
6026 - Fixed a false positive error in the Check Sequence tool 

### DIFF
--- a/src-core/models/MeshObject.cpp
+++ b/src-core/models/MeshObject.cpp
@@ -141,9 +141,10 @@ std::list<std::string> MeshObject::CheckModelSettings()
             if (m.diffuse_texname.length() > 0) {
                 std::string texPath = (std::filesystem::path(objDir) / m.diffuse_texname).string();
                 if (!FileExists(texPath)) {
-                    std::string texPath2 = (std::filesystem::path(objDir) / m.diffuse_texname).string();
+                    std::string texName = std::filesystem::path(m.diffuse_texname).filename().string();
+                    std::string texPath2 = (std::filesystem::path(objDir) / texName).string();
                     if (!FileExists(texPath2)) {
-                        std::string texPath3 = (std::filesystem::path(objDir) / objStem / m.diffuse_texname).string();
+                        std::string texPath3 = (std::filesystem::path(objDir) / objStem / texName).string();
                         if (!FileExists(texPath3)) {
                             res.push_back(std::format("    ERR: Mesh object '{}' cant find texture file '{}'", GetName(), texPath));
                         }


### PR DESCRIPTION
Fixed a false positive error in the Check Sequence tool where Mesh objects would incorrectly report missing texture files. When a material file references a texture using a relative subfolder path, the lookup now correctly falls back to searching for just the filename in the mesh's directory, handling cases where the subfolder name differs from the actual folder name on disk (such as a name with spaces).