### PR TITLE
Fix migration of fix aliases and colors (#5888)

### DIFF
--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -969,6 +969,14 @@ Model* XmlDeserializingModelFactory::DeserializeModelGroup(pugi::xml_node node, 
         }
     }
 
+    // Deserialize child elements (Aliases)
+    for (pugi::xml_node child = node.first_child(); child; child = child.next_sibling()) {
+        std::string_view childName = child.name();
+        if (childName == XmlNodeKeys::AliasesAttribute || childName == "aliases") {
+            DeserializeAliases(model, child);
+        }
+    }
+
     // Note: We call RebuildBuffers() to finalize the model group
     // This handles node initialization and buffer setup
     model->RebuildBuffers();

--- a/src-ui-wx/color/ColorPanel.cpp
+++ b/src-ui-wx/color/ColorPanel.cpp
@@ -818,12 +818,6 @@ void ColorPanel::SetDefaultSettings(bool optionbased) {
         for (const auto& it : checkBoxes) {
             it->SetValue(false);
         }
-        if (checkBoxes.size() > 0) {
-            checkBoxes[0]->SetValue(true);
-        }
-        if (checkBoxes.size() > 1) {
-            checkBoxes[1]->SetValue(true);
-        }
     }
 
     if (!optionbased || (_resetColorPanelCheck && _resetColorPanelCheck->GetValue())) {


### PR DESCRIPTION
also reverting out the color picker selecting the first 2 checkboxes as it was overriding previous choices.