### PR TITLE
#5010 Move/skip fix. Screen/List now scrolls keeping effects visible

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
+<<<<<<< Updated upstream
 2026.06  May ??, 2026
     -enh (dkulp)                Add "Lossless RGB Video, *.mov" model export format — uncompressed RGB24
                                     in a mov container, bit-exact and decoded natively by AVFoundation,
@@ -45,6 +46,14 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                     using stale defaults of 0 for Start/End Radius/Width).
     -bug (dkulp)                Fix Pinwheel Rotation default mismatch between renderer and panel
 2026.05  April 9, 2026
+=======
+2026.05  April ??, 2026
+    -bug (AGFazio)              Sequencer scrolls to keep effects visible after moving them up/down with arrow keys
+    -bug (AGFazio)              Multi-selected effects can now skip over other effects when moved with arrow keys, matching single-effect behavior
+    -bug (derwin12)             Fix crash when adding/defining a curve on the last polyline segment
+    -bug (derwin12)             Make Random Effects Random Again
+    -bug (derwin12)             Cube Model ignored Direction
+>>>>>>> Stashed changes
     -enh (AGFazio)              Add face definition matrix previews
     -enh (derwin12)             Limit preset GIF output to 250 frames to prevent large gifs
     -enh (derwin12)             FPP media/file upload now reports missing source files as errors instead of silently skipping

--- a/src-ui-wx/ui/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/ui/sequencer/EffectsGrid.cpp
@@ -4046,9 +4046,11 @@ void EffectsGrid::MoveSelectedEffectUp(bool shift) {
 
             xlights->AbortRender();
             mSequenceElements->get_undo_mgr().CreateUndoStep();
+            int min_source_row = -1;
             for (int row = first_model_row + 1; row < mSequenceElements->GetRowInformationSize(); row++) {
                 EffectLayer* el2 = mSequenceElements->GetEffectLayer(row);
                 if (mSequenceElements->GetEffectLayer(row)->GetTaggedEffectCount() > 0) {
+                    if (min_source_row == -1) min_source_row = row;
                     EffectLayer* el1 = mSequenceElements->GetEffectLayer(row - move_offset);
                     int num_effects = mSequenceElements->GetEffectLayer(row)->GetEffectCount();
                     for (int i = 0; i < num_effects; ++i) {
@@ -4078,7 +4080,8 @@ void EffectsGrid::MoveSelectedEffectUp(bool shift) {
             mCellRangeSelected = false;
             mRangeStartCol = mRangeEndCol = mRangeStartRow = mRangeEndRow = -1;
             RaiseSelectedEffectChanged(mSelectedEffect, false, false);
-            MakeRowVisible(mSelectedRow - mSequenceElements->GetNumberOfTimingRows() - 1);
+            if (min_source_row != -1)
+                MakeRowVisible(min_source_row - first_model_row - move_offset);
             sendRenderDirtyEvent();
             Draw();
         }
@@ -4195,9 +4198,11 @@ void EffectsGrid::MoveSelectedEffectDown(bool shift) {
 
             xlights->AbortRender();
             mSequenceElements->get_undo_mgr().CreateUndoStep();
+            int max_source_row = -1;
             for (int row = last_row; row > first_model_row; row--) {
                 EffectLayer* el1 = mSequenceElements->GetEffectLayer(row - 1);
                 if (mSequenceElements->GetEffectLayer(row - 1)->GetTaggedEffectCount() > 0) {
+                    if (max_source_row == -1) max_source_row = row - 1;
                     EffectLayer* el2 = mSequenceElements->GetEffectLayer(row - 1 + move_offset);
                     int num_effects = mSequenceElements->GetEffectLayer(row - 1)->GetEffectCount();
                     for (int i = 0; i < num_effects; ++i) {
@@ -4228,7 +4233,10 @@ void EffectsGrid::MoveSelectedEffectDown(bool shift) {
             mRangeStartCol = mRangeEndCol = mRangeStartRow = mRangeEndRow = -1;
             RaiseSelectedEffectChanged(mSelectedEffect, false, false);
             sendRenderDirtyEvent();
-            MakeRowVisible(mSelectedRow - mSequenceElements->GetNumberOfTimingRows() + 1);
+            if (max_source_row != -1) {
+                MakeRowVisible((max_source_row - first_model_row) + move_offset + 1);
+                MakeRowVisible((max_source_row - first_model_row) + move_offset);
+            }
             Draw();
         }
     }


### PR DESCRIPTION
When using arrow keys to move selected efffects up or down, keeps them visible by scrolling screen.