### PR TITLE
Add sequencer prop filter (#5066)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (derwin12)             Improve Shape effect emoji rendering on Windows and Direction (#5636)
     -bug (derwin12)             Fix 3D Spiral gradient flip when Rotation value curve crosses zero (#4807)
     -bug (AGFazio)              Fix Square and Smooth Circle model appearances not scaling with zoom in the layout view (#5849)
+    -enh (derwin12)             Add sequencer prop filter to quickly jump to a prop by name (#5066)
     -enh (derwin12)             Add "Small" option to Model Handle Size preference (#3583)
     -enh (derwin12)             Add Render Styles to Select Effects Window (#4848)
     -enh (dkulp)                Add "Lossless RGB Video, *.mov" model export format — uncompressed RGB24

--- a/src-ui-wx/ui/app-shell/KeyBindings.cpp
+++ b/src-ui-wx/ui/app-shell/KeyBindings.cpp
@@ -159,7 +159,8 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
     { "JUKEBOX_BTN_3", KBSCOPE::Sequence },
     { "JUKEBOX_BTN_4", KBSCOPE::Sequence },
     { "JUKEBOX_BTN_5", KBSCOPE::Sequence },
-    { "FPP_CONNECT", KBSCOPE::All }
+    { "FPP_CONNECT", KBSCOPE::All },
+    { "FILTER_SEQUENCER", KBSCOPE::Sequence }
 };
 
 static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
@@ -208,6 +209,7 @@ static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
     { "SELECT_ALL_NO_TIMING", "Select all effects but not timing marks." },
     { "SHOW_PRESETS", "Show the effect presets panel." },
     { "SEARCH_TOGGLE", "Toggle display of the effect search panel." },
+    { "FILTER_SEQUENCER", "Show/hide the sequencer prop filter box to jump to a prop." },
     { "PERSPECTIVES_TOGGLE", "Toggle display of the perspectives panel." },
     { "EFFECT_UPDATE", "Apply the current effect settings to all selected effects." },
     { "COLOR_UPDATE", "Apply the current colors to all selected effects." },
@@ -373,6 +375,7 @@ const std::vector<KeyBinding> DefaultBindings =
     KeyBinding("F11", false, "COLOR_DROPPER_TOGGLE", false, true),
     KeyBinding("F12", false, "FOCUS_SEQUENCER"),
     KeyBinding("F11", false, "SEARCH_TOGGLE", true),
+    KeyBinding("f", false, "FILTER_SEQUENCER", true),
     KeyBinding("F12", false, "PERSPECTIVES_TOGGLE", true),
     KeyBinding("F5", false, "EFFECT_UPDATE"),
     KeyBinding("", false, "COLOR_UPDATE"),

--- a/src-ui-wx/ui/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/MainSequencer.cpp
@@ -45,6 +45,7 @@ const wxWindowID MainSequencer::ID_SCROLLBAR_EFFECTS_VERTICAL = wxNewId();
 const wxWindowID MainSequencer::ID_CHECKBOX1 = wxNewId();
 const wxWindowID MainSequencer::ID_SCROLLBAR_EFFECT_GRID_HORZ = wxNewId();
 //*)
+const wxWindowID MainSequencer::ID_TEXTCTRL_SEQ_FILTER = wxNewId();
 
 wxDEFINE_EVENT(EVT_HORIZ_SCROLL, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SCROLL_RIGHT, wxCommandEvent);
@@ -313,10 +314,26 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     CheckBox_SuspendRender->SetFont(fnt);
 #endif
 
+    // Sequencer prop filter - hidden by default
+    _seqFilterCtrl = new wxSearchCtrl(this, ID_TEXTCTRL_SEQ_FILTER,
+        wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    _seqFilterCtrl->SetDescriptiveText("Filter props...");
+    _seqFilterCtrl->ShowCancelButton(true);
+    _seqFilterCtrl->Bind(wxEVT_TEXT, &MainSequencer::OnSeqFilterText, this);
+    _seqFilterCtrl->Bind(wxEVT_TEXT_ENTER, &MainSequencer::OnSeqFilterEnter, this);
+    _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &MainSequencer::OnSeqFilterCancel, this);
+    _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &MainSequencer::OnSeqFilterEnter, this);
+    _seqFilterCtrl->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& e) {
+        if (e.GetKeyCode() == WXK_ESCAPE) { ShowSeqFilterPanel(false); }
+        else { e.Skip(); }
+    });
+    FlexGridSizer2->Add(_seqFilterCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 2);
+    _seqFilterCtrl->Hide();
+
     spdlog::debug("                Create time display control");
     timeDisplay = new TimeDisplayControl(this, wxID_ANY);
     FlexGridSizer2->Add(timeDisplay, 1, wxALL |wxEXPAND, 0);
-    FlexGridSizer2->AddGrowableRow(3);
+    FlexGridSizer2->AddGrowableRow(4);
 
     FlexGridSizer2->Fit(this);
     FlexGridSizer2->SetSizeHints(this);
@@ -828,6 +845,9 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->OnMenuItemSelectEffectSelected(e);
             }
+            else if (type == "FILTER_SEQUENCER") {
+                ShowSeqFilterPanel(!_seqFilterCtrl->IsShown());
+            }
             else if (type == "PERSPECTIVES_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHidePerspectivesWindow(e);
@@ -889,6 +909,15 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
 
 void MainSequencer::OnCharHook(wxKeyEvent& event)
 {
+    // wxSearchCtrl on Windows contains inner children; walk ancestry to check
+    if (_seqFilterCtrl != nullptr && _seqFilterCtrl->IsShown()) {
+        wxWindow* evtWin = dynamic_cast<wxWindow*>(event.GetEventObject());
+        while (evtWin != nullptr) {
+            if (evtWin == _seqFilterCtrl) { event.Skip(); return; }
+            evtWin = evtWin->GetParent();
+        }
+    }
+
     wxChar uc = event.GetKeyCode();
 
     if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive())
@@ -1053,6 +1082,15 @@ void MainSequencer::OnKeyDown(wxKeyEvent& event)
 
 void MainSequencer::OnChar(wxKeyEvent& event)
 {
+    // wxSearchCtrl on Windows contains inner children; walk ancestry to check
+    if (_seqFilterCtrl != nullptr && _seqFilterCtrl->IsShown()) {
+        wxWindow* evtWin = dynamic_cast<wxWindow*>(event.GetEventObject());
+        while (evtWin != nullptr) {
+            if (evtWin == _seqFilterCtrl) { event.Skip(); return; }
+            evtWin = evtWin->GetParent();
+        }
+    }
+
     wxChar uc = event.GetUnicodeKey();
 
     if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive())
@@ -2166,4 +2204,70 @@ void MainSequencer::ScrollToRow(int row)
 void MainSequencer::OnCheckBox_SuspendRenderClick(wxCommandEvent& event)
 {
     ToggleRender(CheckBox_SuspendRender->IsChecked());
+}
+
+void MainSequencer::ShowSeqFilterPanel(bool show)
+{
+    if (_seqFilterCtrl == nullptr) return;
+    if (show) {
+        _seqFilterCtrl->Show();
+        GetSizer()->Layout();
+        _seqFilterCtrl->SetFocus();
+        _seqFilterCtrl->SelectAll();
+    } else {
+        _seqFilterCtrl->Hide();
+        _seqFilterCtrl->SetValue("");
+        GetSizer()->Layout();
+        ApplySeqFilter("");
+        PanelEffectGrid->SetFocus();
+    }
+}
+
+void MainSequencer::ApplySeqFilter(const wxString& filter)
+{
+    if (mSequenceElements == nullptr) return;
+
+    int view = mSequenceElements->GetCurrentView();
+    int count = mSequenceElements->GetElementCount(view);
+
+    if (filter.IsEmpty()) {
+        for (int i = 0; i < count; i++) {
+            Element* el = mSequenceElements->GetElement(i, view);
+            if (el == nullptr) continue;
+            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
+            el->SetVisible(true);
+        }
+        spdlog::debug("SeqFilter: cleared");
+    } else {
+        wxString lower = filter.Lower();
+        for (int i = 0; i < count; i++) {
+            Element* el = mSequenceElements->GetElement(i, view);
+            if (el == nullptr) continue;
+            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
+            el->SetVisible(wxString(el->GetName()).Lower().Contains(lower));
+        }
+        spdlog::debug("SeqFilter: filter='{}'", filter.ToStdString());
+    }
+
+    mSequenceElements->PopulateRowInformation();
+    mSequenceElements->SetFirstVisibleModelRow(0);
+    mSequenceElements->PopulateVisibleRowInformation();
+    UpdateEffectGridVerticalScrollBar();
+    PanelEffectGrid->ForceRefresh();
+    PanelRowHeadings->Refresh();
+}
+
+void MainSequencer::OnSeqFilterText(wxCommandEvent& event)
+{
+    ApplySeqFilter(_seqFilterCtrl->GetValue().Trim());
+}
+
+void MainSequencer::OnSeqFilterEnter(wxCommandEvent& event)
+{
+    ShowSeqFilterPanel(false);
+}
+
+void MainSequencer::OnSeqFilterCancel(wxCommandEvent& event)
+{
+    ShowSeqFilterPanel(false);
 }

--- a/src-ui-wx/ui/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/MainSequencer.cpp
@@ -2259,7 +2259,10 @@ void MainSequencer::ApplySeqFilter(const wxString& filter)
 
 void MainSequencer::OnSeqFilterText(wxCommandEvent& event)
 {
-    ApplySeqFilter(_seqFilterCtrl->GetValue().Trim());
+    wxString filter = _seqFilterCtrl->GetValue();
+    filter.Trim();
+    filter.Trim(false);
+    ApplySeqFilter(filter);
 }
 
 void MainSequencer::OnSeqFilterEnter(wxCommandEvent& event)

--- a/src-ui-wx/ui/sequencer/MainSequencer.h
+++ b/src-ui-wx/ui/sequencer/MainSequencer.h
@@ -14,6 +14,7 @@
 #include <wx/sizer.h>
 #include <wx/panel.h>
 #include <wx/scrolbar.h>
+#include <wx/srchctrl.h>
 #include "RowHeading.h"
 #include "EffectsGrid.h"
 #include "Waveform.h"
@@ -126,6 +127,7 @@ class MainSequencer: public wxPanel
 		static const wxWindowID ID_CHECKBOX1;
 		static const wxWindowID ID_SCROLLBAR_EFFECT_GRID_HORZ;
 		//*)
+    static const wxWindowID ID_TEXTCTRL_SEQ_FILTER;
 
 	private:
 
@@ -157,6 +159,13 @@ class MainSequencer: public wxPanel
 
         wxWindow *mParent;
         SequenceElements* mSequenceElements;
+        wxSearchCtrl* _seqFilterCtrl = nullptr;
+
+        void ShowSeqFilterPanel(bool show);
+        void ApplySeqFilter(const wxString& filter);
+        void OnSeqFilterText(wxCommandEvent& event);
+        void OnSeqFilterCancel(wxCommandEvent& event);
+        void OnSeqFilterEnter(wxCommandEvent& event);
         bool mCanUndo;
         bool mPasteByCell;
         std::string _savedTopModel;


### PR DESCRIPTION
Add sequencer prop filter to quickly jump to a prop by name (#5066) Defaults to ctrl+f but can be defined in the keybindings.