### PR TITLE
Replace P3/P4 zero-sentinel with explicit _hasStartEndLevel flag

### DIFF
--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -748,15 +748,14 @@ void ValueCurve::UnFixChangedScale(float newmin, float newmax)
         _parameter2 = _parameter2 * newrange / oldrange + mindiff;
     }
 
-    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && !p34Legacy)
+    if (min == MINVOID && _hasStartEndLevel)
     {
         _parameter3 = _parameter3 * newrange / oldrange + mindiff;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && !p34Legacy)
+    if (min == MINVOID && _hasStartEndLevel)
     {
         _parameter4 = _parameter4 * newrange / oldrange + mindiff;
     }
@@ -813,18 +812,14 @@ void ValueCurve::FixChangedScale(float newmin, float newmax, int divisor)
         _parameter2 = (_parameter2 * newrange / oldrange + mindiff); // / divisor;
     }
 
-    // Protect legacy curves where P3/P4 were both 0 (unset). With MINVOID ranges,
-    // FixChangedScale would otherwise shift these zeros into field-unit space, wrongly
-    // activating the Start/End Level feature on old sequences.
-    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && !p34Legacy)
+    if (min == MINVOID && _hasStartEndLevel)
     {
         _parameter3 = (_parameter3 * newrange / oldrange + mindiff); // / divisor;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && !p34Legacy)
+    if (min == MINVOID && _hasStartEndLevel)
     {
         _parameter4 = (_parameter4 * newrange / oldrange + mindiff); // / divisor;
     }
@@ -855,14 +850,13 @@ void ValueCurve::ConvertChangedScale(float newmin, float newmax)
         _parameter2 = (_parameter2 - _min) * newrange / oldrange + newmin;
     }
 
-    bool p34Legacy = (_parameter3 == 0.0f && _parameter4 == 0.0f);
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && !p34Legacy) {
+    if (min == MINVOID && _hasStartEndLevel) {
         _parameter3 = (_parameter3 - _min) * newrange / oldrange + newmin;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && !p34Legacy) {
+    if (min == MINVOID && _hasStartEndLevel) {
         _parameter4 = (_parameter4 - _min) * newrange / oldrange + newmin;
     }
 
@@ -1015,7 +1009,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1054,7 +1048,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1092,7 +1086,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1130,7 +1124,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1168,7 +1162,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1206,7 +1200,7 @@ void ValueCurve::RenderType()
             bool lastwrapped = false;
             if (_values.size() > 0) _values.back().IsWrapped();
             float fy = Safe01(y);
-            if (_parameter3 != 0 || _parameter4 != 0) {
+            if (_hasStartEndLevel) {
                 float sn = parameter3 / 100.0f;
                 float en = parameter4 / 100.0f;
                 fy = Safe01(sn + fy * (en - sn));
@@ -1397,6 +1391,7 @@ void ValueCurve::SetDefault(float min, float max, int divisor)
     _active = false;
     _wrap = false;
     _realValues = true;
+    _hasStartEndLevel = false;
     if (divisor != MAXVOID)
     {
         _divisor = divisor;
@@ -1566,13 +1561,22 @@ std::string ValueCurve::Serialise()
         {
             res += "P2=" + fmt2f(_parameter2) + "|";
         }
-        if (_parameter3 != 0)
+        if (_hasStartEndLevel)
         {
+            res += "SE=Y|";
             res += "P3=" + fmt2f(_parameter3) + "|";
-        }
-        if (_parameter4 != 0)
-        {
             res += "P4=" + fmt2f(_parameter4) + "|";
+        }
+        else
+        {
+            if (_parameter3 != 0)
+            {
+                res += "P3=" + fmt2f(_parameter3) + "|";
+            }
+            if (_parameter4 != 0)
+            {
+                res += "P4=" + fmt2f(_parameter4) + "|";
+            }
         }
         if (_timeOffset != 0)
         {
@@ -1737,6 +1741,8 @@ void ValueCurve::SetSerialisedValue(const std::string &k, const std::string &s)
         _realValues = true;
     } else if (k == "P2") {
         _parameter2 = std::strtof(s.c_str(), nullptr);
+    } else if (k == "SE") {
+        _hasStartEndLevel = true;
     } else if (k == "P3") {
         _parameter3 = std::strtof(s.c_str(), nullptr);
     } else if (k == "P4") {

--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -32,6 +32,13 @@ AudioManager* ValueCurve::__audioManager = nullptr;
 std::map<std::string, AudioManager*> ValueCurve::__altAudioManagers;
 SequenceElements* ValueCurve::__sequenceElements = nullptr;
 
+static bool IsStartEndLevelType(const std::string& type)
+{
+    return type == "Exponential Up" || type == "Exponential Down" ||
+           type == "Logarithmic Up" || type == "Logarithmic Down" ||
+           type == "Parabolic Down" || type == "Parabolic Up";
+}
+
 static std::string fmt2f(float v) {
     // Note: deliberately using snprintf rather than std::to_chars. The floating-point
     // overloads of std::to_chars are only available in Apple's libc++ starting with
@@ -749,13 +756,13 @@ void ValueCurve::UnFixChangedScale(float newmin, float newmax)
     }
 
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel)
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel))
     {
         _parameter3 = _parameter3 * newrange / oldrange + mindiff;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel)
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel))
     {
         _parameter4 = _parameter4 * newrange / oldrange + mindiff;
     }
@@ -813,13 +820,13 @@ void ValueCurve::FixChangedScale(float newmin, float newmax, int divisor)
     }
 
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel)
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel))
     {
         _parameter3 = (_parameter3 * newrange / oldrange + mindiff); // / divisor;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel)
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel))
     {
         _parameter4 = (_parameter4 * newrange / oldrange + mindiff); // / divisor;
     }
