### PR TITLE
Add Start/End Level to Exponential, Logarithmic and Parabolic value curves

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.07  April ??, 2026
+    -enh (PB)                   Value curve Exponential, Logarithmic, and Parabolic types now support Start/End
+                                    Level (P3/P4) to constrain the output range. Sliders show field units for
+                                    intuitive entry. Existing sequences unaffected.
     -bug (derwin12)             Fix base show folder merge not detecting child element changes (#4265)
     -bug (derwin12)             Preserve Layer Blending and Settings when using Random Effects (#6136)
     -bug (AGFazio)              Honour 2D to 3D Layout changing (#6133)

--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -398,21 +398,33 @@ void ValueCurve::GetRangeParm3(const std::string& type, float& low, float &high)
     }
     else if (type == "Parabolic Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Parabolic Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Logarithmic Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Logarithmic Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Exponential Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Exponential Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Sine")
     {
@@ -479,21 +491,33 @@ void ValueCurve::GetRangeParm4(const std::string& type, float& low, float &high)
     }
     else if (type == "Parabolic Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Parabolic Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Logarithmic Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Logarithmic Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Exponential Up")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Exponential Down")
     {
+        low = MINVOID;
+        high = MAXVOID;
     }
     else if (type == "Sine")
     {
@@ -724,14 +748,15 @@ void ValueCurve::UnFixChangedScale(float newmin, float newmax)
         _parameter2 = _parameter2 * newrange / oldrange + mindiff;
     }
 
+    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID)
+    if (min == MINVOID && !p34Legacy)
     {
         _parameter3 = _parameter3 * newrange / oldrange + mindiff;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID)
+    if (min == MINVOID && !p34Legacy)
     {
         _parameter4 = _parameter4 * newrange / oldrange + mindiff;
     }
@@ -788,14 +813,18 @@ void ValueCurve::FixChangedScale(float newmin, float newmax, int divisor)
         _parameter2 = (_parameter2 * newrange / oldrange + mindiff); // / divisor;
     }
 
+    // Protect legacy curves where P3/P4 were both 0 (unset). With MINVOID ranges,
+    // FixChangedScale would otherwise shift these zeros into field-unit space, wrongly
+    // activating the Start/End Level feature on old sequences.
+    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID)
+    if (min == MINVOID && !p34Legacy)
     {
         _parameter3 = (_parameter3 * newrange / oldrange + mindiff); // / divisor;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID)
+    if (min == MINVOID && !p34Legacy)
     {
         _parameter4 = (_parameter4 * newrange / oldrange + mindiff); // / divisor;
     }
@@ -826,13 +855,14 @@ void ValueCurve::ConvertChangedScale(float newmin, float newmax)
         _parameter2 = (_parameter2 - _min) * newrange / oldrange + newmin;
     }
 
+    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID) {
+    if (min == MINVOID && !p34Legacy) {
         _parameter3 = (_parameter3 - _min) * newrange / oldrange + newmin;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID) {
+    if (min == MINVOID && !p34Legacy) {
         _parameter4 = (_parameter4 - _min) * newrange / oldrange + newmin;
     }
 
@@ -984,7 +1014,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Parabolic Up")
@@ -1017,7 +1053,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Logarithmic Up")
@@ -1049,7 +1091,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Logarithmic Down")
@@ -1081,7 +1129,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Exponential Up")
@@ -1113,7 +1167,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Exponential Down")
@@ -1145,7 +1205,13 @@ void ValueCurve::RenderType()
             }
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
-            _values.push_back(vcSortablePoint(i, Safe01(y), (lastwrapped != wrapped)));
+            float fy = Safe01(y);
+            if (_parameter3 != 0 || _parameter4 != 0) {
+                float sn = parameter3 / 100.0f;
+                float en = parameter4 / 100.0f;
+                fy = Safe01(sn + fy * (en - sn));
+            }
+            _values.push_back(vcSortablePoint(i, fy, (lastwrapped != wrapped)));
         }
     }
     else if (_type == "Sine")

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -594,21 +594,33 @@ void ValueCurveDialog::OnChoice1Select(wxCommandEvent& event) {
     } else if (type == "Parabolic Down") {
         SetParameter100(1, 4);
         SetParameter100(2, 0);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Parabolic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Logarithmic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Logarithmic Down") {
         SetParameter100(1, 15);
         SetParameter100(2, 50);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Exponential Up") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Exponential Down") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
