### PR TITLE
Fix value curve manual entry showing values multiplied by divisor

### DIFF
--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -677,11 +677,11 @@ void ValueCurvePanel::SaveUndoSelected() {
 }
 
 float ValueCurvePanel::ToReal(float y) {
-    return _vc->GetMin() + y * (_vc->GetMax() - _vc->GetMin());
+    return (_vc->GetMin() + y * (_vc->GetMax() - _vc->GetMin())) / _vc->GetDivisor();
 }
 
 float ValueCurvePanel::ToNormalised(float y) {
-    return (y - _vc->GetMin()) / (_vc->GetMax() - _vc->GetMin());
+    return (y * _vc->GetDivisor() - _vc->GetMin()) / (_vc->GetMax() - _vc->GetMin());
 }
 
 void ValueCurvePanel::mouseLeftDClick(wxMouseEvent& event) {
@@ -694,10 +694,10 @@ void ValueCurvePanel::mouseLeftDClick(wxMouseEvent& event) {
             wxTextEntryDialog dlg(GetParent(), "Enter value:", "Manual entry", std::to_string(ToReal(_vc->GetPointAt(point))));
             if (dlg.ShowModal() == wxID_OK) {
                 float v = wxAtof(dlg.GetValue());
-                if (v < _vc->GetMin())
-                    v = _vc->GetMin();
-                if (v > _vc->GetMax())
-                    v = _vc->GetMax();
+                if (v < _vc->GetMin() / _vc->GetDivisor())
+                    v = _vc->GetMin() / _vc->GetDivisor();
+                if (v > _vc->GetMax() / _vc->GetDivisor())
+                    v = _vc->GetMax() / _vc->GetDivisor();
                 SaveUndoSelected();
                 _vc->SetValueAt(x, ToNormalised(v));
                 Refresh();


### PR DESCRIPTION
When double-clicking a point on a Custom value curve to manually enter a value, the displayed value was incorrectly scaled by the divisor (e.g. a field with range -500 to 500 would show 2000 instead of 200). Fixed ToReal() and ToNormalised() in ValueCurvePanel to correctly divide/multiply by the divisor, and updated the entry clamp bounds to match the displayed range.
The hover tooltip also benefits from this fix. Internal stored values (0–1 normalized) are unchanged.

Here is an image of how it was before the fix 
The values in the curve can go from -500 to 500 , but if you edit a point, it shows x10
<img width="844" height="695" alt="image" src="https://github.com/user-attachments/assets/7bb3a68b-8ac5-4915-8b0c-05c653e3e77e" />
