### PR TITLE
#6077 Don't completely hide model/group list in Layout

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.06  May ??, 2026
+    -bug (dkulp)                Prevent model/group list in layout from being fully hidden by the splitter
     -bug (derwin12)             Fix unintended setting of Shadow Model For (#5634)
     -bug (derwin12)             Fix Wave effect speed from a value curve
     -bug (derwin12)             Improve Shape effect emoji rendering on Windows and Direction

--- a/src-ui-wx/ui/layout/LayoutPanel.cpp
+++ b/src-ui-wx/ui/layout/LayoutPanel.cpp
@@ -388,7 +388,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
 	LeftPanelSizer->AddGrowableCol(0);
 	LeftPanelSizer->AddGrowableRow(0);
 	ModelSplitter = new wxSplitterWindow(LeftPanel, ID_SPLITTERWINDOW1, wxDefaultPosition, wxDefaultSize, wxSP_3D|wxSP_LIVE_UPDATE, _T("ID_SPLITTERWINDOW1"));
-	ModelSplitter->SetMinimumPaneSize(100);
+	ModelSplitter->SetMinimumPaneSize(250);
 	ModelSplitter->SetSashGravity(0.5);
 	FirstPanel = new wxPanel(ModelSplitter, ID_PANEL3, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL3"));
 	FlexGridSizer4 = new wxFlexGridSizer(0, 1, 0, 0);

--- a/src-ui-wx/ui/layout/LayoutPanel.cpp
+++ b/src-ui-wx/ui/layout/LayoutPanel.cpp
@@ -388,7 +388,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
 	LeftPanelSizer->AddGrowableCol(0);
 	LeftPanelSizer->AddGrowableRow(0);
 	ModelSplitter = new wxSplitterWindow(LeftPanel, ID_SPLITTERWINDOW1, wxDefaultPosition, wxDefaultSize, wxSP_3D|wxSP_LIVE_UPDATE, _T("ID_SPLITTERWINDOW1"));
-	ModelSplitter->SetMinimumPaneSize(0);
+	ModelSplitter->SetMinimumPaneSize(100);
 	ModelSplitter->SetSashGravity(0.5);
 	FirstPanel = new wxPanel(ModelSplitter, ID_PANEL3, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL3"));
 	FlexGridSizer4 = new wxFlexGridSizer(0, 1, 0, 0);

--- a/src-ui-wx/wxsmith/LayoutPanel.wxs
+++ b/src-ui-wx/wxsmith/LayoutPanel.wxs
@@ -20,7 +20,7 @@
 							<growablerows>0</growablerows>
 							<object class="sizeritem">
 								<object class="wxSplitterWindow" name="ID_SPLITTERWINDOW1" variable="ModelSplitter" member="yes">
-									<minsize>0</minsize>
+									<minsize>100</minsize>
 									<style>wxSP_3D|wxSP_LIVE_UPDATE</style>
 									<object class="wxPanel" name="ID_PANEL3" variable="FirstPanel" member="yes">
 										<object class="wxFlexGridSizer" variable="FlexGridSizer4" member="no">

--- a/src-ui-wx/wxsmith/LayoutPanel.wxs
+++ b/src-ui-wx/wxsmith/LayoutPanel.wxs
@@ -20,7 +20,7 @@
 							<growablerows>0</growablerows>
 							<object class="sizeritem">
 								<object class="wxSplitterWindow" name="ID_SPLITTERWINDOW1" variable="ModelSplitter" member="yes">
-									<minsize>100</minsize>
+									<minsize>250</minsize>
 									<style>wxSP_3D|wxSP_LIVE_UPDATE</style>
 									<object class="wxPanel" name="ID_PANEL3" variable="FirstPanel" member="yes">
 										<object class="wxFlexGridSizer" variable="FlexGridSizer4" member="no">


### PR DESCRIPTION
Previously you could drag the seperator bar between the model/group list and model/group settings window to be able to completely hide the list. This change makes the model/group list a fixed size that can't be hidden. 