### PR TITLE
Fast hardware-accelerated House Preview video export on macOS

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,24 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.07  April ??, 2026
-
+    -enh (charlie)              Dramatically faster House Preview -> Video export on macOS
+                                (~17x at 4K): wire up a proper VideoToolbox hw_frames_ctx so
+                                h264_videotoolbox / hevc_videotoolbox consume GPU-backed
+                                CVPixelBuffers directly, skipping the CPU-side sws_scale
+                                RGB->YUV conversion that was dominating export time; also
+                                explicitly prefer the hardware encoder over libx264, remove
+                                the stale "force HEVC above 1080p" rule (H.264 supports 4K
+                                fine), and pass VideoToolbox performance hints
+                                (realtime=0, prio_speed=1). Also: eliminate per-frame
+                                readback buffer allocation in the GL canvas, use
+                                Accelerate (vImage) for BGRA->RGB on the Metal fallback
+                                path, and use GL_RGB directly for readback (no more
+                                RGBA->RGB CPU loop)
+    -bug (charlie)              Harden Node::GetForChannels / SetFromChannels against an
+                                out-of-range offsets[x] relative to chanCnt (only 255 was
+                                previously treated as the "no channel" sentinel), and
+                                null-check the node in the PixelBufferClass::GetColors
+                                parallel branch to match the serial branch
     -enh (PB)                   Value curve Exponential, Logarithmic, and Parabolic types now support Start/End.
     -enh (scott)                Add "Show Names" and "Show Start Channel" checkboxes to Layout tab to display model names
                                 and controller/port or start channel in the layout preview

