### PR TITLE
#663 Layout tab: dockable model/group panels

### DIFF
--- a/src-ui-wx/ui/layout/LayoutPanel.cpp
+++ b/src-ui-wx/ui/layout/LayoutPanel.cpp
@@ -124,8 +124,9 @@ inline wxCursor CursorTypeToWx(CursorType ct) {
 // Layout sizing constants
 static constexpr int kPaneMinHeight      = 400; // minimum height for ModelList / ModelSettings panes
 static constexpr int kListHeightFallback = 200; // fallback half-height used when container is hidden
-// Left-panel minimum width is computed dynamically in UpdateLayoutSplitter() as
-// 18% of the splitter width (floor 150px) so it scales with screen resolution.
+static constexpr int kMinPaneWidth       = 150; // absolute floor for left-panel sash drag (px)
+// Left-panel target width is computed dynamically in UpdateLayoutSplitter() as
+// 18% of the splitter width (floor kMinPaneWidth) so it scales with screen resolution.
 
 // Custom AUI manager with two enhancements:
 // 1. Floating frames always have wxCLOSE_BOX, regardless of pane CloseButton flag
@@ -239,8 +240,7 @@ public:
                     int maxY = (containerH - kPaneMinHeight) + m_actionOffset.y + dockRect.y;
                     if (maxY < minY) maxY = minY; // degenerate: window too small for both minimums
 
-                    if (event.m_y < minY) event.m_y = minY;
-                    if (event.m_y > maxY) event.m_y = maxY;
+                    event.m_y = std::clamp(event.m_y, minY, maxY);
                 }
             }
         }
@@ -1118,7 +1118,10 @@ LayoutPanel::~LayoutPanel()
             _savedFloatingPerspective.clear();
         }
         // Dock any floating panels before saving so the perspective always
