### PR TITLE
 Fix Twinkle Steps value curve capped to 400 max (#4347) [skip ci]

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,8 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.06  May ??, 2026
-    -bug (AGFazio)               Fix submodels in a group showing at wrong indent level in sequencer element list
+    -bug (derwin12)             Fix Twinkle Steps value curve capped at 100 instead of 400 (#4347)
+    -bug (AGFazio)              Fix submodels in a group showing at wrong indent level in sequencer element list
     -bug (derwin12)             Fix downloaded/imported models always getting start channel 1 (#6075)
     -bug (derwin12)             Fix unintended setting of ShadowModelFor (#5634)
     -bug (dkulp)                Fix macOS 11/12 launch crash "Symbol not found..." due to using
@@ -51,12 +52,6 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                     for newly-created effects, Shape StartSize matches JSON (1 instead of 5),
                                     Faces FaceDefinition fallback is now consistently "Default" across CheckEffectSettings
                                     and Render, Metal Spirals now matches CPU Spirals default for Rotation/Thickness.
-    -bug (dkulp)                Fix Guitar BaseWaveFactor/StringWaveFactor losing user values after JSON panel migration.
-                                    Old E_SLIDER_*WaveFactor int values are migrated forward to E_TEXTCTRL_*WaveFactor floats.
-    -bug (dkulp)                Fix Circles effect Collide checkbox removal causing silent behavior change in old sequences.
-                                    Sequences with Collide=1 are now migrated to Bounce=1 to preserve their non-wrapping render.
-    -bug (dkulp)                Fix Shockwave effect rendering as invisible on macOS for new effects (Metal backend was
-                                    using stale defaults of 0 for Start/End Radius/Width).
     -bug (dkulp)                Fix Pinwheel Rotation default mismatch between renderer and panel
     -bug (derwin12)             Fix crash after using Join in the SubModels dialog. (#6064)
     -change (dkulp)             Effect panels are now built from JSON metadata files in resources/effectmetadata/

--- a/resources/effectmetadata/Twinkle.json
+++ b/resources/effectmetadata/Twinkle.json
@@ -22,7 +22,7 @@
             "default": 30,
             "min": 2,
             "max": 400,
-            "vcMax": 100,
+            "vcMax": 400,
             "valueCurve": true,
             "lockable": true
         },

--- a/src-core/effects/TwinkleEffect.cpp
+++ b/src-core/effects/TwinkleEffect.cpp
@@ -87,7 +87,7 @@ public:
 
 bool TwinkleEffect::needToAdjustSettings(const std::string& version) {
     // give the base class a chance to adjust any settings
-    return RenderableEffect::needToAdjustSettings(version) || IsVersionOlder("2020.57", version);
+    return RenderableEffect::needToAdjustSettings(version) || IsVersionOlder("2020.57", version) || IsVersionOlder("2026.06", version);
 }
 
 void TwinkleEffect::adjustSettings(const std::string& version, Effect* effect, bool removeDefaults) {
@@ -99,6 +99,20 @@ void TwinkleEffect::adjustSettings(const std::string& version, Effect* effect, b
     if (IsVersionOlder("2020.57", version)) {
         SettingsMap& settings = effect->GetSettings();
         settings["E_CHOICE_Twinkle_Style"] = "Old Render Method";
+    }
+    if (IsVersionOlder("2026.06", version)) {
+        // TWINKLE_STEPS_MAX was raised from 100 to 400. UpgradeValueCurve is
+        // disabled for this setting (GetSettingVCDivisor returns 0xFFFF) to
+        // prevent it from rescaling old values into the new range. Instead,
+        // migrate here: preserve the stored values but widen the Max to 400.
+        SettingsMap& settings = effect->GetSettings();
+        std::string vc = settings.Get("E_VALUECURVE_Twinkle_Steps", "");
+        if (vc.find("VALUECURVE") != std::string::npos && vc.find("Max=100.00") != std::string::npos) {
+            ValueCurve v;
+            v.Deserialise(vc, true); // holdminmax=true: keep values, don't rescale
+            v.SetLimits(sStepsVCMin, sStepsVCMax); // extend to new limits (2..400)
+            settings["E_VALUECURVE_Twinkle_Steps"] = v.Serialise();
+        }
     }
 }
 

--- a/src-core/effects/TwinkleEffect.h
+++ b/src-core/effects/TwinkleEffect.h
@@ -21,17 +21,25 @@ public:
     virtual void adjustSettings(const std::string& version, Effect* effect, bool removeDefaults = true) override;
     virtual void Render(Effect* effect, const SettingsMap& settings, RenderBuffer& buffer) override;
     virtual int DrawEffectBackground(const Effect* e, int x1, int y1, int x2, int y2, xlVertexColorAccumulator& backgrounds, xlColor* colorMask, bool ramps) override;
+    virtual int GetSettingVCDivisor(const std::string& name) const override
+    {
+        // Return 0xFFFF to opt out of UpgradeValueCurve auto-rescaling for
+        // Twinkle_Steps. Old sequences stored Max=100; adjustSettings migrates
+        // them to Max=400 while preserving the actual step values.
+        if (name == "E_VALUECURVE_Twinkle_Steps")
+            return 0xFFFF;
+        return RenderableEffect::GetSettingVCDivisor(name);
+    }
 
     // Cached from Twinkle.json by OnMetadataLoaded().
     static int sCountDefault;
     static int sCountMin;
     static int sCountMax;
     static int sStepsDefault;
-    // Twinkle_Steps slider goes 2..400 but the VC is clamped to 2..100 via the
-    // JSON `vcMax` field. sStepsVCMin/Max are the bounds passed to
-    // GetValueCurveInt at render time (so existing VC data in [2, 100]
-    // stays compatible). The base class GetSettingVCMin/Max also honors
-    // vcMin/vcMax so UpgradeValueCurve gets the same answer.
+    // Twinkle_Steps slider and VC both go 2..400 (vcMax=400 in JSON).
+    // GetSettingVCDivisor returns 0xFFFF to disable UpgradeValueCurve
+    // auto-rescaling; adjustSettings manually migrates old VCs (Max=100)
+    // to the new limits (Max=400) without changing their stored values.
     static int sStepsVCMin;
     static int sStepsVCMax;
     static bool sStrobeDefault;


### PR DESCRIPTION
The slider was increased quite a while ago but the value curve was not done at the time. (#4347). [skip ci]