+        SetParameter100(3, 0);
+        SetParameter100(4, 100);
     } else if (type == "Sine") {
         SetParameter100(1, 75);
         _vc->SetTimeOffset(0);
@@ -1149,7 +1161,7 @@ void ValueCurveDialog::ValidateWindow() {
         TextCtrl_Parameter3->Disable();
         Slider_Parameter4->Disable();
         TextCtrl_Parameter4->Disable();
-    } else if (type == "Ramp" || type == "Parabolic Down" || type == "Parabolic Up" || type == "Logarithmic Up" || type == "Logarithmic Down" || type == "Exponential Up" || type == "Exponential Down" || type == "Timing Track Toggle") {
+    } else if (type == "Ramp" || type == "Timing Track Toggle") {
         Slider_Parameter1->Enable();
         TextCtrl_Parameter1->Enable();
         Slider_Parameter2->Enable();
@@ -1158,6 +1170,15 @@ void ValueCurveDialog::ValidateWindow() {
         TextCtrl_Parameter3->Disable();
         Slider_Parameter4->Disable();
         TextCtrl_Parameter4->Disable();
+    } else if (type == "Parabolic Down" || type == "Parabolic Up" || type == "Logarithmic Up" || type == "Logarithmic Down" || type == "Exponential Up" || type == "Exponential Down") {
+        Slider_Parameter1->Enable();
+        TextCtrl_Parameter1->Enable();
+        Slider_Parameter2->Enable();
+        TextCtrl_Parameter2->Enable();
+        Slider_Parameter3->Enable();
+        TextCtrl_Parameter3->Enable();
+        Slider_Parameter4->Enable();
+        TextCtrl_Parameter4->Enable();
     } else if (type == "Saw Tooth" || type == "Ramp Up/Down Hold" || type == "Ramp Up/Down" || type == "Square" || type == "Random" || type == "Music" || type == "Inverted Music" || type == "Timing Track Fade Fixed" || type == "Timing Track Fade Proportional") {
         Slider_Parameter1->Enable();
         TextCtrl_Parameter1->Enable();
@@ -1243,39 +1264,29 @@ void ValueCurveDialog::ValidateWindow() {
         _vc->SetParameter4(0);
     } else if (type == "Parabolic Down") {
         StaticText_P1->SetLabel("Slope");
-        StaticText_P2->SetLabel("Low");
-        StaticText_P3->SetLabel("N/A");
-        StaticText_P4->SetLabel("N/A");
-        _vc->SetParameter3(0);
-        _vc->SetParameter4(0);
+        StaticText_P2->SetLabel("Vertical Offset");
+        StaticText_P3->SetLabel("Start Level");
+        StaticText_P4->SetLabel("End Level");
     } else if (type == "Parabolic Up") {
         StaticText_P1->SetLabel("Slope");
-        StaticText_P2->SetLabel("High");
-        StaticText_P3->SetLabel("N/A");
-        StaticText_P4->SetLabel("N/A");
-        _vc->SetParameter3(0);
-        _vc->SetParameter4(0);
+        StaticText_P2->SetLabel("Vertical Offset");
+        StaticText_P3->SetLabel("Start Level");
+        StaticText_P4->SetLabel("End Level");
     } else if (type == "Logarithmic Up") {
         StaticText_P1->SetLabel("Rate");
         StaticText_P2->SetLabel("Vertical Offset");
-        StaticText_P3->SetLabel("N/A");
-        StaticText_P4->SetLabel("N/A");
-        _vc->SetParameter3(0);
-        _vc->SetParameter4(0);
+        StaticText_P3->SetLabel("Start Level");
+        StaticText_P4->SetLabel("End Level");
     } else if (type == "Logarithmic Down") {
         StaticText_P1->SetLabel("Rate");
         StaticText_P2->SetLabel("Vertical Offset");
-        StaticText_P3->SetLabel("N/A");
-        StaticText_P4->SetLabel("N/A");
-        _vc->SetParameter3(0);
-        _vc->SetParameter4(0);
+        StaticText_P3->SetLabel("Start Level");
+        StaticText_P4->SetLabel("End Level");
     } else if (type == "Exponential Up" || type == "Exponential Down") {
         StaticText_P1->SetLabel("Rate");
         StaticText_P2->SetLabel("Vertical Offset");
-        StaticText_P3->SetLabel("N/A");
-        StaticText_P4->SetLabel("N/A");
-        _vc->SetParameter3(0);
-        _vc->SetParameter4(0);
+        StaticText_P3->SetLabel("Start Level");
+        StaticText_P4->SetLabel("End Level");
     } else if (type == "Sine") {
         StaticText_P1->SetLabel("Start");
         StaticText_P2->SetLabel("Amplitude");


### PR DESCRIPTION
Before you couldn't set the start and endpoints of certain value curves, like exponential,  so if you set it on brightness for example it was 0-400 .. now you can set it to 0-100 if you like as Im using the 3rd and 4th sliders (P3 P4) :)

P3/P4 were unused for these six curve types. They now set a Start Level and End Level in field units, constraining the output to a sub-range while preserving the curve shape.

Fully backward compatible — existing sequences have P3=P4=0 and the remapping is skipped entirely when both are zero.