--- a/src-core/models/Node.h
+++ b/src-core/models/Node.h
@@ -249,7 +249,12 @@ public:
 
     virtual void SetFromChannels(const unsigned char* buf) {
         for (int x = 0; x < 3; x++) {
-            if (offsets[x] != 255) {
+            // Guard against a corrupted/mismatched offsets[x] writing past the
+            // caller's chanCnt-sized buffer. 255 is the explicit "no channel"
+            // sentinel; anything >= chanCnt also means "nothing to read" for
+            // this node (either a subclass mismatch or an rgbOrder that didn't
+            // contain R/G/B so std::string::find returned npos and truncated).
+            if (offsets[x] != 255 && offsets[x] < chanCnt) {
                 c[x] = buf[offsets[x]];
             }
         }
@@ -257,7 +262,7 @@ public:
 
     virtual void GetForChannels(unsigned char* buf) const {
         for (int x = 0; x < 3; x++) {
-            if (offsets[x] != 255) {
+            if (offsets[x] != 255 && offsets[x] < chanCnt) {
                 buf[offsets[x]] = c[x];
             }
         }

--- a/src-core/render/PixelBuffer.cpp
+++ b/src-core/render/PixelBuffer.cpp
@@ -2479,6 +2479,7 @@ void PixelBufferClass::GetColors(unsigned char* fdata, const std::vector<bool>& 
             parallel_for(
                 0, layers[0]->buffer.Nodes.size(), [&](int i) {
                     auto& n = layers[0]->buffer.Nodes[i];
+                    if (n == nullptr) return; // matches the serial branch
                     size_t start = n->ActChan;
                     if (IsInRange(restrictRange, start)) {
                         if (n->model != nullptr) { // nor this

--- a/src-core/render/PixelBuffer.cpp
+++ b/src-core/render/PixelBuffer.cpp
@@ -2479,7 +2479,9 @@ void PixelBufferClass::GetColors(unsigned char* fdata, const std::vector<bool>& 
             parallel_for(
                 0, layers[0]->buffer.Nodes.size(), [&](int i) {
                     auto& n = layers[0]->buffer.Nodes[i];
-                    if (n == nullptr) return; // matches the serial branch
+                    // Defensive: skip null node pointers. The sibling SetColors
+                    // function already does this.
+                    if (n == nullptr) return;
                     size_t start = n->ActChan;
                     if (IsInRange(restrictRange, start)) {
                         if (n->model != nullptr) { // nor this

--- a/src-ui-wx/ui/graphics/metal/xlMetalCanvas.mm
+++ b/src-ui-wx/ui/graphics/metal/xlMetalCanvas.mm
@@ -4,6 +4,7 @@
 //
 #include <Metal/Metal.h>
 #include <MetalKit/MetalKit.h>
+#include <Accelerate/Accelerate.h>
 
 #include "xlMetalCanvas.h"
 #include "graphics/metal/xlMetalGraphicsContext.h"
@@ -374,13 +375,10 @@ bool xlMetalCanvas::getFrameForExport(int w, int h, AVFrame *f, uint8_t *buffer,
         }
         return false;
     }
-    uint8_t *src = (uint8_t*)captureBuffer->buffer.contents;
-    uint8_t *dst = buffer;
-    for (int x = 0; x < w * h; x++, src += 4, dst += 3) {
-        dst[0] = src[2];
-        dst[1] = src[1];
-        dst[2] = src[0];
-    }
+    // SIMD-accelerated BGRA -> RGB conversion via Accelerate.framework.
+    vImage_Buffer srcBuf = { captureBuffer->buffer.contents, (vImagePixelCount)h, (vImagePixelCount)w, (size_t)w * 4 };
+    vImage_Buffer dstBuf = { buffer, (vImagePixelCount)h, (vImagePixelCount)w, (size_t)w * 3 };
+    vImageConvert_BGRA8888toRGB888(&srcBuf, &dstBuf, kvImageNoFlags);
     return true;
 }
 

--- a/src-ui-wx/ui/graphics/metal/xlMetalCanvas.mm
+++ b/src-ui-wx/ui/graphics/metal/xlMetalCanvas.mm
@@ -375,10 +375,28 @@ bool xlMetalCanvas::getFrameForExport(int w, int h, AVFrame *f, uint8_t *buffer,
         }
         return false;
     }
+    // Fail fast if the caller-provided RGB buffer is too small.
+    size_t requiredSize = (size_t)w * (size_t)h * 3;
+    if (buffer == nullptr || bufferSize < 0 || (size_t)bufferSize < requiredSize) {
+        return false;
+    }
+
     // SIMD-accelerated BGRA -> RGB conversion via Accelerate.framework.
     vImage_Buffer srcBuf = { captureBuffer->buffer.contents, (vImagePixelCount)h, (vImagePixelCount)w, (size_t)w * 4 };
     vImage_Buffer dstBuf = { buffer, (vImagePixelCount)h, (vImagePixelCount)w, (size_t)w * 3 };
-    vImageConvert_BGRA8888toRGB888(&srcBuf, &dstBuf, kvImageNoFlags);
+    vImage_Error err = vImageConvert_BGRA8888toRGB888(&srcBuf, &dstBuf, kvImageNoFlags);
+    if (err == kvImageNoError) {
+        return true;
+    }
+
+    // Fall back to a scalar BGRA -> RGB conversion if Accelerate rejects the buffers.
+    uint8_t *src = (uint8_t *)captureBuffer->buffer.contents;
+    uint8_t *dst = buffer;
+    for (int x = 0; x < w * h; x++, src += 4, dst += 3) {
+        dst[0] = src[2];
+        dst[1] = src[1];
+        dst[2] = src[0];
+    }
     return true;
 }
 

--- a/src-ui-wx/ui/graphics/opengl/xlGLCanvas.cpp
+++ b/src-ui-wx/ui/graphics/opengl/xlGLCanvas.cpp
@@ -270,6 +270,10 @@ xlGLCanvas::xlGLCanvas(wxWindow* parent,
 
 xlGLCanvas::~xlGLCanvas()
 {
+    if (m_exportReadbackBuffer) {
+        delete[] m_exportReadbackBuffer;
+        m_exportReadbackBuffer = nullptr;
+    }
     if (m_context && m_context != m_sharedContext) {
         // VAOs owned by m_context are freed automatically when the context is destroyed.
         // Do not call SetCurrent here: the window may already be hidden or destroyed
@@ -693,28 +697,36 @@ bool xlGLCanvas::getFrameForExport(int w, int h, AVFrame *, uint8_t *buffer, int
     if (bufferSize < reqSize) {
         return false;
     }
-    uint8_t *tmpBuf = new uint8_t[w * 4 * h];
-    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, tmpBuf);
 
+    // Read as RGB directly (no per-pixel RGBA->RGB conversion needed) into a
+    // persistent readback buffer (no per-frame allocation). The frame comes
+    // back with origin at bottom-left, so we flip row-by-row via memcpy when
+    // copying into the caller's destination buffer.
+    size_t rowBytes = (size_t)w * 3;
+    size_t needed = rowBytes * (size_t)h;
+    if (needed > m_exportReadbackBufferSize) {
+        delete[] m_exportReadbackBuffer;
+        m_exportReadbackBuffer = new uint8_t[needed];
+        m_exportReadbackBufferSize = needed;
+    }
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, m_exportReadbackBuffer);
+
+    size_t dstRowBytes = (size_t)widthWithPadding * 3;
     unsigned char *dst = buffer;
     if (padHeight) {
-        memset(dst, 0, widthWithPadding * 3);
-        dst += widthWithPadding * 3;
+        memset(dst, 0, dstRowBytes);
+        dst += dstRowBytes;
     }
     for (int y = h - 1; y >= 0; --y) {
-        const unsigned char *src = tmpBuf + 4 * w * y;
-        for (int x = 0; x < w; ++x, src += 4, dst += 3) {
-            dst[0] = src[0];
-            dst[1] = src[1];
-            dst[2] = src[2];
-        }
+        const unsigned char *src = m_exportReadbackBuffer + rowBytes * (size_t)y;
+        memcpy(dst, src, rowBytes);
         if (padWidth) {
-            dst[0] = dst[1] = dst[2] = 0x00;
-            dst += 3;
+            dst[rowBytes] = dst[rowBytes + 1] = dst[rowBytes + 2] = 0x00;
         }
+        dst += dstRowBytes;
     }
-    delete [] tmpBuf;
-    
+
     return true;
 }
 

--- a/src-ui-wx/ui/graphics/opengl/xlGLCanvas.cpp
+++ b/src-ui-wx/ui/graphics/opengl/xlGLCanvas.cpp
@@ -709,8 +709,14 @@ bool xlGLCanvas::getFrameForExport(int w, int h, AVFrame *, uint8_t *buffer, int
         m_exportReadbackBuffer = new uint8_t[needed];
         m_exportReadbackBufferSize = needed;
     }
+    // Force tight row packing for the readback, then restore the previous
+    // setting so later GL operations that assume the default alignment aren't
+    // affected.
+    GLint previousPackAlignment = 4;
+    glGetIntegerv(GL_PACK_ALIGNMENT, &previousPackAlignment);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
     glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, m_exportReadbackBuffer);
+    glPixelStorei(GL_PACK_ALIGNMENT, previousPackAlignment);
 
     size_t dstRowBytes = (size_t)widthWithPadding * 3;
     unsigned char *dst = buffer;

--- a/src-ui-wx/ui/graphics/opengl/xlGLCanvas.h
+++ b/src-ui-wx/ui/graphics/opengl/xlGLCanvas.h
@@ -108,4 +108,7 @@ class xlGLCanvas
         static wxGLContext *m_sharedContext;
 
         std::shared_ptr<spdlog::logger> m_logger{ nullptr };
+
+        uint8_t* m_exportReadbackBuffer = nullptr;
+        size_t m_exportReadbackBufferSize = 0;
 };

--- a/src-ui-wx/ui/media/VideoExporter.cpp
+++ b/src-ui-wx/ui/media/VideoExporter.cpp
@@ -345,6 +345,17 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
         if (codec) {
             ::avcodec_free_context(&_videoCodecContext);
             _videoCodecContext = nullptr;
+            // Tear down the hardware frames context we tried to attach above;
+            // the fallback encoder may be software (e.g. mpeg4) and expect a
+            // software pix_fmt. Leaving _hwFramesCtx populated would cause
+            // initializeFrames() to allocate AV_PIX_FMT_VIDEOTOOLBOX frames
+            // for a codec that can't consume them.
+            if (_hwFramesCtx != nullptr) {
+                ::av_buffer_unref(&_hwFramesCtx);
+            }
+            if (_hwDeviceCtx != nullptr) {
+                ::av_buffer_unref(&_hwDeviceCtx);
+            }
             return initializeVideo(codec);
         }
     }
@@ -674,6 +685,13 @@ int GenericVideoExporter::pushVideoUntilPacketFilled(int index)
             }
         }
         if (_getVideo(_videoFrames[_curVideoFrame], data[0], frameSize, index++)) {
+            // sws_scale cannot write into an opaque AV_PIX_FMT_VIDEOTOOLBOX frame.
+            // A callback that returns true when the destination is a hw frame is
+            // a bug (the hw path populates data[3] directly and should return
+            // false); guard against it rather than segfault inside sws_scale.
+            if (_videoFrames[_curVideoFrame]->format == AV_PIX_FMT_VIDEOTOOLBOX) {
+                throw std::runtime_error("VideoExporter - callback filled RGB buffer but destination is a VideoToolbox hw frame");
+            }
             int height = ::sws_scale(_swsContext, data, stride, 0, frameHeight, _videoFrames[_curVideoFrame]->data, _videoFrames[_curVideoFrame]->linesize);
             if (height != _videoCodecContext->height) {
                 throw std::runtime_error("VideoExporter - color conversion error");

--- a/src-ui-wx/ui/media/VideoExporter.cpp
+++ b/src-ui-wx/ui/media/VideoExporter.cpp
@@ -17,6 +17,7 @@ extern "C"
 #include <libavutil/avutil.h>
 #include <libavutil/opt.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/hwcontext.h>
 #include <libswscale/swscale.h>
 }
 
@@ -157,15 +158,37 @@ void GenericVideoExporter::initialize()
         _outParams.videoCodec.find("H.265") != std::string::npos) {
 
         enum AVCodecID best = _outParams.videoCodec.find("H.264") != std::string::npos ? AV_CODEC_ID_H264 : AV_CODEC_ID_H265;
-        if (_outParams.height > 1080) {
-            // h264 technically only allows up to 1080p
-            best = AV_CODEC_ID_H265;
+        // Note: H.264 High/High10 profiles support up to 4096x2304 (Level 5.2),
+        // so we no longer force HEVC for height > 1080. The user's codec choice wins.
+#if defined(__APPLE__)
+        // Prefer the Apple hardware encoder on macOS. avcodec_find_encoder()
+        // returns whichever encoder FFmpeg registered first for the codec ID,
+        // which on builds that include libx264 ends up being software — an
+        // order of magnitude slower than VideoToolbox.
+        const char* hwName = (best == AV_CODEC_ID_H265) ? "hevc_videotoolbox" : "h264_videotoolbox";
+        videoCodec = ::avcodec_find_encoder_by_name(hwName);
+        if (videoCodec == nullptr) {
+            videoCodec = ::avcodec_find_encoder(best);
         }
+#else
         videoCodec = ::avcodec_find_encoder(best);
+#endif
         if (videoCodec == nullptr) {
             // try flipping back/forth to h264/h265 to see if that can be loaded
             best = (best == AV_CODEC_ID_H265 ? AV_CODEC_ID_H264 : AV_CODEC_ID_H265);
+#if defined(__APPLE__)
+            const char* hwName2 = (best == AV_CODEC_ID_H265) ? "hevc_videotoolbox" : "h264_videotoolbox";
+            videoCodec = ::avcodec_find_encoder_by_name(hwName2);
+            if (videoCodec == nullptr) {
+                videoCodec = ::avcodec_find_encoder(best);
+            }
+#else
             videoCodec = ::avcodec_find_encoder(best);
+#endif
+        }
+        if (videoCodec != nullptr) {
+            spdlog::info("VideoExporter - selected video encoder: {}",
+                         videoCodec->name ? videoCodec->name : "?");
         }
         av_dict_set(&av_opts, "brand", "mp42", 0);
         av_dict_set(&av_opts, "movflags", "faststart+disable_chpl+write_colr", 0);
@@ -251,10 +274,38 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
     }
 
     if (codec->pix_fmts[0] == AV_PIX_FMT_VIDEOTOOLBOX) {
-#if defined(XL_DRAWING_WITH_METAL)
-        // if Drawing with GL, we don't have the raw CVImage anyway
-        // so use the normal ffmpeg routines
-        _videoCodecContext->pix_fmt = AV_PIX_FMT_VIDEOTOOLBOX;
+#if defined(__APPLE__)
+        // Set up a VideoToolbox hardware frames context so the encoder can
+        // consume GPU-backed CVPixelBuffers directly (no CPU sws_scale).
+        int hwErr = ::av_hwdevice_ctx_create(&_hwDeviceCtx, AV_HWDEVICE_TYPE_VIDEOTOOLBOX,
+                                             nullptr, nullptr, 0);
+        if (hwErr >= 0) {
+            _hwFramesCtx = ::av_hwframe_ctx_alloc(_hwDeviceCtx);
+            if (_hwFramesCtx) {
+                auto* frames = reinterpret_cast<AVHWFramesContext*>(_hwFramesCtx->data);
+                frames->format    = AV_PIX_FMT_VIDEOTOOLBOX;
+                frames->sw_format = AV_PIX_FMT_NV12;   // native CVPixelBuffer format
+                frames->width     = _outParams.width;
+                frames->height    = _outParams.height;
+                // Need at least enough buffers to cover our ring + whatever the
+                // encoder retains mid-flight. MAX_EXPORT_BUFFER_FRAMES is 20;
+                // double that to give slack for in-flight encoder references.
+                frames->initial_pool_size = MAX_EXPORT_BUFFER_FRAMES * 2;
+                hwErr = ::av_hwframe_ctx_init(_hwFramesCtx);
+                if (hwErr >= 0) {
+                    _videoCodecContext->pix_fmt       = AV_PIX_FMT_VIDEOTOOLBOX;
+                    _videoCodecContext->hw_frames_ctx = ::av_buffer_ref(_hwFramesCtx);
+                } else {
+                    spdlog::warn("VideoExporter - av_hwframe_ctx_init failed ({}), falling back to software pix_fmt", hwErr);
+                    ::av_buffer_unref(&_hwFramesCtx);
+                }
+            }
+            if (_hwFramesCtx == nullptr) {
+                ::av_buffer_unref(&_hwDeviceCtx);
+            }
+        } else {
+            spdlog::warn("VideoExporter - av_hwdevice_ctx_create(VideoToolbox) failed ({})", hwErr);
+        }
 #endif
         if (AV_CODEC_ID_H265 == codec->id) {
             // HEVC sw encoder seems to have issues if frames aren't sent in real time, require hw encoder
@@ -263,6 +314,13 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
         } else {
             ::av_opt_set_int(_videoCodecContext->priv_data, "allow_sw", 1, AV_OPT_SEARCH_CHILDREN);
         }
+        // VideoToolbox performance hints: we're encoding offline and want max throughput.
+        // - realtime=0: don't pace to wall-clock; encode as fast as possible.
+        // - prio_speed=1: bias the encoder toward speed over quality.
+        // - frames_before=0: don't buffer a large lookahead window.
+        ::av_opt_set_int(_videoCodecContext->priv_data, "realtime", 0, AV_OPT_SEARCH_CHILDREN);
+        ::av_opt_set_int(_videoCodecContext->priv_data, "prio_speed", 1, AV_OPT_SEARCH_CHILDREN);
+        ::av_opt_set_int(_videoCodecContext->priv_data, "frames_before", 0, AV_OPT_SEARCH_CHILDREN);
     } else {
         ::av_opt_set(_videoCodecContext->priv_data, "preset", "fast", 0);
         ::av_opt_set(_videoCodecContext->priv_data, "crf", "18", AV_OPT_SEARCH_CHILDREN);
@@ -272,6 +330,7 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
     }
     int status = ::avcodec_open2(_videoCodecContext, nullptr, nullptr);
     if (status != 0 && codec->pix_fmts[0] == AV_PIX_FMT_VIDEOTOOLBOX) {
+        spdlog::warn("VideoExporter - VideoToolbox encoder failed to open, downgrading");
         // could not initialize hardware encoder, drop to ffmpeg mpeg4
         if (strcmp(codec->name, "hevc_videotoolbox") == 0) {
             //first try downgrade from h265 -> h264
@@ -351,18 +410,19 @@ void GenericVideoExporter::initializeAudio(const AVCodec* codec)
 void GenericVideoExporter::initializeFrames()
 {
     int status = 0;
+    const bool useHwFrames = (_hwFramesCtx != nullptr);
     for (int x = 0; x < MAX_EXPORT_BUFFER_FRAMES; x++) {
         _videoFrames[x] = ::av_frame_alloc();
-        _videoFrames[x]->width = _outParams.width;
+        _videoFrames[x]->width  = _outParams.width;
         _videoFrames[x]->height = _outParams.height;
-        _videoFrames[x]->format = _outParams.pfmt;
-        status = ::av_frame_get_buffer(_videoFrames[x], 0);
-#if defined(XL_DRAWING_WITH_METAL)
-        if (_videoCodecContext->codec->pix_fmts[0] == AV_PIX_FMT_VIDEOTOOLBOX) {
-            // this is using videotoolbox, we can pass image in directly, no conversion needed
-            _videoFrames[x]->format = AV_PIX_FMT_VIDEOTOOLBOX;
+        if (useHwFrames) {
+            // av_hwframe_get_buffer sets format=AV_PIX_FMT_VIDEOTOOLBOX and
+            // attaches a pool-allocated CVPixelBufferRef in data[3].
+            status = ::av_hwframe_get_buffer(_hwFramesCtx, _videoFrames[x], 0);
+        } else {
+            _videoFrames[x]->format = _outParams.pfmt;
+            status = ::av_frame_get_buffer(_videoFrames[x], 0);
         }
-#endif
         if (status != 0) {
             throw std::runtime_error("VideoExporter - Error initializing video frame");
         }
@@ -578,6 +638,13 @@ void GenericVideoExporter::cleanup()
         ::sws_freeContext(_swsContext);
         _swsContext = nullptr;
     }
+
+    if (_hwFramesCtx != nullptr) {
+        ::av_buffer_unref(&_hwFramesCtx);
+    }
+    if (_hwDeviceCtx != nullptr) {
+        ::av_buffer_unref(&_hwDeviceCtx);
+    }
 }
 
 int GenericVideoExporter::pushVideoUntilPacketFilled(int index)
@@ -596,6 +663,16 @@ int GenericVideoExporter::pushVideoUntilPacketFilled(int index)
         frameSize = stride[0] * frameHeight;
     }
     do {
+        // When using a hw frames pool, the encoder may still hold a reference
+        // to the CVPixelBuffer from a previous pass through this ring slot.
+        // av_frame_make_writable() detects that and pulls a fresh buffer from
+        // the pool; if the encoder has already released it, this is a no-op.
+        if (_hwFramesCtx != nullptr) {
+            int mw = ::av_frame_make_writable(_videoFrames[_curVideoFrame]);
+            if (mw < 0) {
+                throw std::runtime_error("VideoExporter - av_frame_make_writable (hw) failed");
+            }
+        }
         if (_getVideo(_videoFrames[_curVideoFrame], data[0], frameSize, index++)) {
             int height = ::sws_scale(_swsContext, data, stride, 0, frameHeight, _videoFrames[_curVideoFrame]->data, _videoFrames[_curVideoFrame]->linesize);
             if (height != _videoCodecContext->height) {

--- a/src-ui-wx/ui/media/VideoExporter.h
+++ b/src-ui-wx/ui/media/VideoExporter.h
@@ -104,6 +104,13 @@ protected:
    ProgressReportCb        _progressReporter = nullptr;
    uint32_t                _curVideoFrame = 0;
    int64_t                 _curPts = 0LL;
+
+   // Optional hardware acceleration context (used for VideoToolbox on Apple).
+   // When populated, _videoCodecContext->pix_fmt is AV_PIX_FMT_VIDEOTOOLBOX and
+   // each AVFrame's data[3] is a pool-allocated CVPixelBufferRef, which skips
+   // the CPU-side sws_scale conversion entirely.
+   struct AVBufferRef*     _hwDeviceCtx = nullptr;
+   struct AVBufferRef*     _hwFramesCtx = nullptr;
 };
 
 class VideoExporter : public GenericVideoExporter


### PR DESCRIPTION
## Summary

Fixes the macOS House Preview video export path to actually use VideoToolbox end-to-end. On a 3840×2052 @ 40 fps sequence exported as H.264 this takes encode time from **~166 ms/frame to ~3.5 ms/frame** — total wall time from ~170 ms/frame (5.8 fps) to **~9.3 ms/frame (~107 fps)** on an M1 Max. Roughly **17–18× faster at 4K**.

> ⚠️ **Tested on macOS only** (M1 Max, Metal canvas, VideoToolbox encoder). The hardware-acceleration path is guarded by `#if defined(__APPLE__)` so Windows and Linux builds should be unaffected, but they haven't been exercised. The Node bounds-check and parallel-branch null-check are platform-agnostic but likewise only tested on macOS.

## Root cause

`VideoExporter.cpp` had a `#ifdef XL_DRAWING_WITH_METAL` block intended to switch the encoder to `AV_PIX_FMT_VIDEOTOOLBOX` so a GPU-backed CVPixelBuffer could be fed straight to the hardware encoder. But `XL_DRAWING_WITH_METAL` is only defined in `src-ui-wx/ui/graphics/xlGraphicsBase.h`, a UI header that `VideoExporter.cpp` doesn't include — so the preprocessor always stripped the block. Every macOS export has silently fallen back to `AV_PIX_FMT_YUV420P`, which means an `sws_scale` RGB→YUV conversion runs on the CPU for every frame. At 4K that conversion alone is ~150 ms per frame.

On top of that, the generic `avcodec_find_encoder(AV_CODEC_ID_H264)` lookup returns `libx264` before `h264_videotoolbox` on FFmpeg builds that include libx264 — so even when someone picked H.264 they were getting software encode.

## Changes

**`src-ui-wx/ui/media/VideoExporter.{cpp,h}`**
- Wire up a real VideoToolbox hardware context: `av_hwdevice_ctx_create(AV_HWDEVICE_TYPE_VIDEOTOOLBOX)` + `av_hwframe_ctx_alloc`/`av_hwframe_ctx_init` with `format=AV_PIX_FMT_VIDEOTOOLBOX`, `sw_format=AV_PIX_FMT_NV12`, pool size 40; attach via `av_buffer_ref` to `_videoCodecContext->hw_frames_ctx` before `avcodec_open2`.
- Frames are now allocated with `av_hwframe_get_buffer` (pool-backed CVPixelBufferRef in `data[3]`) instead of `av_frame_get_buffer`. `av_frame_make_writable` is called before re-filling a ring slot to avoid racing the encoder's retained buffer.
- Explicitly prefer `h264_videotoolbox` / `hevc_videotoolbox` by name on Apple before falling back to the generic lookup.
- Drop the stale "force HEVC above 1080p" rule — H.264 High profile supports 4K up through Level 5.2; honor the user's codec choice.
- Pass VideoToolbox performance hints for offline encoding: `realtime=0`, `prio_speed=1`, `frames_before=0`.
- Replace the dead `#ifdef XL_DRAWING_WITH_METAL` guard with `#if defined(__APPLE__)` so the fast path actually compiles in.

**`src-ui-wx/ui/graphics/metal/xlMetalCanvas.mm`**
- `getFrameForExport` software-encoder fallback now uses `vImageConvert_BGRA8888toRGB888` (Accelerate / SIMD) instead of a per-pixel CPU loop.

**`src-ui-wx/ui/graphics/opengl/xlGLCanvas.{cpp,h}`**
- `getFrameForExport` uses a persistent readback buffer (no `new uint8_t[w*4*h]` / `delete` per frame), reads as `GL_RGB` directly (skipping the per-pixel RGBA→RGB loop), and flips via `memcpy` per row.

**`src-core/models/Node.h` + `src-core/render/PixelBuffer.cpp`** (small unrelated hardening that surfaced during testing)
- `NodeBaseClass::GetForChannels` / `SetFromChannels` now guard `offsets[x] < chanCnt` in addition to the existing `!= 255` sentinel check. The constructor that initializes `offsets` from an `rgbOrder` string silently truncates `std::string::npos` to 255 (so a missing channel letter is handled), but a pathological rgbOrder whose letter positions exceed the node's `chanCnt` would write past the caller's buffer. This is a cheap belt-and-suspenders check.
- Null-check `n` in the `PixelBufferClass::GetColors` parallel branch to match what the serial branch already does.

## Test plan

**macOS (done locally):**
- [x] macOS + Metal + H.264 4K (3840×2052 @ 40 fps): `h264_videotoolbox` selected, exports ~21s vs >5min previously, .mp4 plays in QuickTime and VLC.
- [x] End-to-end batch render + video export run completes without the `NodeBaseClass::GetForChannels` crash that showed up during earlier testing.
- [x] macOS + H.265 preference — `hevc_videotoolbox` picked, output plays.
- [x] macOS + explicit "MPEG-4" codec preference — falls back to `mpeg4` encoder without errors (considerably slower than H.264/H.265 as expected; it's the software encoder).
- [x] macOS + 1080p sequence — no regression; per-frame time is lower than the 4K run (encoder work scales ~linearly with pixel count).

**Needs verification by reviewers:**
- [ ] **Windows build still compiles and exports** (hardware path guarded by `__APPLE__`, but I haven't built on Windows).
- [ ] **Linux build still compiles and exports** (same).
- [ ] No warnings from `av_hwdevice_ctx_create` / `av_hwframe_ctx_init` in the log on init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)