@@ -851,12 +858,12 @@ void ValueCurve::ConvertChangedScale(float newmin, float newmax)
     }
 
     GetRangeParm(3, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel) {
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel)) {
         _parameter3 = (_parameter3 - _min) * newrange / oldrange + newmin;
     }
 
     GetRangeParm(4, _type, min, max);
-    if (min == MINVOID && _hasStartEndLevel) {
+    if (min == MINVOID && (!IsStartEndLevelType(_type) || _hasStartEndLevel)) {
         _parameter4 = (_parameter4 - _min) * newrange / oldrange + newmin;
     }
 
@@ -1433,6 +1440,7 @@ void ValueCurve::Deserialise(const std::string& s, bool holdminmax)
         _active = true;
         _values.clear();
         _hasPreloadedValues = false;
+        _hasStartEndLevel = false;
         _type = "Flat";
         _parameter1 = 0.0f;
         _parameter2 = 0.0f;

--- a/src-core/render/ValueCurve.h
+++ b/src-core/render/ValueCurve.h
@@ -103,6 +103,7 @@ class ValueCurve
     bool _wrap;
     bool _realValues;
     bool _hasPreloadedValues = false; // true when Random values were loaded from serialized form, skip regeneration
+    bool _hasStartEndLevel = false;   // true when P3/P4 Start/End Level was explicitly set by the user or loaded from serialized form
     std::string _audioTrackName; // "" = main; "Track1"/"Drums"/etc = alt
     static AudioManager* __audioManager;
     static std::map<std::string, AudioManager*> __altAudioManagers;
@@ -134,6 +135,8 @@ public:
 
     void SetAudioTrack(const std::string& name) { _audioTrackName = name; }
     std::string GetAudioTrack() const { return _audioTrackName; }
+    void SetStartEndLevelActive(bool v) { _hasStartEndLevel = v; }
+    bool IsStartEndLevelActive() const { return _hasStartEndLevel; }
 
     ValueCurve() { _divisor = 1; _min = MINVOIDF; _max = MAXVOIDF; SetDefault(); }
     ValueCurve(const std::string& serialised);

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -529,6 +529,13 @@ void ValueCurveDialog::SetSliderMinMax() {
     }
 }
 
