### PR TITLE
3829 Add alternate audio tracks w vu meter and vc access (#3820) [skip ci]

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (derwin12)             Improve Shape effect emoji rendering on Windows and Direction (#5636)
     -bug (derwin12)             Fix 3D Spiral gradient flip when Rotation value curve crosses zero (#4807)
     -bug (AGFazio)              Fix Square and Smooth Circle model appearances not scaling with zoom in the layout view (#5849)
+    -enh (derwin12)             Add alternate audio tracks support incl waveform, VU Meter and value curve access. (#3820)
     -enh (derwin12)             Allow selecting audio from a sequence package (zip/piz/xsqz) in Sequence Settings (#5630)
     -enh (derwin12)             Add sequencer prop filter to quickly jump to a prop by name (#5066)
     -enh (derwin12)             Add "Small" option to Model Handle Size preference (#3583)

--- a/resources/effectmetadata/VUMeter.json
+++ b/resources/effectmetadata/VUMeter.json
@@ -216,6 +216,16 @@
             "max": 100,
             "valueCurve": true,
             "lockable": true
+        },
+        {
+            "id": "VUMeter_AudioTrack",
+            "label": "Audio Track",
+            "description": "Selects which audio track drives this VU Meter. 'Main' uses the sequence's primary audio; additional tracks are listed if alternate audio tracks have been added in Sequence Settings.",
+            "type": "enum",
+            "controlType": "choice",
+            "options": [],
+            "default": "",
+            "lockable": true
         }
     ]
 }

--- a/src-core/effects/VUMeterEffect.cpp
+++ b/src-core/effects/VUMeterEffect.cpp
@@ -23,6 +23,7 @@
 
 #include "../render/Effect.h"
 #include "../render/RenderBuffer.h"
+#include "../render/ValueCurve.h"
 #include "UtilClasses.h"
 #include "../models/Model.h"
 #include "../utils/FileUtils.h"
@@ -307,6 +308,11 @@ void VUMeterEffect::RenameTimingTrack(std::string oldname, std::string newname, 
 
 void VUMeterEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBuffer& buffer)
 {
+    // Resolve alternate audio track override
+    std::string audioTrack = SettingsMap.Get("CHOICE_VUMeter_AudioTrack", "");
+    if (audioTrack == "Main") audioTrack = "";
+    buffer._mediaOverride = audioTrack.empty() ? nullptr : ValueCurve::GetAltAudio(audioTrack);
+
     float oset = buffer.GetEffectTimeIntervalPosition();
     Render(buffer,
            effect->GetParentEffectLayer()->GetParentElement()->GetSequenceElements(),

--- a/src-core/render/RenderBuffer.cpp
+++ b/src-core/render/RenderBuffer.cpp
@@ -44,6 +44,9 @@ void RenderBuffer::SetFrameTimeInMs(int i) { frameTimeInMs = i; }
 
 AudioManager* RenderBuffer::GetMedia() const
 {
+	if (_mediaOverride != nullptr) {
+		return _mediaOverride;
+	}
 	if (renderContext == nullptr) {
 		return nullptr;
 	}

--- a/src-core/render/RenderBuffer.h
+++ b/src-core/render/RenderBuffer.h
@@ -497,6 +497,8 @@ public:
     void *gpuRenderData = nullptr;
 
     uint32_t perModelIndex = 0;
+    AudioManager* _mediaOverride = nullptr; // set by effects to use an alt audio track
+
 private:
     PixelBufferClass *parent;
     const Model *model;

--- a/src-core/render/SequenceFile.cpp
+++ b/src-core/render/SequenceFile.cpp
@@ -72,6 +72,7 @@ SequenceFile::~SequenceFile()
         delete audio;
         audio = nullptr;
     }
+    ValueCurve::ClearAltAudio();
     for (auto& t : alt_tracks) {
         delete t.audio;
         t.audio = nullptr;
@@ -272,8 +273,23 @@ void SequenceFile::SetAltTrackPath(const std::string& ShowDir, int idx, const st
 void SequenceFile::SetAltTrackShortname(int idx, const std::string& name)
 {
     if (idx < 0 || idx >= (int)alt_tracks.size()) return;
-    std::string oldName = GetAltTrackDisplayName(idx);
-    alt_tracks[idx].shortname = name;
+    // Ensure the chosen display name is unique across all other tracks.
+    // If there is a collision, append _2, _3, … until it is unique.
+    std::string candidate = name;
+    int suffix = 2;
+    bool collision = true;
+    while (collision) {
+        collision = false;
+        for (int i = 0; i < (int)alt_tracks.size(); i++) {
+            if (i == idx) continue;
+            if (GetAltTrackDisplayName(i) == candidate) {
+                collision = true;
+                candidate = name + "_" + std::to_string(suffix++);
+                break;
+            }
+        }
+    }
+    alt_tracks[idx].shortname = candidate;
     // Rebuild alt audio map since display name may have changed
     ValueCurve::ClearAltAudio();
     for (int i = 0; i < (int)alt_tracks.size(); i++) {

--- a/src-core/render/SequenceFile.cpp
+++ b/src-core/render/SequenceFile.cpp
@@ -72,6 +72,11 @@ SequenceFile::~SequenceFile()
         delete audio;
         audio = nullptr;
     }
+    for (auto& t : alt_tracks) {
+        delete t.audio;
+        t.audio = nullptr;
+    }
+    alt_tracks.clear();
 }
 
 std::string SequenceFile::GetExt() const
@@ -219,6 +224,68 @@ void SequenceFile::ClearMediaFile()
     SetHeaderInfo(HEADER_INFO_TYPES::ARTIST, "");
     SetHeaderInfo(HEADER_INFO_TYPES::ALBUM, "");
     SetHeaderInfo(HEADER_INFO_TYPES::URL, "");
+}
+
+void SequenceFile::AddAltTrack(const std::string& ShowDir, const std::string& path, const std::string& shortname)
+{
+    AlternateAudioTrack t;
+    t.shortname = shortname;
+    t.path = FileUtils::FixFile(ShowDir, path);
+    if (::FileExists(t.path)) {
+        ObtainAccessToURL(t.path);
+        t.audio = new AudioManager(t.path, GetFrameMS());
+    }
+    alt_tracks.push_back(std::move(t));
+    ValueCurve::SetAltAudio(GetAltTrackDisplayName((int)alt_tracks.size() - 1), alt_tracks.back().audio);
+}
+
+void SequenceFile::RemoveAltTrack(int idx)
+{
+    if (idx < 0 || idx >= (int)alt_tracks.size()) return;
+    std::string displayName = GetAltTrackDisplayName(idx);
+    delete alt_tracks[idx].audio;
+    alt_tracks.erase(alt_tracks.begin() + idx);
+    // Rebuild alt audio map in ValueCurve
+    ValueCurve::ClearAltAudio();
+    for (int i = 0; i < (int)alt_tracks.size(); i++) {
+        ValueCurve::SetAltAudio(GetAltTrackDisplayName(i), alt_tracks[i].audio);
+    }
+}
+
+void SequenceFile::SetAltTrackPath(const std::string& ShowDir, int idx, const std::string& path)
+{
+    if (idx < 0 || idx >= (int)alt_tracks.size()) return;
+    delete alt_tracks[idx].audio;
+    alt_tracks[idx].audio = nullptr;
+    alt_tracks[idx].path = FileUtils::FixFile(ShowDir, path);
+    if (::FileExists(alt_tracks[idx].path)) {
+        ObtainAccessToURL(alt_tracks[idx].path);
+        alt_tracks[idx].audio = new AudioManager(alt_tracks[idx].path, GetFrameMS());
+    }
+    // Rebuild ValueCurve alt audio map
+    ValueCurve::ClearAltAudio();
+    for (int i = 0; i < (int)alt_tracks.size(); i++) {
+        ValueCurve::SetAltAudio(GetAltTrackDisplayName(i), alt_tracks[i].audio);
+    }
+}
+
+void SequenceFile::SetAltTrackShortname(int idx, const std::string& name)
+{
+    if (idx < 0 || idx >= (int)alt_tracks.size()) return;
+    std::string oldName = GetAltTrackDisplayName(idx);
+    alt_tracks[idx].shortname = name;
+    // Rebuild alt audio map since display name may have changed
+    ValueCurve::ClearAltAudio();
+    for (int i = 0; i < (int)alt_tracks.size(); i++) {
+        ValueCurve::SetAltAudio(GetAltTrackDisplayName(i), alt_tracks[i].audio);
+    }
+}
+
+std::string SequenceFile::GetAltTrackDisplayName(int idx) const
+{
+    if (idx < 0 || idx >= (int)alt_tracks.size()) return "";
+    if (!alt_tracks[idx].shortname.empty()) return alt_tracks[idx].shortname;
+    return "Track" + std::to_string(idx + 1);
 }
 
 void SequenceFile::SetRenderMode(const std::string& mode)
@@ -396,6 +463,21 @@ std::optional<pugi::xml_document> SequenceFile::LoadSequence(const std::string& 
                             spdlog::error("LoadSequence: audio file does not exist.");
                         }
                     }
+                } else if (name == "altAudioTracks") {
+                    if (!ignore_audio) {
+                        for (auto track : element.children("track")) {
+                            std::string tpath = track.text().as_string("");
+                            std::string tsname = track.attribute("shortname").as_string("");
+                            AlternateAudioTrack t;
+                            t.shortname = tsname;
+                            t.path = FileUtils::FixFile(showDir, tpath);
+                            if (::FileExists(t.path)) {
+                                ObtainAccessToURL(t.path);
+                                t.audio = new AudioManager(t.path, GetFrameMS());
+                            }
+                            alt_tracks.push_back(std::move(t));
+                        }
+                    }
                 } else if (name == "sequenceDuration") {
                     SetSequenceDuration(content);
                 } else if (name == "imageDir") {
@@ -462,6 +544,12 @@ std::optional<pugi::xml_document> SequenceFile::LoadSequence(const std::string& 
         spdlog::debug("LoadSequence: audio manager creation done");
     } else {
         spdlog::info("LoadSequence: No Audio loaded.");
+    }
+
+    // Register alt audio tracks with ValueCurve
+    ValueCurve::ClearAltAudio();
+    for (int i = 0; i < (int)alt_tracks.size(); i++) {
+        ValueCurve::SetAltAudio(GetAltTrackDisplayName(i), alt_tracks[i].audio);
     }
 
     spdlog::info("LoadSequence: Sequence timing interval {}ms.", GetFrameMS());
@@ -1245,6 +1333,14 @@ bool SequenceFile::BuildDocument(pugi::xml_document& doc, SequenceElements& seq_
     head.append_child("sequenceTiming").text().set(seq_timing);
     head.append_child("sequenceType").text().set(seq_type);
     head.append_child("mediaFile").text().set(media_file);
+    if (!alt_tracks.empty()) {
+        auto altNode = head.append_child("altAudioTracks");
+        for (const auto& t : alt_tracks) {
+            auto trackNode = altNode.append_child("track");
+            trackNode.append_attribute("shortname") = t.shortname.c_str();
+            trackNode.text().set(t.path.c_str());
+        }
+    }
     head.append_child("sequenceDuration").text().set(GetSequenceDurationString());
     head.append_child("imageDir").text().set(image_dir);
 

--- a/src-core/render/SequenceFile.h
+++ b/src-core/render/SequenceFile.h
@@ -51,6 +51,12 @@ struct PendingTiming {
     bool randomLabels = false;
 };
 
+struct AlternateAudioTrack {
+    std::string path;       // resolved absolute path
+    std::string shortname;  // user-defined label, e.g. "Drums"; "" → auto "Track1", "Track2"
+    AudioManager* audio = nullptr;
+};
+
 class SequenceFile
 {
     std::string mFilePath;
@@ -115,6 +121,16 @@ public:
     const std::string& GetMediaFile() const { return media_file; }
     void SetMediaFile(const std::string& ShowDir, const std::string& filename, bool overwrite_tags);
     void ClearMediaFile();
+
+    // Alternate audio tracks (stems)
+    int GetAltTrackCount() const { return (int)alt_tracks.size(); }
+    const AlternateAudioTrack& GetAltTrack(int idx) const { return alt_tracks[idx]; }
+    void AddAltTrack(const std::string& ShowDir, const std::string& path, const std::string& shortname = "");
+    void RemoveAltTrack(int idx);
+    void SetAltTrackPath(const std::string& ShowDir, int idx, const std::string& path);
+    void SetAltTrackShortname(int idx, const std::string& name);
+    std::string GetAltTrackDisplayName(int idx) const;
+    AudioManager* GetAltTrackMedia(int idx) const { return alt_tracks[idx].audio; }
 
     const std::string& GetHeaderInfo(HEADER_INFO_TYPES node_type) const;
     void SetHeaderInfo(HEADER_INFO_TYPES node_type, const std::string& node_value);
@@ -196,6 +212,7 @@ private:
     bool sequence_loaded = false;
     DataLayerSet mDataLayers;
     AudioManager* audio = nullptr;
+    std::vector<AlternateAudioTrack> alt_tracks;
     JukeboxButtonMap _jukeboxButtons;
 
     void CreateNew();

--- a/src-core/render/SequenceFile.h
+++ b/src-core/render/SequenceFile.h
@@ -130,7 +130,13 @@ public:
     void SetAltTrackPath(const std::string& ShowDir, int idx, const std::string& path);
     void SetAltTrackShortname(int idx, const std::string& name);
     std::string GetAltTrackDisplayName(int idx) const;
-    AudioManager* GetAltTrackMedia(int idx) const { return alt_tracks[idx].audio; }
+    AudioManager* GetAltTrackMedia(int idx) const
+    {
+        if (idx < 0 || static_cast<std::size_t>(idx) >= alt_tracks.size()) {
+            return nullptr;
+        }
+        return alt_tracks[idx].audio;
+    }
 
     const std::string& GetHeaderInfo(HEADER_INFO_TYPES node_type) const;
     void SetHeaderInfo(HEADER_INFO_TYPES node_type, const std::string& node_value);

--- a/src-core/render/SequencePackage.cpp
+++ b/src-core/render/SequencePackage.cpp
@@ -635,3 +635,49 @@ std::filesystem::path SequencePackage::FindAndCopyAudio(const std::filesystem::p
 
     return CopyMediaToTarget(targetDir.string(), audioFile);
 }
+
+std::vector<std::pair<std::string, std::string>> SequencePackage::FindAndCopyAltAudioTracks(const std::filesystem::path& targetDir)
+{
+    std::vector<std::pair<std::string, std::string>> result;
+
+    if (_xsqFile.empty() || !FileExists(_xsqFile.string())) {
+        return result;
+    }
+
+    pugi::xml_document xsqDoc;
+    if (!xsqDoc.load_file(_xsqFile.string().c_str())) {
+        return result;
+    }
+
+    auto altTracksNode = xsqDoc.child("xsequence").child("head").child("altAudioTracks");
+    if (!altTracksNode) {
+        return result;
+    }
+
+    for (auto trackNode : altTracksNode.children("track")) {
+        std::string shortname = trackNode.attribute("shortname").as_string("");
+        std::string tpath = trackNode.text().as_string("");
+
+        std::string filename;
+        {
+            std::filesystem::path p(tpath);
+            filename = p.filename().string();
+        }
+
+        if (filename.empty()) {
+            result.emplace_back(shortname, std::string());
+            continue;
+        }
+
+        auto it = _media.find(filename);
+        if (it != _media.end() && !it->second.empty() && FileExists(it->second.string())) {
+            std::filesystem::path copied = CopyMediaToTarget(targetDir.string(), it->second);
+            result.emplace_back(shortname, copied.string());
+        } else {
+            spdlog::warn("SequencePackage: Alt audio track '{}' ('{}') not found in package.", shortname, filename);
+            result.emplace_back(shortname, std::string());
+        }
+    }
+
+    return result;
+}

--- a/src-core/render/SequencePackage.h
+++ b/src-core/render/SequencePackage.h
@@ -15,6 +15,9 @@
 #include <pugixml.hpp>
 
 #include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "render/Element.h"
 #include "render/Effect.h"
@@ -72,6 +75,9 @@ class SequencePackage {
         void ImportFaceInfo(Effect* mappedEffect, EffectLayer *target, const std::string& faceName);
         std::filesystem::path CopyMediaToTarget(const std::string& targetFolder, const std::filesystem::path& mediaToCopy);
         std::filesystem::path FindAndCopyAudio(const std::filesystem::path& targetDir);
+        // Returns pairs of (shortname, copied_path) for alt tracks found in the package.
+        // Entries with an empty path indicate tracks referenced in the XSQ but not bundled.
+        std::vector<std::pair<std::string, std::string>> FindAndCopyAltAudioTracks(const std::filesystem::path& targetDir);
         std::list<std::string> GetMissingMedia();
 
         void SetSequenceElements(SequenceElements *se) { sequenceElements = se; };

--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 
 AudioManager* ValueCurve::__audioManager = nullptr;
+std::map<std::string, AudioManager*> ValueCurve::__altAudioManagers;
 SequenceElements* ValueCurve::__sequenceElements = nullptr;
 
 static std::string fmt2f(float v) {
@@ -1316,6 +1317,7 @@ void ValueCurve::SetDefault(float min, float max, int divisor)
         _max = max;
     }
     _timingTrack = "";
+    _audioTrackName = "";
     _filterLabelText = "";
     _isFilterLabelRegex = false;
     _parameter1 = 0;
@@ -1341,6 +1343,7 @@ ValueCurve::ValueCurve(const std::string& s)
     _max = MAXVOIDF;
     _divisor = 1;
     _timingTrack = "";
+    _audioTrackName = "";
     _filterLabelText = "";
     _isFilterLabelRegex = false;
     SetDefault();
@@ -1475,6 +1478,9 @@ std::string ValueCurve::Serialise()
         res += "Max=" + fmt2f(_max) + "|";
         if (_timingTrack != "") {
             res += "TT=" + _timingTrack + "|";
+        }
+        if (_audioTrackName != "") {
+            res += "AT=" + _audioTrackName + "|";
         }
         if (_filterLabelText != "") {
             res += "FT=" + _filterLabelText + "|";
@@ -1626,6 +1632,8 @@ void ValueCurve::SetSerialisedValue(const std::string &k, const std::string &s)
     }
     else if (k == "TT") {
         _timingTrack = s;
+    } else if (k == "AT") {
+        _audioTrackName = s;
     } else if (k == "FT") {
         _filterLabelText = s;
     } else if (k == "FLR") {
@@ -1775,13 +1783,16 @@ float ValueCurve::GetValueAt(float offset, long startMS, long endMS)
 {
     float res = 0.0f;
 
+    // Resolve which audio manager to use for this curve
+    AudioManager* _am = _audioTrackName.empty() ? __audioManager : GetAltAudio(_audioTrackName);
+
     // If we are music trigger fade and we dont have values ... calculate them on the fly
     if (_type == "Music Trigger Fade") {
         // Just generate what we need on the fly
-        if (__audioManager != nullptr && _values.size() == 0) {
+        if (_am != nullptr && _values.size() == 0) {
             float min = (GetParameter1() - _min) / (_max - _min);
             float max = (GetParameter2() - _min) / (_max - _min);
-            int frameMS = __audioManager->GetFrameInterval();
+            int frameMS = _am->GetFrameInterval();
             int fadeFrames = GetParameter4();
             float yperFrame = (max - min) / fadeFrames;
             float perPoint = vcSortablePoint::perPoint();
@@ -1805,7 +1816,7 @@ float ValueCurve::GetValueAt(float offset, long startMS, long endMS)
                 // find the maximum of any intervening frames
                 float f = 0.0;
                 for (long ms = time; ms < time + msperPoint; ms += frameMS) {
-                    auto pf = __audioManager->GetFrameData("", ms + frameMS);
+                    auto pf = _am->GetFrameData("", ms + frameMS);
                     if (pf != nullptr) {
                         if (pf->max > f) {
                             f = pf->max;
@@ -1913,10 +1924,10 @@ float ValueCurve::GetValueAt(float offset, long startMS, long endMS)
         }
     }
     else if (_type == "Music" || _type == "Inverted Music") {
-        if (__audioManager != nullptr) {
+        if (_am != nullptr) {
             long time = (float)startMS + offset * (endMS - startMS);
             float f = 0.0;
-            auto pf = __audioManager->GetFrameData("", time);
+            auto pf = _am->GetFrameData("", time);
             if (pf != nullptr) {
                 f = ApplyGain(pf->max, GetParameter3());
                 if (_type == "Inverted Music") {

--- a/src-core/render/ValueCurve.h
+++ b/src-core/render/ValueCurve.h
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <map>
 #include <string>
 #include <list>
 
@@ -101,7 +102,9 @@ class ValueCurve
     bool _active;
     bool _wrap;
     bool _realValues;
+    std::string _audioTrackName; // "" = main; "Track1"/"Drums"/etc = alt
     static AudioManager* __audioManager;
+    static std::map<std::string, AudioManager*> __altAudioManagers;
     static SequenceElements* __sequenceElements;
 
     void RenderType();
@@ -118,9 +121,18 @@ class ValueCurve
 public:
 
     static void SetAudio(AudioManager* am) { __audioManager = am; }
+    static void SetAltAudio(const std::string& name, AudioManager* am) { __altAudioManagers[name] = am; }
+    static void ClearAltAudio() { __altAudioManagers.clear(); }
+    static AudioManager* GetAltAudio(const std::string& name) {
+        auto it = __altAudioManagers.find(name);
+        return (it != __altAudioManagers.end()) ? it->second : __audioManager;
+    }
     static void SetSequenceElements(SequenceElements* se) { __sequenceElements = se; }
     static SequenceElements* GetSequenceElements() { return __sequenceElements; }
     static std::string GetValueCurveFolder(const std::string& showFolder);
+
+    void SetAudioTrack(const std::string& name) { _audioTrackName = name; }
+    std::string GetAudioTrack() const { return _audioTrackName; }
 
     ValueCurve() { _divisor = 1; _min = MINVOIDF; _max = MAXVOIDF; SetDefault(); }
     ValueCurve(const std::string& serialised);

--- a/src-ui-wx/ui/effectpanels/VUMeterPanel.cpp
+++ b/src-ui-wx/ui/effectpanels/VUMeterPanel.cpp
@@ -20,7 +20,10 @@
 #include "ui/shared/controls/MediaPickerCtrl.h"
 #include "effects/VUMeterEffect.h"
 #include "render/SequenceElements.h"
+#include "render/SequenceFile.h"
 #include "UtilFunctions.h"
+#include "xLightsApp.h"
+#include "xLightsMain.h"
 
 namespace {
 // Helper to look up a child control by name and dynamic_cast it. Returns
@@ -71,6 +74,8 @@ VUMeterPanel::VUMeterPanel(wxWindow* parent, const nlohmann::json& metadata)
     // (matching the legacy Sketch / Ripple / Shape pattern). The hidden file
     // picker still owns the path so the file is serialized as
     // E_FILEPICKERCTRL_SVGFile by GetEffectStringFromWindow.
+    _audioTrackChoice  = FindCtrl<wxChoice>(this, "ID_CHOICE_VUMeter_AudioTrack");
+
     _hiddenSvgPicker = FindCtrl<wxFilePickerCtrl>(this, "ID_FILEPICKERCTRL_SVGFile");
     if (_hiddenSvgPicker != nullptr) {
         _hiddenSvgPicker->Hide();
@@ -286,5 +291,25 @@ void VUMeterPanel::SetPanelStatus(Model* /*cls*/) {
     if (_timingTrackChoice->GetSelection() == wxNOT_FOUND && _timingTrackChoice->GetCount() > 0) {
         _timingTrackChoice->SetSelection(0);
     }
+
+    if (_audioTrackChoice != nullptr) {
+        wxString audioSel = _audioTrackChoice->GetStringSelection();
+        _audioTrackChoice->Clear();
+        _audioTrackChoice->Append("Main");
+        auto* frame = xLightsApp::GetFrame();
+        if (frame != nullptr && frame->CurrentSeqXmlFile != nullptr) {
+            int altCount = frame->CurrentSeqXmlFile->GetAltTrackCount();
+            for (int i = 0; i < altCount; i++) {
+                _audioTrackChoice->Append(wxString(frame->CurrentSeqXmlFile->GetAltTrackDisplayName(i)));
+            }
+        }
+        if (!audioSel.empty() && audioSel != "Main") {
+            _audioTrackChoice->SetStringSelection(audioSel);
+        }
+        if (_audioTrackChoice->GetSelection() == wxNOT_FOUND) {
+            _audioTrackChoice->SetSelection(0); // default to Main
+        }
+    }
+
     ValidateWindow();
 }

--- a/src-ui-wx/ui/effectpanels/VUMeterPanel.h
+++ b/src-ui-wx/ui/effectpanels/VUMeterPanel.h
@@ -59,4 +59,5 @@ private:
 
     wxFilePickerCtrl* _hiddenSvgPicker = nullptr;
     MediaPickerCtrl* _svgMediaPicker = nullptr;
+    wxChoice* _audioTrackChoice = nullptr;
 };

--- a/src-ui-wx/ui/sequencer/MainSequencer.h
+++ b/src-ui-wx/ui/sequencer/MainSequencer.h
@@ -89,6 +89,7 @@ class MainSequencer: public wxPanel
         void SetLargeWaveform();
         void SetSmallWaveform();
         void SetShowAlternateTimingMark(bool b);
+        int GetActiveAudioTrackIndex() const { return PanelWaveForm ? PanelWaveForm->GetActiveAudioTrackIndex() : 0; }
 
         void TouchButtonEvent(wxCommandEvent &event);
         void ToggleHousePreview();

--- a/src-ui-wx/ui/sequencer/RowHeading.cpp
+++ b/src-ui-wx/ui/sequencer/RowHeading.cpp
@@ -889,8 +889,14 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
             auto* frame = xLightsApp::GetFrame();
             if (frame != nullptr && frame->GetMainSequencer() != nullptr) {
                 int trackIdx = frame->GetMainSequencer()->GetActiveAudioTrackIndex();
-                if (trackIdx > 0 && xml_file->GetAltTrackMedia(trackIdx - 1) != nullptr) {
-                    vampMedia = xml_file->GetAltTrackMedia(trackIdx - 1);
+                if (trackIdx > 0) {
+                    int altTrackIdx = trackIdx - 1;
+                    if (altTrackIdx < xml_file->GetAltTrackCount()) {
+                        AudioManager* altTrackMedia = xml_file->GetAltTrackMedia(altTrackIdx);
+                        if (altTrackMedia != nullptr) {
+                            vampMedia = altTrackMedia;
+                        }
+                    }
                 }
             }
         }

--- a/src-ui-wx/ui/sequencer/RowHeading.cpp
+++ b/src-ui-wx/ui/sequencer/RowHeading.cpp
@@ -23,6 +23,7 @@
 #include "EffectsGrid.h"
 #include "ui/color/ColorManager.h"
 #include "render/SequenceElements.h"
+#include "media/AudioManager.h"
 #include "xLightsMain.h"
 #include "xLightsApp.h"
 #include "ui/sequencer/NewTimingDialog.h"
@@ -881,9 +882,22 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
         }
         
         VAMPPluginDialog vamp(this);
+
+        // Use the waveform's currently selected audio track for VAMP analysis
+        AudioManager* vampMedia = xml_file->GetMedia();
+        {
+            auto* frame = xLightsApp::GetFrame();
+            if (frame != nullptr && frame->GetMainSequencer() != nullptr) {
+                int trackIdx = frame->GetMainSequencer()->GetActiveAudioTrackIndex();
+                if (trackIdx > 0 && xml_file->GetAltTrackMedia(trackIdx - 1) != nullptr) {
+                    vampMedia = xml_file->GetAltTrackMedia(trackIdx - 1);
+                }
+            }
+        }
+
         std::list<std::string> plugins;
-        if (xml_file->HasAudioMedia()) {
-            plugins = xml_file->GetMedia()->GetVamp()->GetAvailablePlugins(xml_file->GetMedia());
+        if (vampMedia != nullptr) {
+            plugins = vampMedia->GetVamp()->GetAvailablePlugins(vampMedia);
             if (plugins.size() == 0) {
                 dialog.Choice_New_Fixed_Timing->Append("Download Queen Mary Vamp plugins for audio analysis");
             } else {
@@ -904,7 +918,7 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
                 DownloadVamp();
             } else {
                 if (std::find(plugins.begin(), plugins.end(), selected_timing) != plugins.end()) {
-                    name = vamp.ProcessPlugin(xml_file, xLightsApp::GetFrame(), selected_timing, xml_file->GetMedia());
+                    name = vamp.ProcessPlugin(xml_file, xLightsApp::GetFrame(), selected_timing, vampMedia);
                     if (name != "") {
                         timing_added = true;
                     }

--- a/src-ui-wx/ui/sequencer/SeqSettingsDialog.cpp
+++ b/src-ui-wx/ui/sequencer/SeqSettingsDialog.cpp
@@ -22,6 +22,8 @@
 #include <wx/filedlg.h>
 #include <wx/treectrl.h>
 #include <wx/dir.h>
+#include <wx/listctrl.h>
+#include <wx/textdlg.h>
 
 #include <list>
 
@@ -134,6 +136,13 @@ const long SeqSettingsDialog::ID_BUTTON_import_timings = wxNewId();
 const long SeqSettingsDialog::ID_BUTTON_wizard_done = wxNewId();
 const long SeqSettingsDialog::ID_CHOICE_Models = wxNewId();
 const long SeqSettingsDialog::ID_BUTTON_models_next = wxNewId();
+
+const long SeqSettingsDialog::ID_PANEL_Audio = wxNewId();
+const long SeqSettingsDialog::ID_LISTCTRL_AudioTracks = wxNewId();
+const long SeqSettingsDialog::ID_BUTTON_AudioAdd = wxNewId();
+const long SeqSettingsDialog::ID_BUTTON_AudioRemove = wxNewId();
+const long SeqSettingsDialog::ID_BUTTON_AudioChangeFile = wxNewId();
+const long SeqSettingsDialog::ID_BUTTON_AudioEditShortname = wxNewId();
 
 
 wxDEFINE_EVENT(EVT_GRID_ROW_CLICKED, wxCommandEvent);
@@ -488,6 +497,59 @@ SeqSettingsDialog::SeqSettingsDialog(wxWindow* parent, SequenceFile* file_to_han
         GetSizer()->SetSizeHints(this);
     }
 
+    // Audio Tracks tab — added programmatically (not wxSmith-generated), only in non-wizard mode
+    if (!wizard_active) {
+        PanelAudio = new wxPanel(Notebook_Seq_Settings, ID_PANEL_Audio, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+        wxFlexGridSizer* audioSizer = new wxFlexGridSizer(0, 1, 0, 0);
+        audioSizer->AddGrowableCol(0);
+        audioSizer->AddGrowableRow(0);
+
+        ListCtrl_AudioTracks = new wxListCtrl(PanelAudio, ID_LISTCTRL_AudioTracks,
+                                              wxDefaultPosition, wxDLG_UNIT(PanelAudio, wxSize(400, 120)),
+                                              wxLC_REPORT | wxLC_SINGLE_SEL | wxBORDER_SIMPLE);
+        ListCtrl_AudioTracks->AppendColumn(_("Track"), wxLIST_FORMAT_LEFT, wxDLG_UNIT(PanelAudio, wxSize(80, -1)).GetWidth());
+        ListCtrl_AudioTracks->AppendColumn(_("File"), wxLIST_FORMAT_LEFT, wxDLG_UNIT(PanelAudio, wxSize(280, -1)).GetWidth());
+        audioSizer->Add(ListCtrl_AudioTracks, 1, wxALL | wxEXPAND, 5);
+
+        wxFlexGridSizer* audioBtnSizer = new wxFlexGridSizer(0, 4, 0, 0);
+        Button_AudioAdd = new wxButton(PanelAudio, ID_BUTTON_AudioAdd, _("Add"));
+        Button_AudioRemove = new wxButton(PanelAudio, ID_BUTTON_AudioRemove, _("Remove"));
+        Button_AudioRemove->Disable();
+        Button_AudioChangeFile = new wxButton(PanelAudio, ID_BUTTON_AudioChangeFile, _("Change File"));
+        Button_AudioChangeFile->Disable();
+        Button_AudioEditShortname = new wxButton(PanelAudio, ID_BUTTON_AudioEditShortname, _("Edit Name"));
+        Button_AudioEditShortname->Disable();
+        audioBtnSizer->Add(Button_AudioAdd, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        audioBtnSizer->Add(Button_AudioRemove, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        audioBtnSizer->Add(Button_AudioChangeFile, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        audioBtnSizer->Add(Button_AudioEditShortname, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        audioSizer->Add(audioBtnSizer, 0, wxALL | wxALIGN_CENTER_HORIZONTAL, 5);
+
+        PanelAudio->SetSizer(audioSizer);
+        Notebook_Seq_Settings->AddPage(PanelAudio, _("Audio Tracks"), false);
+
+        // Wire up Audio Tracks tab events
+        Button_AudioAdd->Bind(wxEVT_BUTTON, &SeqSettingsDialog::OnButton_AudioAddClick, this);
+        Button_AudioRemove->Bind(wxEVT_BUTTON, &SeqSettingsDialog::OnButton_AudioRemoveClick, this);
+        Button_AudioChangeFile->Bind(wxEVT_BUTTON, &SeqSettingsDialog::OnButton_AudioChangeFileClick, this);
+        Button_AudioEditShortname->Bind(wxEVT_BUTTON, &SeqSettingsDialog::OnButton_AudioEditShortnameClick, this);
+        ListCtrl_AudioTracks->Bind(wxEVT_LIST_ITEM_ACTIVATED, &SeqSettingsDialog::OnListCtrl_AudioTracksActivated, this);
+        ListCtrl_AudioTracks->Bind(wxEVT_LIST_ITEM_SELECTED, [this](wxListEvent& evt) {
+            long sel = ListCtrl_AudioTracks->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+            bool isAlt = (sel > 0);
+            Button_AudioRemove->Enable(isAlt);
+            Button_AudioChangeFile->Enable(isAlt);
+            Button_AudioEditShortname->Enable(sel >= 0);
+            evt.Skip();
+        });
+        ListCtrl_AudioTracks->Bind(wxEVT_LIST_ITEM_DESELECTED, [this](wxListEvent& evt) {
+            Button_AudioRemove->Disable();
+            Button_AudioChangeFile->Disable();
+            Button_AudioEditShortname->Disable();
+            evt.Skip();
+        });
+    }
+
     TextCtrl_Xml_Seq_Duration->Connect(wxEVT_KILL_FOCUS, (wxObjectEventFunction)&SeqSettingsDialog::OnTextCtrl_Xml_Seq_DurationLoseFocus, nullptr, this);
 
     TreeCtrl_Data_Layers->AddRoot("Layers to Render");
@@ -568,6 +630,7 @@ SeqSettingsDialog::SeqSettingsDialog(wxWindow* parent, SequenceFile* file_to_han
     TreeCtrl_Data_Layers->Expand(root);
 
     RenderModeChoice->SetStringSelection(xml_file->GetRenderMode());
+    PopulateAudioTrackList();
 
     if (!defaultView.IsEmpty()) {
         if (xLightsParent->GetViewsManager()->GetViewIndex(defaultView) != -1) {
@@ -2214,4 +2277,116 @@ void SeqSettingsDialog::OnButton_AddMillisecondsClick(wxCommandEvent& event) {
     } else {
         wxMessageBox("Audio file created successfully, " + targetFile.GetFullPath() + " Please choose the new media file for your sequence.");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Audio Tracks tab
+// ---------------------------------------------------------------------------
+
+void SeqSettingsDialog::PopulateAudioTrackList()
+{
+    if (ListCtrl_AudioTracks == nullptr) return;
+
+    ListCtrl_AudioTracks->DeleteAllItems();
+
+    // Row 0: main track (always present)
+    {
+        wxListItem item;
+        item.SetId(0);
+        item.SetText(_("Main"));
+        ListCtrl_AudioTracks->InsertItem(item);
+        std::string mainPath = xml_file->GetMedia() ? xml_file->GetMedia()->FileName() : xml_file->GetMediaFile();
+        ListCtrl_AudioTracks->SetItem(0, 1, mainPath.empty() ? _("(none)") : wxString(mainPath));
+    }
+
+    // Alt tracks
+    for (int i = 0; i < xml_file->GetAltTrackCount(); i++) {
+        const AlternateAudioTrack& t = xml_file->GetAltTrack(i);
+        wxString displayName = xml_file->GetAltTrackDisplayName(i);
+        long row = ListCtrl_AudioTracks->InsertItem(i + 1, displayName);
+        wxString pathLabel = t.path.empty() ? _("(not found)") : wxString(t.path);
+        if (t.audio == nullptr && !t.path.empty()) pathLabel = wxString("\u26A0 ") + pathLabel;
+        ListCtrl_AudioTracks->SetItem(row, 1, pathLabel);
+        ListCtrl_AudioTracks->SetItemData(row, i + 1);
+    }
+
+    Button_AudioRemove->Disable();
+    Button_AudioChangeFile->Disable();
+    Button_AudioEditShortname->Disable();
+}
+
+void SeqSettingsDialog::OnButton_AudioAddClick(wxCommandEvent& /*event*/)
+{
+    wxString filter = _("Audio Files|*.mp3;*.ogg;*.flac;*.wav;*.m4a;*.aac;*.wma;*.aiff;*.aif|All Files|*.*");
+    wxString startDir = xLightsParent ? wxString(xLightsParent->GetShowDirectory()) : wxString{};
+    wxFileDialog dlg(this, _("Choose Audio File"), startDir, wxEmptyString, filter, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    if (dlg.ShowModal() != wxID_OK) return;
+
+    wxString path = dlg.GetPath();
+    ObtainAccessToURL(path.ToStdString());
+    std::string showDir = xLightsParent ? xLightsParent->GetShowDirectory() : std::string{};
+    xml_file->AddAltTrack(showDir, path.ToStdString());
+    PopulateAudioTrackList();
+}
+
+void SeqSettingsDialog::OnButton_AudioRemoveClick(wxCommandEvent& /*event*/)
+{
+    long sel = ListCtrl_AudioTracks->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    if (sel <= 0) return; // row 0 is Main, not removable
+    int idx = (int)sel - 1;
+    xml_file->RemoveAltTrack(idx);
+    PopulateAudioTrackList();
+}
+
+void SeqSettingsDialog::OnButton_AudioChangeFileClick(wxCommandEvent& /*event*/)
+{
+    long sel = ListCtrl_AudioTracks->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    if (sel <= 0) return;
+    int idx = (int)sel - 1;
+
+    wxString filter = _("Audio Files|*.mp3;*.ogg;*.flac;*.wav;*.m4a;*.aac;*.wma;*.aiff;*.aif|All Files|*.*");
+    wxString startDir = xLightsParent ? wxString(xLightsParent->GetShowDirectory()) : wxString{};
+    wxFileDialog dlg(this, _("Choose Audio File"), startDir, wxEmptyString, filter, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    if (dlg.ShowModal() != wxID_OK) return;
+
+    wxString newPath = dlg.GetPath();
+    ObtainAccessToURL(newPath.ToStdString());
+    std::string showDir = xLightsParent ? xLightsParent->GetShowDirectory() : std::string{};
+    xml_file->SetAltTrackPath(showDir, idx, newPath.ToStdString());
+    PopulateAudioTrackList();
+}
+
+void SeqSettingsDialog::OnButton_AudioEditShortnameClick(wxCommandEvent& /*event*/)
+{
+    long sel = ListCtrl_AudioTracks->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    if (sel < 0) return;
+
+    if (sel == 0) {
+        // Main track: no shortname to edit
+        wxMessageBox(_("The main track label cannot be changed."), _("Audio Tracks"), wxOK | wxICON_INFORMATION, this);
+        return;
+    }
+
+    int idx = (int)sel - 1;
+    wxString current = xml_file->GetAltTrack(idx).shortname;
+    wxTextEntryDialog dlg(this, _("Enter a short name for this track (leave empty for auto-name):"),
+                          _("Edit Track Name"), current);
+    if (dlg.ShowModal() != wxID_OK) return;
+
+    xml_file->SetAltTrackShortname(idx, dlg.GetValue().ToStdString());
+    PopulateAudioTrackList();
+}
+
+void SeqSettingsDialog::OnListCtrl_AudioTracksActivated(wxListEvent& event)
+{
+    // Double-click → edit shortname
+    long sel = event.GetIndex();
+    if (sel < 0) return;
+    wxCommandEvent dummy;
+    if (sel == 0) {
+        // For Main row activation, allow browsing for a new main media file
+        MediaChooser();
+        return;
+    }
+    OnButton_AudioEditShortnameClick(dummy);
 }

--- a/src-ui-wx/ui/sequencer/SeqSettingsDialog.cpp
+++ b/src-ui-wx/ui/sequencer/SeqSettingsDialog.cpp
@@ -1765,6 +1765,22 @@ void SeqSettingsDialog::MediaChooser()
             SetCursor(wxCURSOR_WAIT);
             MediaLoad(fsPathToWxString(audioFile));
             SetCursor(wxCURSOR_DEFAULT);
+
+            // Import any alternate audio tracks bundled in the package.
+            // Tracks referenced in the XSQ but absent from the package become
+            // placeholder entries (empty path, audio == nullptr) so the user can
+            // see and resolve them in the Audio Tracks tab.
+            auto altTracks = pkg.FindAndCopyAltAudioTracks(importDir);
+            if (!altTracks.empty()) {
+                std::string showDir = xLightsParent ? xLightsParent->GetShowDirectory() : std::string{};
+                for (const auto& [shortname, path] : altTracks) {
+                    if (!path.empty()) {
+                        ObtainAccessToURL(path);
+                    }
+                    xml_file->AddAltTrack(showDir, path, shortname);
+                }
+                PopulateAudioTrackList();
+            }
         } else {
             ObtainAccessToURL(std::string(fDir.utf8_string()));
             ObtainAccessToURL(std::string(name_and_path.GetFullPath().utf8_string()));

--- a/src-ui-wx/ui/sequencer/SeqSettingsDialog.h
+++ b/src-ui-wx/ui/sequencer/SeqSettingsDialog.h
@@ -28,6 +28,7 @@
 #include <wx/textctrl.h>
 #include <wx/treectrl.h>
 //*)
+#include <wx/listctrl.h>
 
 #define NEEDS_RENDER 9998
 
@@ -137,6 +138,14 @@ class SeqSettingsDialog: public wxDialog
 		wxButton* ModelsChoiceNext;
         ManageMediaPanel* Panel_ManageMedia;
 
+        // Audio Tracks tab (not wxSmith-generated)
+        wxPanel* PanelAudio = nullptr;
+        wxListCtrl* ListCtrl_AudioTracks = nullptr;
+        wxButton* Button_AudioAdd = nullptr;
+        wxButton* Button_AudioRemove = nullptr;
+        wxButton* Button_AudioChangeFile = nullptr;
+        wxButton* Button_AudioEditShortname = nullptr;
+
 	protected:
 
 		//(*Identifiers(SeqSettingsDialog)
@@ -226,6 +235,13 @@ class SeqSettingsDialog: public wxDialog
         static const long ID_PANEL_Wizard;
         static const long ID_CHOICE_Models;
         static const long ID_BUTTON_models_next;
+
+        static const long ID_PANEL_Audio;
+        static const long ID_LISTCTRL_AudioTracks;
+        static const long ID_BUTTON_AudioAdd;
+        static const long ID_BUTTON_AudioRemove;
+        static const long ID_BUTTON_AudioChangeFile;
+        static const long ID_BUTTON_AudioEditShortname;
 
 	private:
 
@@ -335,6 +351,12 @@ class SeqSettingsDialog: public wxDialog
         void AddTimingCell(const wxString& name);
         void UpdateDataLayer();
         void MediaChooser();
+        void PopulateAudioTrackList();
+        void OnButton_AudioAddClick(wxCommandEvent& event);
+        void OnButton_AudioRemoveClick(wxCommandEvent& event);
+        void OnButton_AudioChangeFileClick(wxCommandEvent& event);
+        void OnButton_AudioEditShortnameClick(wxCommandEvent& event);
+        void OnListCtrl_AudioTracksActivated(wxListEvent& event);
         void RemoveWizard();
         void WizardPage1();
         void WizardPage2();

--- a/src-ui-wx/ui/sequencer/Waveform.cpp
+++ b/src-ui-wx/ui/sequencer/Waveform.cpp
@@ -58,6 +58,16 @@ const long Waveform::ID_WAVE_MNU_TREBLE = wxNewId();
 const long Waveform::ID_WAVE_MNU_CUSTOM = wxNewId();
 const long Waveform::ID_WAVE_MNU_NONVOCALS = wxNewId();
 const long Waveform::ID_WAVE_MNU_DOUBLEHEIGHT = wxNewId();
+// Reserve 32 IDs for audio track submenu items (base + 0..31)
+const long Waveform::ID_WAVE_MNU_AUDIO_TRACK_BASE = wxNewId();
+static long _audioTrackIdPool[32];
+static bool _audioTrackIdPoolInited = false;
+static void EnsureAudioTrackIds() {
+    if (!_audioTrackIdPoolInited) {
+        for (int i = 0; i < 32; i++) _audioTrackIdPool[i] = wxNewId();
+        _audioTrackIdPoolInited = true;
+    }
+}
 
 Waveform::Waveform(wxPanel* parent, wxWindowID id, const wxPoint &pos, const wxSize &size,
                    long style, const wxString &name):
@@ -192,6 +202,31 @@ void Waveform::rightClick(wxMouseEvent& event)
         mnuWave.AppendRadioItem(ID_WAVE_MNU_NONVOCALS, "Non Vocals waveform")->Check(_type == AUDIOSAMPLETYPE::NONVOCALS);
         mnuWave.AppendSeparator();
         mnuWave.AppendCheckItem(ID_WAVE_MNU_DOUBLEHEIGHT, "Double height waveform")->Check(_doubleHeight);
+
+        // Audio Track submenu
+        auto* frame = xLightsApp::GetFrame();
+        if (frame != nullptr && frame->CurrentSeqXmlFile != nullptr &&
+            frame->CurrentSeqXmlFile->GetAltTrackCount() > 0) {
+            EnsureAudioTrackIds();
+            mnuWave.AppendSeparator();
+            wxMenu* trackMenu = new wxMenu();
+            // Main track
+            wxString mainLabel = "Main";
+            if (frame->CurrentSeqXmlFile->GetMedia() != nullptr) {
+                wxFileName fn(frame->CurrentSeqXmlFile->GetMedia()->FileName());
+                mainLabel = "Main  [" + fn.GetFullName() + "]";
+            }
+            trackMenu->AppendRadioItem(_audioTrackIdPool[0], mainLabel)->Check(_activeAudioTrackIndex == 0);
+            // Alt tracks
+            int altCount = frame->CurrentSeqXmlFile->GetAltTrackCount();
+            for (int i = 0; i < altCount && i + 1 < 32; i++) {
+                std::string dispName = frame->CurrentSeqXmlFile->GetAltTrackDisplayName(i);
+                wxFileName fn(frame->CurrentSeqXmlFile->GetAltTrack(i).path);
+                wxString label = wxString(dispName) + "  [" + fn.GetFullName() + "]";
+                trackMenu->AppendRadioItem(_audioTrackIdPool[i + 1], label)->Check(_activeAudioTrackIndex == i + 1);
+            }
+            mnuWave.AppendSubMenu(trackMenu, "Audio Track");
+        }
     }
     if (mnuWave.GetMenuItemCount() > 0) {
         mnuWave.Connect(wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)& Waveform::OnGridPopup, nullptr, this);
@@ -232,6 +267,23 @@ void Waveform::OnGridPopup(wxCommandEvent& event)
         _type = AUDIOSAMPLETYPE::CUSTOM;
     } else if (id == ID_WAVE_MNU_DOUBLEHEIGHT) {
         _doubleHeight = !_doubleHeight;
+    } else {
+        // Check if this is an audio track selection
+        EnsureAudioTrackIds();
+        for (int i = 0; i < 32; i++) {
+            if (id == _audioTrackIdPool[i]) {
+                _activeAudioTrackIndex = i;
+                auto* frame = xLightsApp::GetFrame();
+                if (frame != nullptr && frame->CurrentSeqXmlFile != nullptr) {
+                    wxString err;
+                    AudioManager* newMedia = (i == 0)
+                        ? frame->CurrentSeqXmlFile->GetMedia()
+                        : frame->CurrentSeqXmlFile->GetAltTrackMedia(i - 1);
+                    OpenfileMedia(newMedia, err);
+                }
+                return;
+            }
+        }
     }
 
     wxSetCursor(wxCURSOR_WAIT);

--- a/src-ui-wx/ui/sequencer/Waveform.cpp
+++ b/src-ui-wx/ui/sequencer/Waveform.cpp
@@ -202,11 +202,14 @@ void Waveform::rightClick(wxMouseEvent& event)
         mnuWave.AppendRadioItem(ID_WAVE_MNU_NONVOCALS, "Non Vocals waveform")->Check(_type == AUDIOSAMPLETYPE::NONVOCALS);
         mnuWave.AppendSeparator();
         mnuWave.AppendCheckItem(ID_WAVE_MNU_DOUBLEHEIGHT, "Double height waveform")->Check(_doubleHeight);
+    }
 
-        // Audio Track submenu
+    // Audio Track submenu — outside the _media guard so the user can always switch
+    // back to Main even when the current track has a broken/missing file (_media == nullptr).
+    {
         auto* frame = xLightsApp::GetFrame();
         if (frame != nullptr && frame->CurrentSeqXmlFile != nullptr &&
-            frame->CurrentSeqXmlFile->GetAltTrackCount() > 0) {
+            (frame->CurrentSeqXmlFile->GetAltTrackCount() > 0 || _activeAudioTrackIndex != 0)) {
             EnsureAudioTrackIds();
             mnuWave.AppendSeparator();
             wxMenu* trackMenu = new wxMenu();

--- a/src-ui-wx/ui/sequencer/Waveform.h
+++ b/src-ui-wx/ui/sequencer/Waveform.h
@@ -65,6 +65,8 @@ class Waveform : public GRAPHICS_BASE_CLASS
         void CheckNeedToScroll() const;
         void ForceRedraw();
 
+        int GetActiveAudioTrackIndex() const { return _activeAudioTrackIndex; }
+
         Waveform(wxPanel* parent, wxWindowID id, const wxPoint &pos=wxDefaultPosition,
                 const wxSize &size=wxDefaultSize,long style=0, const wxString &name=wxPanelNameStr);
 		virtual ~Waveform();
@@ -103,6 +105,7 @@ class Waveform : public GRAPHICS_BASE_CLASS
         AUDIOSAMPLETYPE _type = AUDIOSAMPLETYPE::RAW;
         int _lowNote = -1;
         int _highNote = -1;
+        int _activeAudioTrackIndex = 0; // 0 = main, 1..N = alt tracks
         static const long ID_WAVE_MNU_RENDER;
         static const long ID_WAVE_MNU_RAW;
         static const long ID_WAVE_MNU_BASS;
@@ -111,6 +114,8 @@ class Waveform : public GRAPHICS_BASE_CLASS
         static const long ID_WAVE_MNU_CUSTOM;
         static const long ID_WAVE_MNU_NONVOCALS;
         static const long ID_WAVE_MNU_DOUBLEHEIGHT;
+        // Audio track submenu: IDs are ID_WAVE_MNU_AUDIO_TRACK_BASE + index
+        static const long ID_WAVE_MNU_AUDIO_TRACK_BASE;
 
         class WaveView
         {

--- a/src-ui-wx/ui/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/tabSequencer.cpp
@@ -1699,8 +1699,9 @@ void xLightsFrame::DoPlaySequence()
 			playStartTime = mainSequencer->PanelTimeLine->GetNewStartTimeMS();
 			playEndTime = mainSequencer->PanelTimeLine->GetNewEndTimeMS();
 			if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-				if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-					CurrentSeqXmlFile->GetMedia()->Seek(playStartTime);
+				AudioManager* playAudio = GetPlaybackAudio();
+				if (playAudio != nullptr) {
+					playAudio->Seek(playStartTime);
 				}
 			}
 			if (playEndTime == -1 || playEndTime > CurrentSeqXmlFile->GetSequenceDurationMS()) {
@@ -1708,8 +1709,9 @@ void xLightsFrame::DoPlaySequence()
 			}
 			mainSequencer->PanelTimeLine->PlayStarted();
 			if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-				if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-					CurrentSeqXmlFile->GetMedia()->Play();
+				AudioManager* playAudio = GetPlaybackAudio();
+				if (playAudio != nullptr) {
+					playAudio->Play();
 				}
 			}
 		}
@@ -1729,11 +1731,12 @@ void xLightsFrame::PauseSequence(wxCommandEvent& event)
     if (CurrentSeqXmlFile == nullptr) return;
 
     if( CurrentSeqXmlFile->GetSequenceType() == "Media" ) {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-			if (CurrentSeqXmlFile->GetMedia()->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING) {
-				CurrentSeqXmlFile->GetMedia()->Pause();
-            } else if (CurrentSeqXmlFile->GetMedia()->GetPlayingState() == MEDIAPLAYINGSTATE::PAUSED) {
-				CurrentSeqXmlFile->GetMedia()->Play();
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr) {
+			if (playAudio->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING) {
+				playAudio->Pause();
+            } else if (playAudio->GetPlayingState() == MEDIAPLAYINGSTATE::PAUSED) {
+				playAudio->Play();
 			}
 		}
 	}
@@ -1954,9 +1957,10 @@ void xLightsFrame::DoStopSequence()
 	mLoopAudio = false;
     if( playType == PLAY_TYPE_MODEL || playType == PLAY_TYPE_MODEL_PAUSED ) {
         if( CurrentSeqXmlFile->GetSequenceType() == "Media" ) {
-			if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-				CurrentSeqXmlFile->GetMedia()->Stop();
-				CurrentSeqXmlFile->GetMedia()->Seek(playStartTime);
+			AudioManager* playAudio = GetPlaybackAudio();
+			if (playAudio != nullptr) {
+				playAudio->Stop();
+				playAudio->Seek(playStartTime);
 			}
         }
         mainSequencer->PanelTimeLine->PlayStopped();
@@ -2026,23 +2030,26 @@ void xLightsFrame::SequenceRewind10(wxCommandEvent& event)
     if (CurrentSeqXmlFile == nullptr) return;
 
     int current_play_time;
-    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr)
     {
-        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-    }
-    else
-    {
-        wxTimeSpan ts = wxDateTime::UNow() - starttime;
-        long curtime = ts.GetMilliseconds().ToLong();
-        int msec;
-        if (playAnimation) {
-            msec = curtime * playSpeed;
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr)
+        {
+            current_play_time = playAudio->Tell();
         }
-        else {
-            msec = curtime;
-        }
+        else
+        {
+            wxTimeSpan ts = wxDateTime::UNow() - starttime;
+            long curtime = ts.GetMilliseconds().ToLong();
+            int msec;
+            if (playAnimation) {
+                msec = curtime * playSpeed;
+            }
+            else {
+                msec = curtime;
+            }
 
-        current_play_time = (playStartTime + msec - playStartMS);
+            current_play_time = (playStartTime + msec - playStartMS);
+        }
     }
 
     long origtime = current_play_time;
@@ -2050,9 +2057,10 @@ void xLightsFrame::SequenceRewind10(wxCommandEvent& event)
     if (current_play_time < 0) current_play_time = 0;
 
     if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr)
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr)
         {
-            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+            playAudio->Seek(current_play_time);
         }
     }
     else
@@ -2070,23 +2078,26 @@ void xLightsFrame::SequenceFForward10(wxCommandEvent& event)
     if (CurrentSeqXmlFile == nullptr) return;
 
     int current_play_time;
-    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr)
     {
-        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-    }
-    else
-    {
-        wxTimeSpan ts = wxDateTime::UNow() - starttime;
-        long curtime = ts.GetMilliseconds().ToLong();
-        int msec;
-        if (playAnimation) {
-            msec = curtime * playSpeed;
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr)
+        {
+            current_play_time = playAudio->Tell();
         }
-        else {
-            msec = curtime;
-        }
+        else
+        {
+            wxTimeSpan ts = wxDateTime::UNow() - starttime;
+            long curtime = ts.GetMilliseconds().ToLong();
+            int msec;
+            if (playAnimation) {
+                msec = curtime * playSpeed;
+            }
+            else {
+                msec = curtime;
+            }
 
-        current_play_time = (playStartTime + msec - playStartMS);
+            current_play_time = (playStartTime + msec - playStartMS);
+        }
     }
 
     long origtime = current_play_time;
@@ -2095,9 +2106,10 @@ void xLightsFrame::SequenceFForward10(wxCommandEvent& event)
     if (current_play_time > end_ms) current_play_time = end_ms;
 
     if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr)
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr)
         {
-            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+            playAudio->Seek(current_play_time);
         }
     }
     else
@@ -2115,18 +2127,21 @@ void xLightsFrame::SequencePriorTag(wxCommandEvent& event) {
         return;
 
     int current_play_time;
-    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr) {
-        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-    } else {
-        wxTimeSpan ts = wxDateTime::UNow() - starttime;
-        long curtime = ts.GetMilliseconds().ToLong();
-        int msec;
-        if (playAnimation) {
-            msec = curtime * playSpeed;
+    {
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr) {
+            current_play_time = playAudio->Tell();
         } else {
-            msec = curtime;
+            wxTimeSpan ts = wxDateTime::UNow() - starttime;
+            long curtime = ts.GetMilliseconds().ToLong();
+            int msec;
+            if (playAnimation) {
+                msec = curtime * playSpeed;
+            } else {
+                msec = curtime;
+            }
+            current_play_time = (playStartTime + msec - playStartMS);
         }
-        current_play_time = (playStartTime + msec - playStartMS);
     }
 
     long origtime = current_play_time;
@@ -2137,8 +2152,9 @@ void xLightsFrame::SequencePriorTag(wxCommandEvent& event) {
         current_play_time = end_ms;
 
     if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr) {
+            playAudio->Seek(current_play_time);
         }
     } else {
         starttime += wxTimeSpan(0, 0, (origtime - current_play_time) / 1000, (origtime - current_play_time) % 1000);
@@ -2154,19 +2170,22 @@ void xLightsFrame::SequenceNextTag(wxCommandEvent& event) {
         return;
 
     int current_play_time;
-    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr) {
-        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-    } else {
-        wxTimeSpan ts = wxDateTime::UNow() - starttime;
-        long curtime = ts.GetMilliseconds().ToLong();
-        int msec;
-        if (playAnimation) {
-            msec = curtime * playSpeed;
+    {
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr) {
+            current_play_time = playAudio->Tell();
         } else {
-            msec = curtime;
-        }
+            wxTimeSpan ts = wxDateTime::UNow() - starttime;
+            long curtime = ts.GetMilliseconds().ToLong();
+            int msec;
+            if (playAnimation) {
+                msec = curtime * playSpeed;
+            } else {
+                msec = curtime;
+            }
 
-        current_play_time = (playStartTime + msec - playStartMS);
+            current_play_time = (playStartTime + msec - playStartMS);
+        }
     }
 
     long origtime = current_play_time;
@@ -2176,8 +2195,9 @@ void xLightsFrame::SequenceNextTag(wxCommandEvent& event) {
         current_play_time = end_ms;
 
     if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr) {
+            playAudio->Seek(current_play_time);
         }
     } else {
         starttime += wxTimeSpan(0, 0, (origtime - current_play_time) / 1000, (origtime - current_play_time) % 1000);
@@ -2194,19 +2214,22 @@ void xLightsFrame::SequenceSeekTo(wxCommandEvent& event)
 
     int pos = event.GetInt();
     int current_play_time;
-    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr) {
-        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-    } else {
-        wxTimeSpan ts = wxDateTime::UNow() - starttime;
-        long curtime = ts.GetMilliseconds().ToLong();
-        int msec;
-        if (playAnimation) {
-            msec = curtime * playSpeed;
+    {
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr) {
+            current_play_time = playAudio->Tell();
         } else {
-            msec = curtime;
-        }
+            wxTimeSpan ts = wxDateTime::UNow() - starttime;
+            long curtime = ts.GetMilliseconds().ToLong();
+            int msec;
+            if (playAnimation) {
+                msec = curtime * playSpeed;
+            } else {
+                msec = curtime;
+            }
 
-        current_play_time = (playStartTime + msec - playStartMS);
+            current_play_time = (playStartTime + msec - playStartMS);
+        }
     }
 
     long origtime = current_play_time;
@@ -2217,8 +2240,9 @@ void xLightsFrame::SequenceSeekTo(wxCommandEvent& event)
     }
 
     if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
-        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
-            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (playAudio != nullptr) {
+            playAudio->Seek(current_play_time);
         }
     } else {
         starttime += wxTimeSpan(0, 0, (origtime - current_play_time) / 1000, (origtime - current_play_time) % 1000);
@@ -2541,9 +2565,10 @@ int xLightsFrame::GetCurrentPlayTime()
 
     if (playType == PLAY_TYPE_MODEL) {
 
-        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr && CurrentSeqXmlFile->GetMedia()->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING)
+        AudioManager* playAudio = GetPlaybackAudio();
+        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr && playAudio->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING)
         {
-            curt = CurrentSeqXmlFile->GetMedia()->Tell();
+            curt = playAudio->Tell();
         }
     }
 
@@ -2657,11 +2682,14 @@ bool xLightsFrame::TimerRgbSeq(long msec)
 
     int current_play_time = 0;
     if (playType == PLAY_TYPE_MODEL) {
-        if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr && CurrentSeqXmlFile->GetMedia()->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING) {
-            current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
-            curt = current_play_time;
-        } else {
-            current_play_time = curt;
+        {
+            AudioManager* playAudio = GetPlaybackAudio();
+            if (CurrentSeqXmlFile->GetSequenceType() == "Media" && playAudio != nullptr && playAudio->GetPlayingState() == MEDIAPLAYINGSTATE::PLAYING) {
+                current_play_time = playAudio->Tell();
+                curt = current_play_time;
+            } else {
+                current_play_time = curt;
+            }
         }
 
         // see if its time to stop model play

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -126,6 +126,9 @@ const long ValueCurveDialog::ID_BUTTON1 = wxNewId();
 const long ValueCurveDialog::ID_BUTTON2 = wxNewId();
 //*)
 
+// Audio track ID (outside wxSmith guard)
+const long ValueCurveDialog::ID_CHOICE_AudioTrack = wxNewId();
+
 BEGIN_EVENT_TABLE(ValueCurveDialog, wxDialog)
 //(*EventTable(ValueCurveDialog)
 //*)
@@ -308,6 +311,22 @@ ValueCurveDialog::ValueCurveDialog(wxWindow* parent, ValueCurve* vc, bool slider
 
     Connect(wxID_ANY, wxEVT_CHAR_HOOK, wxKeyEventHandler(ValueCurveDialog::OnChar), (wxObject*)nullptr, this);
 
+    // Audio track row (outside wxSmith guard)
+    {
+        auto* audioRowSizer = new wxBoxSizer(wxHORIZONTAL);
+        StaticText_AudioTrack = new wxStaticText(this, wxID_ANY, _("Audio Track:"), wxDefaultPosition, wxDefaultSize, 0);
+        audioRowSizer->Add(StaticText_AudioTrack, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        Choice_AudioTrack = new wxChoice(this, ID_CHOICE_AudioTrack, wxDefaultPosition, wxDLG_UNIT(this, wxSize(120, -1)), 0, nullptr, 0);
+        audioRowSizer->Add(Choice_AudioTrack, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+        // Insert before the last item in the top-level sizer (the OK/Cancel row)
+        auto* topSizer = GetSizer();
+        topSizer->Insert(topSizer->GetItemCount() - 1, audioRowSizer, 0, wxALL | wxALIGN_LEFT, 2);
+        Bind(wxEVT_CHOICE, [this](wxCommandEvent&) {
+            int sel = Choice_AudioTrack->GetSelection();
+            _vc->SetAudioTrack(sel > 0 ? Choice_AudioTrack->GetStringSelection().ToStdString() : "");
+        }, ID_CHOICE_AudioTrack);
+    }
+
     TextCtrl_FilterLabel->SetToolTip("Only trigger on timing events which contain this token in their text. Blank matches all. Multiple tokens can be ; separated in non-regex mode.");
 
     Button_Ok->SetDefault();
@@ -382,6 +401,26 @@ ValueCurveDialog::ValueCurveDialog(wxWindow* parent, ValueCurve* vc, bool slider
     CheckBox_FilterLabelRegex->SetValue(_vc->IsFilterLabelRegex());
 
     PopulatePresets();
+
+    // Populate audio track choice with available alt tracks
+    Choice_AudioTrack->Clear();
+    Choice_AudioTrack->Append(_("(Main Track)"));
+    {
+        auto* seqFile = xLightsApp::GetFrame()->CurrentSeqXmlFile;
+        if (seqFile != nullptr) {
+            for (int i = 0; i < seqFile->GetAltTrackCount(); i++) {
+                Choice_AudioTrack->Append(wxString(seqFile->GetAltTrackDisplayName(i)));
+            }
+        }
+    }
+    // Restore saved selection
+    if (!_vc->GetAudioTrack().empty()) {
+        if (Choice_AudioTrack->SetStringSelection(wxString(_vc->GetAudioTrack())) == false) {
+            Choice_AudioTrack->SetSelection(0);
+        }
+    } else {
+        Choice_AudioTrack->SetSelection(0);
+    }
 
     Layout();
     Fit();
@@ -1332,6 +1371,15 @@ void ValueCurveDialog::ValidateWindow() {
         CheckBox_FilterLabelRegex->Enable(false);
         _vc->SetTimingTrack("");
     }
+
+    // Show audio track selector only for music-reactive types
+    bool isMusicType = (type == "Music" || type == "Inverted Music" || type == "Music Trigger Fade");
+    if (StaticText_AudioTrack != nullptr) StaticText_AudioTrack->Show(isMusicType);
+    if (Choice_AudioTrack != nullptr) Choice_AudioTrack->Show(isMusicType);
+    if (!isMusicType && _vc != nullptr) {
+        _vc->SetAudioTrack("");
+    }
+    GetSizer()->Layout();
 }
 
 void ValueCurveDialog::OnChar(wxKeyEvent& event) {

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -268,7 +268,7 @@ ValueCurveDialog::ValueCurveDialog(wxWindow* parent, ValueCurve* vc, bool slider
     FlexGridSizer7->AddGrowableRow(0);
     PresetSizer = new wxFlexGridSizer(0, 5, 0, 0);
     FlexGridSizer7->Add(PresetSizer, 1, wxALL|wxEXPAND, 2);
-    FlexGridSizer8 = new wxFlexGridSizer(0, 1, 0, 0);
+    FlexGridSizer8 = new wxFlexGridSizer(0, 2, 0, 0);
     ButtonLoad = new wxButton(this, ID_BUTTON3, _("Load"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON3"));
     FlexGridSizer8->Add(ButtonLoad, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     ButtonExport = new wxButton(this, ID_BUTTON4, _("Export"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
@@ -311,16 +311,14 @@ ValueCurveDialog::ValueCurveDialog(wxWindow* parent, ValueCurve* vc, bool slider
 
     Connect(wxID_ANY, wxEVT_CHAR_HOOK, wxKeyEventHandler(ValueCurveDialog::OnChar), (wxObject*)nullptr, this);
 
-    // Audio track row (outside wxSmith guard)
+    // Audio track row — added as a proper 3-column row in FlexGridSizer2,
+    // matching the Timing Track and Filter Label rows above it.
     {
-        auto* audioRowSizer = new wxBoxSizer(wxHORIZONTAL);
         StaticText_AudioTrack = new wxStaticText(this, wxID_ANY, _("Audio Track:"), wxDefaultPosition, wxDefaultSize, 0);
-        audioRowSizer->Add(StaticText_AudioTrack, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-        Choice_AudioTrack = new wxChoice(this, ID_CHOICE_AudioTrack, wxDefaultPosition, wxDLG_UNIT(this, wxSize(120, -1)), 0, nullptr, 0);
-        audioRowSizer->Add(Choice_AudioTrack, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-        // Insert before the last item in the top-level sizer (the OK/Cancel row)
-        auto* topSizer = GetSizer();
-        topSizer->Insert(topSizer->GetItemCount() - 1, audioRowSizer, 0, wxALL | wxALIGN_LEFT, 2);
+        FlexGridSizer2->Add(StaticText_AudioTrack, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
+        Choice_AudioTrack = new wxChoice(this, ID_CHOICE_AudioTrack, wxDefaultPosition, wxDefaultSize, 0, nullptr, 0);
+        FlexGridSizer2->Add(Choice_AudioTrack, 1, wxALL | wxEXPAND, 5);
+        FlexGridSizer2->Add(-1, -1, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
         Bind(wxEVT_CHOICE, [this](wxCommandEvent&) {
             int sel = Choice_AudioTrack->GetSelection();
             _vc->SetAudioTrack(sel > 0 ? Choice_AudioTrack->GetStringSelection().ToStdString() : "");
@@ -1374,12 +1372,18 @@ void ValueCurveDialog::ValidateWindow() {
 
     // Show audio track selector only for music-reactive types
     bool isMusicType = (type == "Music" || type == "Inverted Music" || type == "Music Trigger Fade");
+    bool audioWasVisible = (StaticText_AudioTrack != nullptr && StaticText_AudioTrack->IsShown());
     if (StaticText_AudioTrack != nullptr) StaticText_AudioTrack->Show(isMusicType);
     if (Choice_AudioTrack != nullptr) Choice_AudioTrack->Show(isMusicType);
     if (!isMusicType && _vc != nullptr) {
         _vc->SetAudioTrack("");
     }
     GetSizer()->Layout();
+    if (isMusicType != audioWasVisible) {
+        int currentWidth = GetSize().x;
+        Fit();
+        SetSize(currentWidth, GetSize().y);
+    }
 }
 
 void ValueCurveDialog::OnChar(wxKeyEvent& event) {

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.h
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.h
@@ -138,6 +138,10 @@ class ValueCurveDialog: public wxDialog
 		wxTextCtrl* TextCtrl_TimeOffset;
 		//*)
 
+        // Audio track choice (outside wxSmith guard)
+        wxStaticText* StaticText_AudioTrack = nullptr;
+        wxChoice* Choice_AudioTrack = nullptr;
+
 	protected:
 
 		//(*Identifiers(ValueCurveDialog)
@@ -173,6 +177,9 @@ class ValueCurveDialog: public wxDialog
 		static const long ID_BUTTON1;
 		static const long ID_BUTTON2;
 		//*)
+
+        // Audio track ID (outside wxSmith guard)
+        static const long ID_CHOICE_AudioTrack;
 
 	private:
 

--- a/src-ui-wx/wxsmith/ValueCurveDialog.wxs
+++ b/src-ui-wx/wxsmith/ValueCurveDialog.wxs
@@ -372,7 +372,7 @@
 					</object>
 					<object class="sizeritem">
 						<object class="wxFlexGridSizer" variable="FlexGridSizer8" member="no">
-							<cols>1</cols>
+							<cols>2</cols>
 							<object class="sizeritem">
 								<object class="wxButton" name="ID_BUTTON3" variable="ButtonLoad" member="yes">
 									<label>Load</label>

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -7809,6 +7809,18 @@ std::string xLightsFrame::PackageSequence(bool showDialogs)
             lostfiles[fnMedia.GetFullPath().ToStdString()] = lost;
         }
         prog.Update(35, fnMedia.GetFullName());
+
+        // Add alternate audio tracks
+        for (int i = 0; i < CurrentSeqXmlFile->GetAltTrackCount(); ++i) {
+            const auto& track = CurrentSeqXmlFile->GetAltTrack(i);
+            if (!track.path.empty()) {
+                wxFileName fnAlt(track.path);
+                lost = AddFileToZipFile(CurrentDir.ToStdString(), fnAlt.GetFullPath().ToStdString(), zip, zippedfiles);
+                if (lost != "") {
+                    lostfiles[fnAlt.GetFullPath().ToStdString()] = lost;
+                }
+            }
+        }
     } else {
         prog.Update(35, "Skipping audio.");
     }

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2575,6 +2575,23 @@ AudioManager* xLightsFrame::GetCurrentMediaManager() const
     return CurrentSeqXmlFile->GetMedia();
 }
 
+AudioManager* xLightsFrame::GetPlaybackAudio() const
+{
+    if (CurrentSeqXmlFile == nullptr) {
+        return nullptr;
+    }
+    if (mainSequencer != nullptr) {
+        int trackIdx = mainSequencer->GetActiveAudioTrackIndex();
+        if (trackIdx > 0) {
+            AudioManager* alt = CurrentSeqXmlFile->GetAltTrackMedia(trackIdx - 1);
+            if (alt != nullptr) {
+                return alt;
+            }
+        }
+    }
+    return CurrentSeqXmlFile->GetMedia();
+}
+
 const std::string& xLightsFrame::GetHeaderInfo(HEADER_INFO_TYPES type) const
 {
     static const std::string empty;

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -428,6 +428,7 @@ public:
     const std::string &GetShowDirectory() const override { return showDirectory; }
     const std::string &GetFseqDirectory() const override { return fseqDirectory; }
     AudioManager* GetCurrentMediaManager() const override;
+    AudioManager* GetPlaybackAudio() const; // Returns active alt track audio if selected, else main media
     const std::string& GetHeaderInfo(HEADER_INFO_TYPES type) const override;
     static wxString GetFilename() { return xlightsFilename; }
     void ConversionInit();


### PR DESCRIPTION
Add alternate audio tracks support allowing sequences to reference multiple audio files selectable per waveform and value curve.
#3820 #3620, #2715