-        // starts with panels docked on the next launch.
+        // starts with panels docked on the next launch.  GetAllPanes() returns
+        // a reference to the internal m_panes array; mutations here are read
+        // directly by SavePerspective() without needing Update() (which would
+        // try to render to a partially-destroyed window).
         wxAuiPaneInfoArray& panes = layout_mgr->GetAllPanes();
         for (size_t i = 0; i < panes.GetCount(); i++) {
             if (panes[i].IsFloating()) {
@@ -9044,10 +9047,9 @@ void LayoutPanel::DockAll() {
         // force the sash to the target width — that would leave no room to drag left.
         CallAfter([this]() {
             if (SplitterWindow2->IsSplit()) {
-                constexpr int kMinPane = 150;
-                if (SplitterWindow2->GetSashPosition() < kMinPane)
-                    SplitterWindow2->SetSashPosition(kMinPane);
-                SplitterWindow2->SetMinimumPaneSize(kMinPane);
+                if (SplitterWindow2->GetSashPosition() < kMinPaneWidth)
+                    SplitterWindow2->SetSashPosition(kMinPaneWidth);
+                SplitterWindow2->SetMinimumPaneSize(kMinPaneWidth);
             }
         });
     }
@@ -9082,8 +9084,7 @@ void LayoutPanel::ResetToDefaults() {
     int targetW = LeftPanelMinWidth();
     SplitterWindow2->SetSashGravity(0.5);
     SplitterWindow2->SetSashPosition(targetW);
-    constexpr int kMinPane = 150;
-    SplitterWindow2->SetMinimumPaneSize(kMinPane);
+    SplitterWindow2->SetMinimumPaneSize(kMinPaneWidth);
 
     // Clear saved state so the defaults persist across restarts.
     wxConfigBase* config = wxConfigBase::Get();
@@ -9119,10 +9120,9 @@ void LayoutPanel::OnLayoutPaneClose(wxAuiManagerEvent& event) {
         // force the sash to the target width — that would leave no room to drag left.
         CallAfter([this]() {
             if (SplitterWindow2->IsSplit()) {
-                constexpr int kMinPane = 150;
-                if (SplitterWindow2->GetSashPosition() < kMinPane)
-                    SplitterWindow2->SetSashPosition(kMinPane);
-                SplitterWindow2->SetMinimumPaneSize(kMinPane);
+                if (SplitterWindow2->GetSashPosition() < kMinPaneWidth)
+                    SplitterWindow2->SetSashPosition(kMinPaneWidth);
+                SplitterWindow2->SetMinimumPaneSize(kMinPaneWidth);
             }
         });
     });
@@ -9196,7 +9196,6 @@ void LayoutPanel::UpdateLayoutSplitter() {
         // All panes are floating or hidden — collapse the left panel so the
         // preview canvas expands to fill the full available width.
         if (SplitterWindow2->IsSplit()) {
-            _savedSashPos = SplitterWindow2->GetSashPosition();
             SplitterWindow2->SetMinimumPaneSize(0);
             SplitterWindow2->Unsplit(LeftPanel);
         }
@@ -9204,18 +9203,17 @@ void LayoutPanel::UpdateLayoutSplitter() {
         // Target width: 18% of splitter width, floor 150px.  This is where the
         // left panel is placed when (re-)docking.  The hard minimum below is
         // intentionally smaller so the user can drag the sash further left.
-        int targetW  = LeftPanelMinWidth(); // 18% of total, floor 150px
-        constexpr int kMinPane = 150;       // drag floor — smaller than target
+        int targetW  = LeftPanelMinWidth(); // 18% of total, floor kMinPaneWidth
 
         if (!SplitterWindow2->IsSplit()) {
             SplitterWindow2->SplitVertically(LeftPanel, PreviewGLPanel, targetW);
         } else {
             int sash = SplitterWindow2->GetSashPosition();
-            if (sash < kMinPane) {
-                SplitterWindow2->SetSashPosition(kMinPane);
+            if (sash < kMinPaneWidth) {
+                SplitterWindow2->SetSashPosition(kMinPaneWidth);
             }
         }
-        SplitterWindow2->SetMinimumPaneSize(kMinPane);
+        SplitterWindow2->SetMinimumPaneSize(kMinPaneWidth);
     }
 }
 

--- a/src-ui-wx/ui/layout/LayoutPanel.cpp
+++ b/src-ui-wx/ui/layout/LayoutPanel.cpp
@@ -9,7 +9,8 @@
  **************************************************************/
 
  //(*InternalHeaders(LayoutPanel)
- #include <wx/button.h>
+ #include <wx/stopwatch.h>
+#include <wx/button.h>
  #include <wx/checkbox.h>
  #include <wx/choice.h>
  #include <wx/font.h>
@@ -31,6 +32,7 @@
 #include <wx/srchctrl.h>
 #include <pugixml.hpp>
 #include <fstream>
+#include <functional>
 #include <spdlog/fmt/fmt.h>
 #include <regex>
 #include <sstream>
@@ -100,6 +102,7 @@
 #include <log.h>
 
 #include <wx/cursor.h>
+#include <wx/aui/floatpane.h>
 #include "utils/CursorType.h"
 
 inline wxCursor CursorTypeToWx(CursorType ct) {
@@ -117,6 +120,153 @@ inline wxCursor CursorTypeToWx(CursorType ct) {
 }
 
 #include <set>
+
+// Layout sizing constants
+static constexpr int kPaneMinHeight      = 400; // minimum height for ModelList / ModelSettings panes
+static constexpr int kListHeightFallback = 200; // fallback half-height used when container is hidden
+// Left-panel minimum width is computed dynamically in UpdateLayoutSplitter() as
+// 18% of the splitter width (floor 150px) so it scales with screen resolution.
+
+// Custom AUI manager with two enhancements:
+// 1. Floating frames always have wxCLOSE_BOX, regardless of pane CloseButton flag
+//    (lets us suppress the AUI caption close button while keeping the OS X button).
+// 2. Center-docked panes can be dragged to float — wxAUI hardcodes an early return
+//    for center panes in OnLeftDown, which we work around by tracking the drag
+//    ourselves and calling StartPaneDrag once the threshold is exceeded.
+class LayoutAuiManager : public wxAuiManager {
+public:
+    // Called (via CallAfter) after a drag-initiated float or dock completes.
+    std::function<void()> m_onPaneStateChanged;
+
+    LayoutAuiManager(wxWindow* managed_wnd, unsigned int flags)
+        : wxAuiManager(managed_wnd, flags) {}
+
+    wxAuiFloatingFrame* CreateFloatingFrame(wxWindow* parent, const wxAuiPaneInfo& p) override {
+        wxAuiFloatingFrame* frame = new wxAuiFloatingFrame(parent, this, p, wxID_ANY,
+            wxRESIZE_BORDER | wxSYSTEM_MENU | wxCAPTION |
+            wxFRAME_NO_TASKBAR | wxFRAME_FLOAT_ON_PARENT |
+            wxCLIP_CHILDREN | wxCLOSE_BOX);
+        // Prevent floating panels from being resized smaller than a usable area.
+        frame->SetMinClientSize(wxSize(300, kPaneMinHeight));
+        return frame;
+    }
+
+    // Track a pending center-pane drag until the system drag threshold is met.
+    bool m_pendingCenterDrag = false;
+    wxWindow* m_centerDragWindow = nullptr;
+    wxPoint m_centerDragStart;
+    wxPoint m_centerDragOffset;
+
+    void OnLeftDown(wxMouseEvent& event) {
+        wxAuiDockUIPart* part = HitTest(event.GetX(), event.GetY());
+        if (part &&
+            (part->type == wxAuiDockUIPart::typeCaption ||
+             part->type == wxAuiDockUIPart::typeGripper) &&
+            part->dock &&
+            part->dock->dock_direction == wxAUI_DOCK_CENTER &&
+            part->pane && !part->pane->IsToolbar() &&
+            (GetFlags() & wxAUI_MGR_ALLOW_FLOATING) &&
+            part->pane->IsFloatable()) {
+            m_pendingCenterDrag = true;
+            m_centerDragWindow = part->pane->window;
+            m_centerDragStart = wxPoint(event.GetX(), event.GetY());
+            m_centerDragOffset = wxPoint(event.GetX() - part->rect.x,
+                                         event.GetY() - part->rect.y);
+        }
+        event.Skip();
+    }
+
+    void OnMotion(wxMouseEvent& event) {
+        if (m_pendingCenterDrag && m_centerDragWindow) {
+            int dx = std::abs(event.GetX() - m_centerDragStart.x);
+            int dy = std::abs(event.GetY() - m_centerDragStart.y);
+            int tx = wxSystemSettings::GetMetric(wxSYS_DRAG_X, GetManagedWindow());
+            int ty = wxSystemSettings::GetMetric(wxSYS_DRAG_Y, GetManagedWindow());
+            static const int kDefaultDragThreshold = 4;
+            if (tx < 0) tx = kDefaultDragThreshold;
+            if (ty < 0) ty = kDefaultDragThreshold;
+            if (dx > tx || dy > ty) {
+                m_pendingCenterDrag = false;
+                wxWindow* wnd = m_centerDragWindow;
+                wxPoint offset = m_centerDragOffset;
+                m_centerDragWindow = nullptr;
+                wxAuiPaneInfo& pane = GetPane(wnd);
+                if (pane.IsOk() && pane.IsFloatable()) {
+                    pane.Float();
+                    Update();
+                    StartPaneDrag(wnd, offset);
+                }
+                return;  // don't let wxAuiManager::OnMotion run this cycle
+            }
+        }
+
+        // Clamp sash Y to enforce minimum heights for both docked panels.
+        // Runs before wxAuiManager::OnMotion so the base class sees the clamped position.
+        // Works for whichever center pane is currently visible (ModelSettings or
+        // ModelGroupSettings).
+        if (m_action == actionResize) {
+            // m_actionPart may be null after Update(); refresh from the stored drag index.
+            wxAuiDockUIPart* part = m_actionPart;
+            if (part == nullptr && m_currentDragItem >= 0 &&
+                m_currentDragItem < static_cast<int>(m_uiParts.GetCount()))
+                part = &m_uiParts.Item(m_currentDragItem);
+
+            if (part != nullptr &&
+                part->type == wxAuiDockUIPart::typeDockSizer &&
+                part->dock != nullptr &&
+                part->dock->dock_direction == wxAUI_DOCK_TOP) {
+
+                wxAuiPaneInfo& listPane = GetPane("ModelList");
+                bool centerVisible = false;
+                for (const char* nm : {"ModelSettings", "ModelGroupSettings"}) {
+                    wxAuiPaneInfo& p = GetPane(nm);
+                    if (p.IsOk() && p.IsShown() && !p.IsFloating()) {
+                        centerVisible = true;
+                        break;
+                    }
+                }
+                if (listPane.IsOk() && listPane.IsShown() && !listPane.IsFloating() &&
+                    centerVisible) {
+                    const wxRect& dockRect = part->dock->rect;
+                    int containerH = GetManagedWindow()->GetClientSize().GetHeight();
+
+                    // new_size = (event.m_y - m_actionOffset.y) - dockRect.y
+                    // Enforce new_size >= kPaneMinHeight
+                    //   =>  event.m_y >= kPaneMinHeight + m_actionOffset.y + dockRect.y
+                    // Enforce new_size <= containerH - kPaneMinHeight
+                    //   =>  event.m_y <= containerH - kPaneMinHeight + m_actionOffset.y + dockRect.y
+                    int minY = kPaneMinHeight + m_actionOffset.y + dockRect.y;
+                    int maxY = (containerH - kPaneMinHeight) + m_actionOffset.y + dockRect.y;
+                    if (maxY < minY) maxY = minY; // degenerate: window too small for both minimums
+
+                    if (event.m_y < minY) event.m_y = minY;
+                    if (event.m_y > maxY) event.m_y = maxY;
+                }
+            }
+        }
+
+        event.Skip();
+    }
+
+    void OnLeftUp(wxMouseEvent& event) {
+        m_pendingCenterDrag = false;
+        m_centerDragWindow = nullptr;
+        event.Skip();
+        // After the base-class finishes processing the mouse-up (which may have
+        // docked or floated a pane), update the splitter state.
+        if (m_onPaneStateChanged) {
+            GetManagedWindow()->CallAfter(m_onPaneStateChanged);
+        }
+    }
+
+    wxDECLARE_EVENT_TABLE();
+};
+
+wxBEGIN_EVENT_TABLE(LayoutAuiManager, wxAuiManager)
+    EVT_LEFT_DOWN(LayoutAuiManager::OnLeftDown)
+    EVT_MOTION(LayoutAuiManager::OnMotion)
+    EVT_LEFT_UP(LayoutAuiManager::OnLeftUp)
+wxEND_EVENT_TABLE()
 
 #define MODELCOLNAME "Model/Group"
 #define STARTCHANCOLNAME "Start Chan"
@@ -447,7 +597,6 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
 	SplitterWindow2->SplitVertically(LeftPanel, PreviewGLPanel);
 	FlexGridSizerPreview->Add(SplitterWindow2, 1, wxALL|wxEXPAND, 1);
 	SetSizer(FlexGridSizerPreview);
-	FlexGridSizerPreview->SetSizeHints(this);
 
 	Connect(ID_NOTEBOOK_OBJECTS, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, (wxObjectEventFunction)&LayoutPanel::OnNotebook_ObjectsPageChanged);
 	Connect(ID_CHECKBOX_3D, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&LayoutPanel::OnCheckBox_3DClick);
@@ -634,12 +783,128 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
         SplitterWindow2->SetSashGravity(0.0);
         SplitterWindow2->SetSashPosition(sp);
     }
-    if (msp != -1) {
-        ModelSplitter->SetSashGravity(0.0);
-        ModelSplitter->SetSashPosition(msp);
-    } else {
-        ModelSplitter->SetSashPosition(200);
+    // Replace ModelSplitter with an AUI-managed container.
+    wxSizer* lps = LeftPanel->GetSizer();
+
+    // Detach the old toolbar row from LeftPanelSizer — controls move to the preview.
+    {
+        wxSizer* fgs3 = CheckBox_3D->GetContainingSizer();
+        if (fgs3) {
+            fgs3->Detach(CheckBox_3D);
+            fgs3->Detach(CheckBoxOverlap);
+            lps->Detach(fgs3);
+            delete fgs3;
+        }
+        lps->Detach(ButtonSavePreview);
     }
+
+    ModelPanelContainer = new wxPanel(LeftPanel, wxID_ANY);
+    lps->Replace(ModelSplitter, ModelPanelContainer);
+    lps->Layout();
+
+    FirstPanel->Reparent(ModelPanelContainer);
+    propertyEditor->Reparent(ModelPanelContainer);
+    ModelGroupWindow->Reparent(ModelPanelContainer);
+
+    ModelSplitter->Destroy();
+    ModelSplitter = nullptr;
+
+    LayoutAuiManager* new_layout_mgr = new LayoutAuiManager(ModelPanelContainer, wxAUI_MGR_ALLOW_FLOATING | wxAUI_MGR_DEFAULT);
+    new_layout_mgr->m_onPaneStateChanged = [this]() {
+        UpdateLayoutSplitter();
+    };
+    layout_mgr = new_layout_mgr;
+    ModelPanelContainer->Bind(wxEVT_AUI_PANE_CLOSE, &LayoutPanel::OnLayoutPaneClose, this);
+
+    FirstPanel->SetMinSize(wxSize(0, kPaneMinHeight));
+    int listHeight = (msp > 0) ? msp : kListHeightFallback;
+    layout_mgr->AddPane(FirstPanel, wxAuiPaneInfo()
+        .Name("ModelList")
+        .Caption("Groups/Models List")
+        .CaptionVisible(true)
+        .CloseButton(false)
+        .Floatable(true)
+        .Dockable(true)
+        .TopDockable(true)
+        .BottomDockable(true)
+        .LeftDockable(false)
+        .RightDockable(false)
+        .Top().Layer(0).Row(0)
+        .BestSize(-1, listHeight)
+        .FloatingSize(600, 1000)
+        .MinSize(300, kPaneMinHeight));
+
+    propertyEditor->SetMinSize(wxSize(0, kPaneMinHeight));
+    layout_mgr->AddPane(propertyEditor, wxAuiPaneInfo()
+        .Name("ModelSettings")
+        .Caption("Groups/Models Settings")
+        .CaptionVisible(true)
+        .CloseButton(false)
+        .Floatable(true)
+        .TopDockable(false)
+        .BottomDockable(false)
+        .LeftDockable(false)
+        .RightDockable(false)
+        .Center()
+        .FloatingSize(600, 1000)
+        .MinSize(0, kPaneMinHeight));
+
+    layout_mgr->AddPane(ModelGroupWindow, wxAuiPaneInfo()
+        .Name("ModelGroupSettings")
+        .Caption("Model Group Settings")
+        .CaptionVisible(false)
+        .CloseButton(false)
+        .Floatable(true)
+        .TopDockable(false)
+        .BottomDockable(false)
+        .LeftDockable(false)
+        .RightDockable(false)
+        .Center()
+        .FloatingSize(600, 1000)
+        .MinSize(-1, 50)
+        .Hide());
+
+    wxString auiPerspective = config->Read("LayoutAUIPerspective2", wxEmptyString);
+    if (!auiPerspective.empty()) {
+        layout_mgr->LoadPerspective(auiPerspective);
+    }
+    // Always reapply settings that LoadPerspective overwrites via SafeSet()
+    layout_mgr->GetPane("ModelList").MinSize(300, kPaneMinHeight).CaptionVisible(true).Caption("Groups/Models List")
+        .TopDockable(true).BottomDockable(true).LeftDockable(false).RightDockable(false);
+    layout_mgr->GetPane("ModelSettings").MinSize(0, kPaneMinHeight).CaptionVisible(true).Caption("Groups/Models Settings")
+        .TopDockable(false).BottomDockable(false).LeftDockable(false).RightDockable(false);
+    layout_mgr->GetPane("ModelGroupSettings").TopDockable(false).BottomDockable(false).LeftDockable(false).RightDockable(false);
+    // Always start with the two main panels docked and visible regardless of
+    // what was saved.  If the saved perspective had them floating or hidden
+    // (e.g. closed while on another tab, or crashed), force them back to
+    // docked+shown.  ModelGroupSettings stays hidden — it is only shown by
+    // ShowPropGrid(false) when a model group is selected.
+    layout_mgr->GetPane("ModelList").Top().Dock().Show();
+    layout_mgr->GetPane("ModelSettings").Center().Dock().Show();
+    {
+        wxAuiPaneInfo& mgp = layout_mgr->GetPane("ModelGroupSettings");
+        if (mgp.IsOk() && mgp.IsFloating()) mgp.Center().Dock(); // dock but keep hidden
+    }
+    layout_mgr->Update();
+    // Enable splitter auto-collapse / expand logic now that AUI is fully set up.
+    _auiInitialized = true;
+    UpdateLayoutSplitter();
+
+    // Move 3D / Overlap / Save controls to a bar at the bottom-center of the
+    // layout preview canvas, below the GL canvas.
+    wxPanel* layoutControlsBar = new wxPanel(PreviewGLPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_SIMPLE);
+    CheckBox_3D->Reparent(layoutControlsBar);
+    CheckBoxOverlap->Reparent(layoutControlsBar);
+    ButtonSavePreview->Reparent(layoutControlsBar);
+    {
+        wxBoxSizer* lcbSizer = new wxBoxSizer(wxHORIZONTAL);
+        lcbSizer->Add(CheckBox_3D, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+        lcbSizer->Add(CheckBoxOverlap, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+        lcbSizer->Add(ButtonSavePreview, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+        layoutControlsBar->SetSizer(lcbSizer);
+    }
+    PreviewGLPanel->GetSizer()->Add(layoutControlsBar, 0, wxALIGN_CENTER_HORIZONTAL|wxBOTTOM, 3);
+    PreviewGLPanel->Layout();
 
     TreeListViewModels->SetColumnWidth(0, wxCOL_WIDTH_AUTOSIZE);
     TreeListViewModels->SetColumnWidth(1, TreeListViewModels->WidthFor(CHNUMWIDTH));
@@ -843,9 +1108,32 @@ void LayoutPanel::SaveModelsListColumns()
 
 LayoutPanel::~LayoutPanel()
 {
-    if (ModelGroupWindow != nullptr) {
+    if (layout_mgr != nullptr) {
+        // If panels were hidden by HideFloatingPanes() (tab-switch stash), restore
+        // their info so we can inspect and dock them below.  Pass false to skip
+        // the UI update — we are in the destructor and the window may be partially
+        // destroyed already.
+        if (!_savedFloatingPerspective.empty()) {
+            layout_mgr->LoadPerspective(_savedFloatingPerspective, false);
+            _savedFloatingPerspective.clear();
+        }
+        // Dock any floating panels before saving so the perspective always
+        // starts with panels docked on the next launch.
+        wxAuiPaneInfoArray& panes = layout_mgr->GetAllPanes();
+        for (size_t i = 0; i < panes.GetCount(); i++) {
+            if (panes[i].IsFloating()) {
+                if (panes[i].name == "ModelList") {
+                    panes[i].Top().Dock();
+                } else {
+                    panes[i].Center().Dock();
+                }
+            }
+        }
         wxConfigBase* config = wxConfigBase::Get();
-        config->Write("LayoutModelSplitterSash", ModelSplitter->GetSashPosition());
+        config->Write("LayoutAUIPerspective2", layout_mgr->SavePerspective());
+        layout_mgr->UnInit();
+        delete layout_mgr;
+        layout_mgr = nullptr;
     }
 
     SaveModelsListColumns();
@@ -5264,9 +5552,9 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
             wxLogNull logNo; // kludge: avoid "error 0" message from wxWidgets after new file is written
             wxString fn = wxFileSelector(_("Choose output file"), wxEmptyString, name, wxEmptyString, "Custom Model files (*.xmodel)|*.xmodel", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
             if (!fn.IsEmpty()) {
-                FileSerializingVisitor visitor(ToStdString(fn), true /*exporting*/);
+                FileSerializingVisitor visitor(fn.ToStdString(), true /*exporting*/);
                 if (!visitor.IsOpen())
-                    DisplayError("Unable to create file " + ToStdString(fn));
+                    DisplayError("Unable to create file " + fn.ToStdString());
                 else
                     md->ExportAsCustomXModel(visitor);
             }
@@ -5280,9 +5568,9 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
             wxLogNull logNo; // kludge: avoid "error 0" message from wxWidgets after new file is written
             wxString fn = wxFileSelector(_("Choose output file"), wxEmptyString, name, wxEmptyString, "Custom Model files (*.xmodel)|*.xmodel", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
             if (!fn.IsEmpty()) {
-                FileSerializingVisitor visitor(ToStdString(fn), true /*exporting*/);
+                FileSerializingVisitor visitor(fn.ToStdString(), true /*exporting*/);
                 if (!visitor.IsOpen())
-                    DisplayError("Unable to create file " + ToStdString(fn));
+                    DisplayError("Unable to create file " + fn.ToStdString());
                 else
                     md->ExportAsCustomXModel3D(visitor);
             }
@@ -5331,7 +5619,7 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
         if (!filename.IsEmpty()) {
             ObtainAccessToURL(filename);
             pugi::xml_document doc = serializer.SerializeModel(md, true);
-            doc.save_file(ToStdString(filename).c_str());
+            doc.save_file(filename.ToStdString().c_str());
         }
     } else if (event.GetId() == ID_PREVIEW_DELETE_ACTIVE) {
         DeleteCurrentPreview();
@@ -7802,9 +8090,9 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
             wxLogNull logNo; // kludge: avoid "error 0" message from wxWidgets after new file is written
             wxString fn = wxFileSelector(_("Choose output file"), wxEmptyString, name, wxEmptyString, "Custom Model files (*.xmodel)|*.xmodel", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
             if (!fn.IsEmpty()) {
-                FileSerializingVisitor visitor(ToStdString(fn), true /*exporting*/);
+                FileSerializingVisitor visitor(fn.ToStdString(), true /*exporting*/);
                 if (!visitor.IsOpen())
-                    DisplayError("Unable to create file " + ToStdString(fn));
+                    DisplayError("Unable to create file " + fn.ToStdString());
                 else
                     md->ExportAsCustomXModel(visitor);
             }
@@ -7818,9 +8106,9 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
             wxLogNull logNo; // kludge: avoid "error 0" message from wxWidgets after new file is written
             wxString fn = wxFileSelector(_("Choose output file"), wxEmptyString, name, wxEmptyString, "Custom Model files (*.xmodel)|*.xmodel", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
             if (!fn.IsEmpty()) {
-                FileSerializingVisitor visitor(ToStdString(fn), true /*exporting*/);
+                FileSerializingVisitor visitor(fn.ToStdString(), true /*exporting*/);
                 if (!visitor.IsOpen())
-                    DisplayError("Unable to create file " + ToStdString(fn));
+                    DisplayError("Unable to create file " + fn.ToStdString());
                 else
                     md->ExportAsCustomXModel3D(visitor);
             }
@@ -7867,7 +8155,7 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
         if (!filename.IsEmpty()) {
             ObtainAccessToURL(filename);
             pugi::xml_document doc = serializer.SerializeModel(md, true);
-            doc.save_file(ToStdString(filename).c_str());
+            doc.save_file(filename.ToStdString().c_str());
         }
     } else if (event.GetId() == ID_PREVIEW_DELETE_ACTIVE) {
         DeleteCurrentPreview();
@@ -8719,16 +9007,228 @@ void LayoutPanel::RenameCurrentPreview()
                                                   OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::RenameCurrentPreview");
 }
 
+void LayoutPanel::DockAll() {
+    if (layout_mgr == nullptr) return;
+    // If floating panes were stashed by HideFloatingPanes() (e.g. startup with
+    // Layout tab already active, or called from a non-Layout context), restore
+    // them now so the loop below sees them as floating+shown and can dock them.
+    if (!_savedFloatingPerspective.empty()) {
+        RestoreFloatingPanes();
+    }
+    wxAuiPaneInfoArray& panes = layout_mgr->GetAllPanes();
+    bool hasModelList = false;
+    bool update = false;
+    for (size_t i = 0; i < panes.GetCount(); i++) {
+        if (panes[i].IsFloating() && panes[i].IsShown()) {
+            if (panes[i].name == "ModelList") {
+                panes[i].Top().Dock();
+                hasModelList = true;
+            } else {
+                panes[i].Center().Dock();
+            }
+            update = true;
+        }
+    }
+    if (update) {
+        // Restore LeftPanel visibility before measuring and laying out so that
+        // ModelPanelContainer has a real size when wxAUI performs the layout.
+        UpdateLayoutSplitter();
+        if (hasModelList) {
+            int halfHeight = ModelPanelContainer->GetSize().GetHeight() / 2;
+            if (halfHeight < kListHeightFallback) halfHeight = kListHeightFallback;
+            layout_mgr->GetPane("ModelList").BestSize(-1, halfHeight);
+        }
+        layout_mgr->Update();
+        // Defer minimum-size enforcement until after pending size events from
+        // SplitVertically / layout_mgr->Update() have been processed.  Do NOT
+        // force the sash to the target width — that would leave no room to drag left.
+        CallAfter([this]() {
+            if (SplitterWindow2->IsSplit()) {
+                constexpr int kMinPane = 150;
+                if (SplitterWindow2->GetSashPosition() < kMinPane)
+                    SplitterWindow2->SetSashPosition(kMinPane);
+                SplitterWindow2->SetMinimumPaneSize(kMinPane);
+            }
+        });
+    }
+}
+
+void LayoutPanel::ResetToDefaults() {
+    if (!_auiInitialized || layout_mgr == nullptr) return;
+
+    // Discard any stashed floating perspective — we are rebuilding from scratch.
+    _savedFloatingPerspective.clear();
+
+    // Dock all panels to their default positions: ModelList at top, ModelSettings
+    // in the center, ModelGroupSettings docked but hidden.
+    layout_mgr->GetPane("ModelList").Top().Layer(0).Row(0).Dock().Show();
+    layout_mgr->GetPane("ModelSettings").Center().Dock().Show();
+    {
+        wxAuiPaneInfo& mgp = layout_mgr->GetPane("ModelGroupSettings");
+        if (mgp.IsOk()) mgp.Center().Dock().Hide();
+    }
+
+    // Split ModelList and ModelSettings evenly (50/50).
+    int halfHeight = ModelPanelContainer->GetSize().GetHeight() / 2;
+    if (halfHeight < kListHeightFallback) halfHeight = kListHeightFallback;
+    layout_mgr->GetPane("ModelList").BestSize(-1, halfHeight);
+
+    // Ensure the left panel is visible in the splitter.
+    UpdateLayoutSplitter();
+    layout_mgr->Update();
+
+    // Reset the vertical sash to the default 18% position with proportional
+    // gravity (same behaviour as first launch with no saved config).
+    int targetW = LeftPanelMinWidth();
+    SplitterWindow2->SetSashGravity(0.5);
+    SplitterWindow2->SetSashPosition(targetW);
+    constexpr int kMinPane = 150;
+    SplitterWindow2->SetMinimumPaneSize(kMinPane);
+
+    // Clear saved state so the defaults persist across restarts.
+    wxConfigBase* config = wxConfigBase::Get();
+    config->DeleteEntry("LayoutAUIPerspective2");
+    config->DeleteEntry("LayoutMainSplitterSash");
+    config->DeleteEntry("LayoutModelSplitterSash");
+}
+
+void LayoutPanel::OnLayoutPaneClose(wxAuiManagerEvent& event) {
+    event.Veto();
+    wxAuiPaneInfo* pane = event.GetPane();
+    wxString name = pane->name;
+    CallAfter([this, name]() {
+        if (layout_mgr == nullptr) return;
+        wxAuiPaneInfo& p = layout_mgr->GetPane(name);
+        if (!p.IsOk()) return;
+        if (name == "ModelList") {
+            p.Top().Dock();
+        } else {
+            p.Center().Dock();
+        }
+        // Restore LeftPanel visibility before measuring and laying out so that
+        // ModelPanelContainer has a real size when wxAUI performs the layout.
+        UpdateLayoutSplitter();
+        if (name == "ModelList") {
+            int halfHeight = ModelPanelContainer->GetSize().GetHeight() / 2;
+            if (halfHeight < kListHeightFallback) halfHeight = kListHeightFallback;
+            p.BestSize(-1, halfHeight);
+        }
+        layout_mgr->Update();
+        // Defer minimum-size enforcement until after pending size events from
+        // SplitVertically / layout_mgr->Update() have been processed.  Do NOT
+        // force the sash to the target width — that would leave no room to drag left.
+        CallAfter([this]() {
+            if (SplitterWindow2->IsSplit()) {
+                constexpr int kMinPane = 150;
+                if (SplitterWindow2->GetSashPosition() < kMinPane)
+                    SplitterWindow2->SetSashPosition(kMinPane);
+                SplitterWindow2->SetMinimumPaneSize(kMinPane);
+            }
+        });
+    });
+}
+
+void LayoutPanel::HideFloatingPanes() {
+    if (layout_mgr == nullptr) return;
+    wxAuiPaneInfoArray& panes = layout_mgr->GetAllPanes();
+    bool hasFloating = false;
+    for (size_t i = 0; i < panes.GetCount(); i++) {
+        if (panes[i].IsFloating() && panes[i].IsShown()) {
+            hasFloating = true;
+            break;
+        }
+    }
+    if (!hasFloating) return;
+    _savedFloatingPerspective = layout_mgr->SavePerspective();
+    for (size_t i = 0; i < panes.GetCount(); i++) {
+        if (panes[i].IsFloating() && panes[i].IsShown()) {
+            panes[i].Hide();
+        }
+    }
+    layout_mgr->Update();
+}
+
+void LayoutPanel::RestoreFloatingPanes() {
+    if (layout_mgr == nullptr || _savedFloatingPerspective.empty()) return;
+    layout_mgr->LoadPerspective(_savedFloatingPerspective);
+    // Reapply pane configuration that LoadPerspective may overwrite via SafeSet(),
+    // but preserve the visibility restored from the saved perspective.
+    wxAuiPaneInfo& modelListPane = layout_mgr->GetPane("ModelList");
+    if (modelListPane.IsOk()) {
+        modelListPane.MinSize(300, kPaneMinHeight).CaptionVisible(true).Caption("Groups/Models List")
+            .TopDockable(true).BottomDockable(true).LeftDockable(false).RightDockable(false);
+    }
+    wxAuiPaneInfo& modelSettingsPane = layout_mgr->GetPane("ModelSettings");
+    if (modelSettingsPane.IsOk()) {
+        modelSettingsPane.MinSize(0, kPaneMinHeight).CaptionVisible(true).Caption("Groups/Models Settings")
+            .TopDockable(false).BottomDockable(false).LeftDockable(false).RightDockable(false);
+    }
+    wxAuiPaneInfo& modelGroupSettingsPane = layout_mgr->GetPane("ModelGroupSettings");
+    if (modelGroupSettingsPane.IsOk()) {
+        modelGroupSettingsPane.MinSize(0, kPaneMinHeight).CaptionVisible(false)
+            .TopDockable(false).BottomDockable(false).LeftDockable(false).RightDockable(false);
+    }
+    layout_mgr->Update();
+    _savedFloatingPerspective.clear();
+    UpdateLayoutSplitter();
+}
+
+int LayoutPanel::LeftPanelMinWidth() const
+{
+    int totalW = SplitterWindow2->GetClientSize().GetWidth();
+    return std::max(totalW * 18 / 100, 150);
+}
+
+void LayoutPanel::UpdateLayoutSplitter() {
+    if (!_auiInitialized || layout_mgr == nullptr) return;
+
+    // Check if any relevant pane is docked (shown and not floating).
+    bool anyDocked = false;
+    for (const char* nm : {"ModelList", "ModelSettings", "ModelGroupSettings"}) {
+        wxAuiPaneInfo& p = layout_mgr->GetPane(nm);
+        if (p.IsOk() && p.IsShown() && !p.IsFloating()) {
+            anyDocked = true;
+            break;
+        }
+    }
+
+    if (!anyDocked) {
+        // All panes are floating or hidden — collapse the left panel so the
+        // preview canvas expands to fill the full available width.
+        if (SplitterWindow2->IsSplit()) {
+            _savedSashPos = SplitterWindow2->GetSashPosition();
+            SplitterWindow2->SetMinimumPaneSize(0);
+            SplitterWindow2->Unsplit(LeftPanel);
+        }
+    } else {
+        // Target width: 18% of splitter width, floor 150px.  This is where the
+        // left panel is placed when (re-)docking.  The hard minimum below is
+        // intentionally smaller so the user can drag the sash further left.
+        int targetW  = LeftPanelMinWidth(); // 18% of total, floor 150px
+        constexpr int kMinPane = 150;       // drag floor — smaller than target
+
+        if (!SplitterWindow2->IsSplit()) {
+            SplitterWindow2->SplitVertically(LeftPanel, PreviewGLPanel, targetW);
+        } else {
+            int sash = SplitterWindow2->GetSashPosition();
+            if (sash < kMinPane) {
+                SplitterWindow2->SetSashPosition(kMinPane);
+            }
+        }
+        SplitterWindow2->SetMinimumPaneSize(kMinPane);
+    }
+}
+
 void LayoutPanel::ShowPropGrid(bool show) {
-    if( !mPropGridActive && show ) {
-        ModelSplitter->ReplaceWindow(ModelGroupWindow, propertyEditor);
-        ModelGroupWindow->Hide();
-        propertyEditor->Show();
+    if (!mPropGridActive && show) {
+        layout_mgr->GetPane("ModelGroupSettings").Hide();
+        layout_mgr->GetPane("ModelSettings").Show();
+        layout_mgr->Update();
         mPropGridActive = true;
-    } else if( mPropGridActive && !show) {
-        ModelSplitter->ReplaceWindow(propertyEditor, ModelGroupWindow);
-        propertyEditor->Hide();
-        ModelGroupWindow->Show();
+    } else if (mPropGridActive && !show) {
+        layout_mgr->GetPane("ModelSettings").Hide();
+        layout_mgr->GetPane("ModelGroupSettings").Show();
+        layout_mgr->Update();
         mPropGridActive = false;
     }
 }

--- a/src-ui-wx/ui/layout/LayoutPanel.h
+++ b/src-ui-wx/ui/layout/LayoutPanel.h
@@ -137,7 +137,6 @@ class LayoutPanel: public wxPanel
         wxPanel* ModelPanelContainer = nullptr;
         wxAuiManager* layout_mgr = nullptr;
         wxString _savedFloatingPerspective;
-        int _savedSashPos = -1;
         bool _auiInitialized = false;
         void UpdateLayoutSplitter();
         int LeftPanelMinWidth() const; // 18% of splitter width, floor 150px

--- a/src-ui-wx/ui/layout/LayoutPanel.h
+++ b/src-ui-wx/ui/layout/LayoutPanel.h
@@ -35,6 +35,7 @@ class wxStaticText;
 
 #include "ui/setup/ControllerConnectionDialog.h"
 #include "ui/shared/utils/xlPropertyGrid.h"
+#include <wx/aui/aui.h>
 
 #include <memory>
 #include <sstream>
@@ -133,6 +134,13 @@ class LayoutPanel: public wxPanel
 
 		wxScrolledWindow* ViewObjectWindow = nullptr;
 		wxScrolledWindow* ModelGroupWindow = nullptr;
+        wxPanel* ModelPanelContainer = nullptr;
+        wxAuiManager* layout_mgr = nullptr;
+        wxString _savedFloatingPerspective;
+        int _savedSashPos = -1;
+        bool _auiInitialized = false;
+        void UpdateLayoutSplitter();
+        int LeftPanelMinWidth() const; // 18% of splitter width, floor 150px
 		wxTreeListCtrl* TreeListViewModels = nullptr;
         wxDataViewModel* TreeListMiewInternalModel = nullptr;
         bool ctrlFPressed = false;
@@ -297,6 +305,11 @@ class LayoutPanel: public wxPanel
         void OnPropertyGridContextMenu(wxCommandEvent& event);
         void OnModelFilterTextChanged(wxCommandEvent& event);
         void OnModelFilterCancelBtn(wxCommandEvent& event);
+        void DockAll();
+        void ResetToDefaults();
+        void HideFloatingPanes();
+        void RestoreFloatingPanes();
+        void OnLayoutPaneClose(wxAuiManagerEvent& event);
 
 		DECLARE_EVENT_TABLE()
 

--- a/src-ui-wx/ui/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/tabSequencer.cpp
@@ -218,6 +218,11 @@ void xLightsFrame::CreateSequencer()
 
 void xLightsFrame::ResetWindowsToDefaultPositions(wxCommandEvent& event)
 {
+    if (Notebook1->GetSelection() == LAYOUTTAB) {
+        layoutPanel->ResetToDefaults();
+        return;
+    }
+
     m_mgr->GetPane("ModelPreview").Caption("Model Preview").Dock().Left().Layer(1).Show();
     m_mgr->GetPane("HousePreview").Caption("House Preview").Dock().Left().Layer(1).Show();
     m_mgr->GetPane("EffectAssist").Caption("Effect Assist").Dock().Left().Layer(1).Hide();
@@ -3281,7 +3286,11 @@ void xLightsFrame::ShowHideSelectEffectsWindow(wxCommandEvent& event)
 
 void xLightsFrame::OnMenuDockAllSelected(wxCommandEvent& event)
 {
-    ResetAllSequencerWindows();
+    if (Notebook1->GetSelection() == LAYOUTTAB) {
+        layoutPanel->DockAll();
+    } else {
+        ResetAllSequencerWindows();
+    }
 }
 
 void xLightsFrame::ShowHideBufferSettingsWindow(wxCommandEvent& event)

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -3025,6 +3025,7 @@ void xLightsFrame::OnNotebook1PageChanging(wxAuiNotebookEvent& event)
         layoutPanel->UnSelectAllModels();
     } else if (event.GetOldSelection() == LAYOUTTAB) {
         _housePreviewPanel->Set3d(layoutPanel->Is3d());
+        layoutPanel->HideFloatingPanes();
     }
     if (event.GetSelection() == SETUPTAB) {
         DoSetupWork();
@@ -3047,6 +3048,7 @@ void xLightsFrame::OnNotebook1PageChanged1(wxAuiNotebookEvent& event)
         SetStatusText(_(""));
         MenuItem_File_Save->Enable(true);
         MenuItem_File_Save->SetItemLabel("Save Layout\tCTRL-s");
+        layoutPanel->RestoreFloatingPanes();
     } else if (pagenum == NEWSEQUENCER) {
         InitSequencer();
         ShowHideAllSequencerWindows(true);


### PR DESCRIPTION
The Groups/Models List and Groups/Models Settings panels in the Layout tab can now be floated and re-docked independently.

- ModelList can float or dock Top/Bottom; LeftDockable/RightDockable disabled
- Vertical sash defaults to 18% of window width when panels are docked; draggable left to a 150px floor (was stuck at minimum after re-docking)
- View > Windows > Dock All docks all floating layout panels when on Layout tab
- View > Windows > Reset to Defaults resets to 50/50 even split at 18% width and clears saved config so defaults persist across restarts
- Floating panels are hidden when switching away from the Layout tab and restored on return
- Drag threshold null-guard for platforms where wxSystemSettings::GetMetric returns -1