### PR TITLE
Model Preview window reset to show the model(s) selected (#5758)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -change (dkulp)             Pinwheel effect now defaults to the New Render Method; existing sequences
                                     are migrated to preserve the Old Render Method so their look is unchanged.
     -enh (AGFazio)              Add 'Yes to All' / 'No to All' options when merging base show directory changes
+    -bug (derwin12)             Model preview reset after changing model (#5758)
     -bug (derwin12)             Fix Twinkle Steps value curve capped at 100 instead of 400 (#4347)
     -bug (AGFazio)              Fix submodels in a group showing at wrong indent level in sequencer element list
     -bug (derwin12)             Fix downloaded/imported models always getting start channel 1 (#6075)

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -3544,8 +3544,8 @@ void Model::DisplayEffectOnWindow(IModelPreview* preview, double pointSize)
             // cache has the model in model coordinates
             // we need to scale/translate/etc.... to world
             ctx->PushMatrix();
-            ctx->Translate(w / 2.0f - (ml < 0.0f ? ml : 0.0f),
-                           h / 2.0f - (mb < 0.0f ? mb : 0.0f), 0.0f);
+            ctx->Translate(w / 2.0f - ml * scale,
+                           h / 2.0f - mb * scale, 0.0f);
             ctx->Scale(scale, scale, 1.0);
             if (!GetModelScreenLocation().IsCenterBased()) {
                 ctx->Translate(-GetModelScreenLocation().RenderWi / 2.0,

--- a/src-core/models/ModelGroup.cpp
+++ b/src-core/models/ModelGroup.cpp
@@ -752,7 +752,7 @@ bool ModelGroup::RebuildBuffers() {
     }
 
     screenLocation.SetRenderSize(maxx - nminx + 1, maxy - nminy + 1);
-    screenLocation.SetPosition(BufferWi / 2.0f, BufferHt / 2.0f);
+    screenLocation.SetPosition(midX, midY);
 
     return true;
 }

--- a/src-ui-wx/ui/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/tabSequencer.cpp
@@ -1299,6 +1299,7 @@ void xLightsFrame::SelectedEffectChanged(SelectedEffectChangedEvent& event)
                     playEndTime = effect->GetEndTimeMS();
                     playStartMS = -1;
                     playModel = GetModel(effect->GetParentEffectLayer()->GetParentElement()->GetModelName());
+                    ResetModelPreviewIfModelChanged();
                     SetAudioControls();
                 }
             }
@@ -1321,6 +1322,15 @@ void xLightsFrame::SelectedRowChanged(wxCommandEvent& event)
 {
     mainSequencer->PanelRowHeadings->SetSelectedRow(event.GetInt());
     playModel = GetModel(event.GetString().ToStdString());
+    ResetModelPreviewIfModelChanged();
+}
+
+void xLightsFrame::ResetModelPreviewIfModelChanged()
+{
+    if (playModel != _lastPlayModel) {
+        _lastPlayModel = playModel;
+        _modelPreviewPanel->Reset();
+    }
 }
 
 void xLightsFrame::EffectDroppedOnGrid(wxCommandEvent& event)
@@ -1395,6 +1405,7 @@ void xLightsFrame::EffectDroppedOnGrid(wxCommandEvent& event)
             }
 
             playModel = GetModel(el->GetParentElement()->GetModelName());
+            ResetModelPreviewIfModelChanged();
 
 			SetAudioControls();
         }
@@ -1598,6 +1609,7 @@ void xLightsFrame::EffectFileDroppedOnGrid(wxCommandEvent& event)
             }
 
             playModel = GetModel(el->GetParentElement()->GetModelName());
+            ResetModelPreviewIfModelChanged();
 
             SetAudioControls();
         }
@@ -1627,6 +1639,7 @@ void xLightsFrame::PlayModel(wxCommandEvent& event)
 {
     std::string model = event.GetString().ToStdString();
     playModel = GetModel(model);
+    ResetModelPreviewIfModelChanged();
     if (playModel != nullptr
         && playType != PLAY_TYPE_MODEL) {
         wxCommandEvent playEvent(EVT_PLAY_SEQUENCE);
@@ -1655,6 +1668,7 @@ void xLightsFrame::ModelSelected(wxCommandEvent& event)
     if (playType == PLAY_TYPE_MODEL)
     {
         playModel = GetModel(event.GetString().ToStdString());
+        ResetModelPreviewIfModelChanged();
     }
 }
 
@@ -2274,6 +2288,7 @@ void xLightsFrame::PlayModelEffect(wxCommandEvent& event)
         EventPlayEffectArgs* args = (EventPlayEffectArgs*)event.GetClientData();
         if (args == nullptr || args->effect == nullptr || !_sequenceElements.IsValidEffect(args->effect)) return;
         playModel = GetModel(args->element->GetModelName());
+        ResetModelPreviewIfModelChanged();
         if (playModel != nullptr) {
             SetPlayStatus(PLAY_TYPE_EFFECT);
             playStartTime = (int)(args->effect->GetStartTimeMS());

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1759,6 +1759,8 @@ private:
     std::unique_ptr<RenderEngine> _renderEngine;
 
     Model *playModel;
+    Model *_lastPlayModel = nullptr;
+    void ResetModelPreviewIfModelChanged();
     int playType;
     int playStartMS;
     std::vector<std::list<FPSEvent>> fpsEvents;


### PR DESCRIPTION
When you click on a different model, the model preview brings the selected model into view. (#5758)

[skip ci]