+static bool IsStartEndLevelType(const std::string& type)
+{
+    return type == "Exponential Up" || type == "Exponential Down" ||
+           type == "Logarithmic Up" || type == "Logarithmic Down" ||
+           type == "Parabolic Down" || type == "Parabolic Up";
+}
+
 void ValueCurveDialog::OnChoice1Select(wxCommandEvent& event) {
     _vcp->SetType(std::string(Choice1->GetStringSelection().c_str()));
     _vcp->SetTimeOffset(Slider_TimeOffset->GetValue());
@@ -539,6 +546,7 @@ void ValueCurveDialog::OnChoice1Select(wxCommandEvent& event) {
     SetSliderMinMax();
 
     wxString type = Choice1->GetStringSelection();
+    _vc->SetStartEndLevelActive(IsStartEndLevelType(type.ToStdString()));
     if (type == "Flat") {
         // Dont change anything
     } else if (type == "Ramp") {
@@ -594,37 +602,31 @@ void ValueCurveDialog::OnChoice1Select(wxCommandEvent& event) {
     } else if (type == "Parabolic Down") {
         SetParameter100(1, 4);
         SetParameter100(2, 0);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Parabolic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Logarithmic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Logarithmic Down") {
         SetParameter100(1, 15);
         SetParameter100(2, 50);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Exponential Up") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Exponential Down") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
-        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Sine") {
@@ -959,7 +961,8 @@ void ValueCurveDialog::OnTextCtrl_Parameter3Text(wxCommandEvent& event) {
     float low, high;
     ValueCurve::GetRangeParm3(Choice1->GetStringSelection().ToStdString(), low, high);
     if (low == MINVOID) {
-        _vc->SetStartEndLevelActive(true);
+        if (IsStartEndLevelType(_vc->GetType()))
+            _vc->SetStartEndLevelActive(true);
         i *= _vc->GetDivisor();
     }
     _vc->SetParameter3(i);
@@ -971,7 +974,7 @@ void ValueCurveDialog::OnSlider_Parameter3CmdSliderUpdated(wxScrollEvent& event)
     float i = Slider_Parameter3->GetValue();
     float low, high;
     ValueCurve::GetRangeParm3(Choice1->GetStringSelection().ToStdString(), low, high);
-    if (low == MINVOID)
+    if (low == MINVOID && IsStartEndLevelType(_vc->GetType()))
         _vc->SetStartEndLevelActive(true);
     _vc->SetParameter3(i);
     _vcp->Refresh();
@@ -983,7 +986,8 @@ void ValueCurveDialog::OnTextCtrl_Parameter4Text(wxCommandEvent& event) {
     float low, high;
     ValueCurve::GetRangeParm4(Choice1->GetStringSelection().ToStdString(), low, high);
     if (low == MINVOID) {
-        _vc->SetStartEndLevelActive(true);
+        if (IsStartEndLevelType(_vc->GetType()))
+            _vc->SetStartEndLevelActive(true);
         i *= _vc->GetDivisor();
     }
     _vc->SetParameter4(i);
@@ -995,7 +999,7 @@ void ValueCurveDialog::OnSlider_Parameter4CmdSliderUpdated(wxScrollEvent& event)
     float i = Slider_Parameter4->GetValue();
     float low, high;
     ValueCurve::GetRangeParm4(Choice1->GetStringSelection().ToStdString(), low, high);
-    if (low == MINVOID)
+    if (low == MINVOID && IsStartEndLevelType(_vc->GetType()))
         _vc->SetStartEndLevelActive(true);
     _vc->SetParameter4(i);
     _vcp->Refresh();

--- a/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/ValueCurveDialog.cpp
@@ -594,31 +594,37 @@ void ValueCurveDialog::OnChoice1Select(wxCommandEvent& event) {
     } else if (type == "Parabolic Down") {
         SetParameter100(1, 4);
         SetParameter100(2, 0);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Parabolic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Logarithmic Up") {
         SetParameter100(1, 4);
         SetParameter100(2, 100);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Logarithmic Down") {
         SetParameter100(1, 15);
         SetParameter100(2, 50);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Exponential Up") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Exponential Down") {
         SetParameter100(1, 100);
         SetParameter100(2, 50);
+        _vc->SetStartEndLevelActive(true);
         SetParameter100(3, 0);
         SetParameter100(4, 100);
     } else if (type == "Sine") {
@@ -952,8 +958,10 @@ void ValueCurveDialog::OnTextCtrl_Parameter3Text(wxCommandEvent& event) {
     float i = wxAtof(TextCtrl_Parameter3->GetValue());
     float low, high;
     ValueCurve::GetRangeParm3(Choice1->GetStringSelection().ToStdString(), low, high);
-    if (low == MINVOID)
+    if (low == MINVOID) {
+        _vc->SetStartEndLevelActive(true);
         i *= _vc->GetDivisor();
+    }
     _vc->SetParameter3(i);
     _vcp->Refresh();
 }
@@ -961,6 +969,10 @@ void ValueCurveDialog::OnTextCtrl_Parameter3Text(wxCommandEvent& event) {
 void ValueCurveDialog::OnSlider_Parameter3CmdSliderUpdated(wxScrollEvent& event) {
     UpdateLinkedTextCtrl(event);
     float i = Slider_Parameter3->GetValue();
+    float low, high;
+    ValueCurve::GetRangeParm3(Choice1->GetStringSelection().ToStdString(), low, high);
+    if (low == MINVOID)
+        _vc->SetStartEndLevelActive(true);
     _vc->SetParameter3(i);
     _vcp->Refresh();
 }
@@ -970,8 +982,10 @@ void ValueCurveDialog::OnTextCtrl_Parameter4Text(wxCommandEvent& event) {
     float i = wxAtof(TextCtrl_Parameter4->GetValue());
     float low, high;
     ValueCurve::GetRangeParm4(Choice1->GetStringSelection().ToStdString(), low, high);
-    if (low == MINVOID)
+    if (low == MINVOID) {
+        _vc->SetStartEndLevelActive(true);
         i *= _vc->GetDivisor();
+    }
     _vc->SetParameter4(i);
     _vcp->Refresh();
 }
@@ -979,6 +993,10 @@ void ValueCurveDialog::OnTextCtrl_Parameter4Text(wxCommandEvent& event) {
 void ValueCurveDialog::OnSlider_Parameter4CmdSliderUpdated(wxScrollEvent& event) {
     UpdateLinkedTextCtrl(event);
     float i = Slider_Parameter4->GetValue();
+    float low, high;
+    ValueCurve::GetRangeParm4(Choice1->GetStringSelection().ToStdString(), low, high);
+    if (low == MINVOID)
+        _vc->SetStartEndLevelActive(true);
     _vc->SetParameter4(i);
     _vcp->Refresh();
 }


### PR DESCRIPTION
Addresses code review feedback from Copilot on #6150 (which landed before the review was actioned).

  The original implementation detected "legacy" curves (pre-Start/End Level feature) by checking if both P3 and P4 were
  zero. Copilot correctly flagged that this conflates "unset" with "intentionally set to zero", making Start=0 / End=0
  impossible to represent correctly.

  Changes:
  - Added explicit `_hasStartEndLevel` bool flag (defaults false)
  - Added `SE=Y` serialization key so the flag survives save/load
  - All RenderType and scale function guards now use the flag instead of the value check

  Backward compatible — existing sequences have no `SE=Y` key, so the flag stays false and rendering is identical to
  before.